### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.tags*
+log/
+results/
+tmp/


### PR DESCRIPTION
During the Great Exodus of 2016, the potential for clutter has been
reintroduced by lack of a .gitignore file.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>