### PR TITLE
Fix aws-cli `$pkg_bin_dirs`.

### DIFF
--- a/aws-cli/plan.sh
+++ b/aws-cli/plan.sh
@@ -11,10 +11,7 @@ pkg_deps=(
   core/groff
   core/python
 )
-pkg_bin_dirs=(
-  $(pkg_path_for core/groff)/bin
-  bin
-)
+pkg_bin_dirs=(bin)
 
 do_download() {
   return 0


### PR DESCRIPTION
The path to `core/groff` should not be present in `$pkg_bin_dirs` but rather the package should be invoked with `hab pkg exec core/aws-cli` in order to get the `groff` command properly set on `$PATH`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>