### PR TITLE
bison2 2.7.1 (new plan)

### DIFF
--- a/bison/plan.sh
+++ b/bison/plan.sh
@@ -1,8 +1,10 @@
 pkg_name=bison
 pkg_origin=core
 pkg_version=3.0.4
+pkg_description="A parser generator that converts an annotated context-free grammar into a parser"
+pkg_upstream_url=https://www.gnu.org/software/bison/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv3')
+pkg_license=('GPL-3.0')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=a72428c7917bdf9fa93cb8181c971b6e22834125848cf1d03ce10b1bb0716fe1
 pkg_deps=(core/glibc)

--- a/bison2/plan.sh
+++ b/bison2/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=bison2
+pkg_distname=bison
+pkg_origin=core
+pkg_version=2.7.1
+pkg_description="A parser generator that converts an annotated context-free grammar into a parser"
+pkg_upstream_url=https://www.gnu.org/software/bison/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-3.0')
+pkg_source=http://ftp.gnu.org/gnu/$pkg_distname/${pkg_distname}-${pkg_version}.tar.xz
+pkg_filename=${pkg_distname}-${pkg_version}.tar.xz
+pkg_dirname=${pkg_distname}-${pkg_version}
+pkg_shasum=b409adcbf245baadb68d2f66accf6fdca5e282cafec1b865f4b5e963ba8ea7fb
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/m4 core/perl)
+pkg_bin_dirs=(bin)
+
+do_check() {
+  make check
+}


### PR DESCRIPTION
The current `bison` plan is 3.x and other software packages like PHP5
restrict their supported bison version to below 3.x.

Using this package:

    pkg_build_deps=(... core/bison2)

Signed-off-by: Mike Fiedler <miketheman@gmail.com>