### PR TITLE
Add pre-commit hook to test for variables in plan.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@
     hooks:
     -   id: shell-lint
         args: ["--exclude=SC2034,SC2148,SC2153,SC2154", "--external-sources"]
+-   repo: local
+    hooks:
+    -   id: check-default-variables
+        name: Check for Habitat default plan variables
+        entry: ./check-default-variables.sh
+        language: system
+        files: plan.sh$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
     sha: 28f9ecf7857d17ebd9d1715cb5bf208c9e8e2bdd
     hooks:
     -   id: shell-lint
-        args: ["--exclude=SC2034,SC2148,SC2153,SC2154", "--external-sources"]
+        args: ["--exclude=SC2034,SC2148,SC2153,SC2154"]
 -   repo: local
     hooks:
     -   id: check-default-variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,16 @@ branches:
   only:
   - auto
   - master
-language: c # Not really, but makes it so we don't have to install Ruby
+language: python
+cache: pip
+addons:
+  apt:
+    sources:
+    - debian-sid  # Grab shellcheck from the Debian repo (o_O)
+    packages:
+    - shellcheck
+install:
+  - pip install pre-commit
 notifications:
   webhooks: https://habitat-homu.herokuapp.com/travis
 script: ./travis.sh

--- a/check-default-variables.sh
+++ b/check-default-variables.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# pre-commit hook:
+# Check for Habitat default variables in a plan.sh file
+#
+# Authors:
+# - Mike Fiedler <miketheman@gmail.com>
+
+required_variables=(
+  pkg_description
+  pkg_license
+  pkg_name
+  pkg_origin
+  pkg_source
+  pkg_upstream_url
+  pkg_version
+)
+
+for var in "${required_variables[@]}"
+do
+  grep -Eq "^$var" "$@"
+  if [[ $? -ne 0 ]]
+  then
+    echo "Error detected by Check Default Variables."
+    echo ""
+    echo "    Unable to find '$var' in $*"
+    echo ""
+    echo "Ensure that your plan.sh contains all of:"
+    IFS=$'\n'; echo "${required_variables[*]}"
+    exit 1
+  fi
+
+done
+
+exit 0

--- a/travis.sh
+++ b/travis.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
 # Script to run when testing core-plans on Travis CI
+set -x
 
+pre-commit install
+
+# Retrieve the canonical range.
+# The TRAVIS_COMMIT env var is always a merge commit, so we want to test from
+# the original commit all the way up until HEAD.
+ORIGIN=$(echo "$TRAVIS_COMMIT_RANGE" | cut -f1 -d'.')
+
+pre-commit run --origin "$ORIGIN" --source HEAD


### PR DESCRIPTION
pre-commit was introduced in #18 and this addition of a hook that greps
the changed files scope for required metadata should help prevent cycles
of review.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>