### PR TITLE
[merged] Add gcc-libs runtime dep to git

### DIFF
--- a/git/plan.sh
+++ b/git/plan.sh
@@ -1,22 +1,32 @@
 pkg_name=git
 pkg_version=2.7.4
 pkg_origin=core
-pkg_license=('gplv2')
+pkg_description="Git is a free and open source distributed version control
+  system designed to handle everything from small to very large projects with
+  speed and efficiency."
+pkg_upstream_url=https://git-scm.com/
+pkg_license=('GPL-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.kernel.org/pub/software/scm/git/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=7104c4f5d948a75b499a954524cb281fe30c6649d8abe20982936f75ec1f275b
-pkg_deps=(core/glibc core/zlib core/perl core/curl core/gettext core/expat core/cacerts)
+pkg_deps=(
+  core/cacerts
+  core/curl
+  core/expat
+  core/gettext
+  core/gcc-libs
+  core/glibc
+  core/perl
+  core/zlib
+)
 pkg_build_deps=(core/make core/gcc)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
 do_prepare() {
-  _perl_path="$(pkg_path_for perl)/bin/perl"
-  sed -e "s#/usr/bin/perl#${_perl_path}#g" -i Makefile
-}
-
-do_build() {
-  ./configure --prefix=${pkg_prefix}
-  make
+  local perl_path
+  perl_path="$(pkg_path_for perl)/bin/perl"
+  sed -e "s#/usr/bin/perl#$perl_path#g" -i Makefile
 }


### PR DESCRIPTION
In some situations using git would give you:

    libgcc_s.so.1 must be installed for pthread_cancel to work

Add a runtime dep on gcc-libs to fix this.

Also:

* Add description, upstream url, and maintainer
* Make license use SPDX format
* Remove the `do_build`, because it's the same as the default
* Make ShellCheck happy

![gif-keyboard-5589462069318955526](https://cloud.githubusercontent.com/assets/9912/16816530/d9c48af2-4903-11e6-80e8-06046d36f30a.gif)
