### PR TITLE
Fix Travis on auto branch

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -5,6 +5,7 @@ set -x
 # debug info
 echo "TRAVIS_COMMIT=$TRAVIS_COMMIT"
 echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
+echo "HEAD=$(git rev-parse HEAD)"
 
 PARENT_COMMIT=$(git log --pretty=%P -n 1 "$TRAVIS_COMMIT")
 echo "PARENT_COMMIT=$PARENT_COMMIT"
@@ -16,5 +17,6 @@ pre-commit install
 # The TRAVIS_COMMIT env var is always a merge commit, so we want to test from
 # the original commit all the way up until HEAD.
 ORIGIN=$(echo "$TRAVIS_COMMIT_RANGE" | cut -f1 -d'.')
+SOURCE=$(echo "$TRAVIS_COMMIT_RANGE" | cut -f4 -d'.')
 
-pre-commit run --origin "$ORIGIN" --source HEAD
+pre-commit run --origin "$ORIGIN" --source "$SOURCE"


### PR DESCRIPTION
When homu runs its test on the aut branch, use the values given in the
commit range to make sure it passes.

