### PR TITLE
Add CONTRIBUTING.md and pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: 3fa02652357ff0dbb42b5bc78c673b7bc105fcf3
+    hooks:
+    -   id: check-added-large-files
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: git://github.com/detailyang/pre-commit-shell
+    sha: 28f9ecf7857d17ebd9d1715cb5bf208c9e8e2bdd
+    hooks:
+    -   id: shell-lint
+        args: ["--exclude=SC2034,SC2148,SC2153,SC2154", "--external-sources"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+When contributing to the `core-plans` repository, follow these guidelines.
+
+## Package Metadata
+
+A package should contain key elements:
+
+- `pkg_name`
+- `pkg_license` (in [SPDX format](http://spdx.org/licenses/))
+- `pkg_description`
+- `pkg_maintainer` in the format of "The Habitat Maintainers <humans@habitat.sh>"
+- `pkg_upstream_url`
+
+## Pre-commit hooks
+
+Install [pre-commit](http://pre-commit.com/) to run prior to your commits.
+This will perform some initial checks against your changes and recommend any fixes before you commit.
+
+## Signing Your Commits
+
+This project utilizes a Developer Certificate of Origin (DCO) to ensure that each commit was written by the
+author or that the author has the appropriate rights necessary to contribute the change.  The project
+utilizes [Developer Certificate of Origin, Version 1.1](http://developercertificate.org/)
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Each commit must include a DCO which looks like this
+
+`Signed-off-by: Joe Smith <joe.smith@email.com>`
+
+The project requires that the name used is your real name.  Neither anonymous contributors nor those
+utilizing pseudonyms will be accepted.
+
+Git makes it easy to add this line to your commit messages.
+
+1. Make sure the `user.name` and `user.email` are set in your git configs.
+2. Use `-s` or `--signoff` to add the Signed-off-by line to the end of the commit message.


### PR DESCRIPTION
As the project gains more contributors, documentation on how to best
write plans and commits is helpful.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>