### PR TITLE
[ImageMagick] Set prefix, enable a few features

### DIFF
--- a/imagemagick/plan.sh
+++ b/imagemagick/plan.sh
@@ -1,17 +1,25 @@
 pkg_name=imagemagick
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_origin=core
 pkg_version=6.9.2-10
+pkg_description="A software suite to create, edit, compose, or convert bitmap images."
+pkg_upstream_url="http://imagemagick.org/"
 pkg_license=('Apache2')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://www.imagemagick.org/download/releases/ImageMagick-${pkg_version}.tar.xz
 pkg_shasum=da2f6fba43d69f20ddb11783f13f77782b0b57783dde9cda39c9e5e733c2013c
+pkg_deps=(core/glibc core/zlib core/libpng core/xz core/gcc-libs)
+pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc core/pkg-config)
 pkg_bin_dirs=(bin)
-pkg_deps=(core/zlib core/glibc)
-pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc)
+pkg_include_dirs=(include/ImageMagick-6)
+pkg_lib_dirs=(lib)
 pkg_dirname=ImageMagick-${pkg_version}
 
 do_build() {
-  CC="gcc -std=gnu99" ./configure --disable-openmp
-  make
+    PKG_CONFIG_PATH="$(pkg_path_for zlib)/lib/pkgconfig"
+    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for libpng)/lib/pkgconfig"
+    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for xz)/lib/pkgconfig"
+    export PKG_CONFIG_PATH
+    build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
+    CC="gcc -std=gnu99" ./configure --prefix=$pkg_prefix
+    make
 }


### PR DESCRIPTION
This change:

- Sets the --prefix option to configure so that the final artifact has
  the content we expect

- Sets PKG_CONFIG_PATH and depends on core/pkg-config to ensure we can
  enable features that require libraries to be configured via pkg-config

- Depends on libpng, xz and gcc-libs to enable a few more useful features
  in the built version of ImageMagick

- Sets pkg_lib_dirs and pkg_include_dirs so other plans can depend on
  imagemagick.

Signed-off-by: Steven Danna <steve@chef.io>