### PR TITLE
Add Tor plan

### DIFF
--- a/libscrypt/plan.sh
+++ b/libscrypt/plan.sh
@@ -1,0 +1,26 @@
+pkg_name=libscrypt
+pkg_version=1.21
+pkg_origin=core
+pkg_license=('BSD-2-Clause')
+pkg_description="An implementation of Colin Percival's scrypt hash"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_upstream_url="http://www.lolware.net/libscrypt.html"
+pkg_source=https://github.com/technion/libscrypt/archive/v${pkg_version}.tar.gz
+pkg_shasum=68e377e79745c10d489b759b970e52d819dbb80dd8ca61f8c975185df3f457d3
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/gcc core/make)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+  CFLAGS="${CFLAGS} -O2 -Wall -g -D_FORTIFY_SOURCE=2 -fstack-protector -fPIC"
+  make
+}
+
+do_install() {
+  PREFIX="${pkg_prefix}" make install
+}
+
+do_check() {
+  make check
+}

--- a/libseccomp/plan.sh
+++ b/libseccomp/plan.sh
@@ -1,0 +1,15 @@
+pkg_name=libseccomp
+pkg_version=2.3.1
+pkg_origin=core
+pkg_license=('LGPL-2.1')
+pkg_description="An easy to use, platform independent, interface
+to the Linux Kernel's syscall filtering mechanism."
+pkg_upstream_url="https://github.com/seccomp/libseccomp"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/seccomp/libseccomp/releases/download/v${pkg_version}/libseccomp-${pkg_version}.tar.gz"
+pkg_shasum=ff5bdd2168790f1979e24eaa498f8606c2f2d96f08a8dc4006a2e88affa4562b
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/gcc core/make core/diffutils)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)

--- a/tor/config/torrc
+++ b/tor/config/torrc
@@ -1,0 +1,6 @@
+SOCKSPort {{cfg.socks_bind_addr}}:{{cfg.socks_bind_port}}
+SOCKSPolicy {{cfg.socks_policy}}
+
+Log {{cfg.log_level}} stdout
+DataDirectory {{pkg.svc_var_path}}
+

--- a/tor/default.toml
+++ b/tor/default.toml
@@ -1,0 +1,5 @@
+socks_bind_addr = "localhost"
+socks_bind_port = 9050
+socks_policy = "accept *"
+
+log_level = "notice"

--- a/tor/plan.sh
+++ b/tor/plan.sh
@@ -1,0 +1,38 @@
+pkg_name=tor
+pkg_version=0.2.7.6
+pkg_origin=core
+pkg_license=('BSD-3-Clause')
+pkg_description="Free software and an open network that helps you defend against traffic analysis"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_upstream_url="https://www.torproject.org/"
+pkg_source="https://www.torproject.org/dist/tor-${pkg_version}.tar.gz"
+pkg_shasum=493a8679f904503048114aca6467faef56861206bab8283d858f37141d95105d
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/libevent
+  core/openssl
+  core/zlib
+  core/libseccomp
+  core/libscrypt)
+pkg_build_deps=(core/gcc core/make core/pkg-config core/python)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+pkg_svc_run="bin/tor -f $pkg_svc_config_path/torrc"
+pkg_expose=(9050)
+
+do_build() {
+   # Enabling -02 avoids hundreds of warnings about _FORTIFY_SOURCE
+   export CFLAGS="-O2 ${CFLAGS}"
+   # -lgcc_s seems to be needed to dlopen libgcc_s.so
+   # It is unclear to me why this is needed since the RUNPATH tag in the elf binary
+   # contains the path that includes libgcc_s.so
+   export LDFLAGS="-lgcc_s ${LDFLAGS}"
+   ./configure --prefix="${pkg_prefix}" --disable-dependency-tracking
+   make
+}
+
+do_check() {
+  make test
+}


### PR DESCRIPTION
This adds a plan for Tor with minimal configuration for operating as a
tor-client. Additionally, it adds two tor dependencies: libseccomp and
libscrypt.

Signed-off-by: Steven Danna <steve@chef.io>