### PR TITLE
WIP on Delivery CLI

### DIFF
--- a/delivery-cli/plan.sh
+++ b/delivery-cli/plan.sh
@@ -1,0 +1,64 @@
+pkg_name=delivery-cli
+pkg_distname=$pkg_name
+pkg_origin=core
+pkg_version=0.0.32
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_source=https://github.com/chef/delivery-cli/archive/${pkg_version}.tar.gz
+pkg_shasum=a89a6eba61492dd7c09e6ddae464bfebc696606cb3a255003ab0d36991130f27
+pkg_deps=(
+)
+pkg_build_deps=(
+  core/rust
+  core/gcc
+  core/cacerts
+  core/libarchive
+  core/zlib
+  core/openssl
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  # Used by Cargo to fetch registries/crates/etc.
+  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
+  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
+
+  # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
+  # this used only at build time, we will use the version found in the gcc
+  # package proper--it won't find its way into the final binaries.
+  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+  # If there are any build errors this may help
+  export RUST_BACKTRACE=1
+
+  la_ldflags="-L$(pkg_path_for zlib)/lib -lz"
+  la_ldflags="$la_ldflags -L$(pkg_path_for openssl)/lib -lssl -lcrypto"
+
+  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
+  export LIBARCHIVE_LDFLAGS="$la_ldflags"
+  export LIBARCHIVE_STATIC=true
+  export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
+  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
+  export OPENSSL_STATIC=true
+
+  export DELIV_CLI_VERSION=${pkg_version}
+  # TODO
+  # export DELIV_CLI_GIT_SHA=Omnibus::Fetcher.resolve_version(version, source)
+  export DELIV_CLI_GIT_SHA=444effdf9c81908795e88157f01cd667a6c43b5f
+}
+
+do_build() {
+  cargo clean --verbose
+  cargo build  -j $(nproc) --release --verbose
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/target/default/release/$program \
+    $pkg_prefix/bin/$pkg_distname
+}
+
+do_strip() {
+  strip $pkg_prefix/bin/$pkg_distname
+}


### PR DESCRIPTION
🚧 

This is currently failing when building delivery cli with the following errors:

```
   Compiling delivery v0.0.1 (file:///hab/cache/src/delivery-cli-0.0.32)
     Running `rustc src/delivery/lib.rs --crate-name delivery --crate-type lib -C opt-level=3 --out-dir /hab/cache/src/delivery-cli-0.0.32/target/release --emit=dep-info,link -L dependency=/hab/cache/src/delivery-cli-0.0.32/target/release -L dependency=/hab/cache/src/delivery-cli-0.0.32/target/release/deps --extern hyper=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libhyper-893e263b09660bd1.rlib --extern regex=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libregex-a3ad4db16bc20e1f.rlib --extern mime=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libmime-f137e5ecbeaa5435.rlib --extern clap=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libclap-4d255c56456af762.rlib --extern rustc_serialize=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/librustc_serialize-3bc953984ed46e7f.rlib --extern time=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtime-71756e48b8b5b73b.rlib --extern log=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblog-342ffb7444a9471d.rlib --extern uuid=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libuuid-ad64362ac96e59a8.rlib --extern env_logger=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libenv_logger-54fa0d25029b02ef.rlib --extern term=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libterm-585dc449d37783e7.rlib --extern libc=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblibc-d9dba2869ce64308.rlib --extern toml=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtoml-cd71fbce840828ea.rlib --extern tempdir=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtempdir-2cdf7b3a831e6ac5.rlib -L native=/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-8f82a1ac7a7f09d7/out -L native=/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-sys-extras-6cdd9aaab3f99a18/out -L native=/hab/pkgs/core/openssl/1.0.2h/20160708160802/lib`
     Running `rustc src/main.rs --crate-name delivery --crate-type bin -C opt-level=3 --out-dir /hab/cache/src/delivery-cli-0.0.32/target/release --emit=dep-info,link -L dependency=/hab/cache/src/delivery-cli-0.0.32/target/release -L dependency=/hab/cache/src/delivery-cli-0.0.32/target/release/deps --extern hyper=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libhyper-893e263b09660bd1.rlib --extern regex=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libregex-a3ad4db16bc20e1f.rlib --extern mime=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libmime-f137e5ecbeaa5435.rlib --extern clap=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libclap-4d255c56456af762.rlib --extern rustc_serialize=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/librustc_serialize-3bc953984ed46e7f.rlib --extern time=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtime-71756e48b8b5b73b.rlib --extern log=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblog-342ffb7444a9471d.rlib --extern uuid=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libuuid-ad64362ac96e59a8.rlib --extern env_logger=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libenv_logger-54fa0d25029b02ef.rlib --extern term=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libterm-585dc449d37783e7.rlib --extern libc=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblibc-d9dba2869ce64308.rlib --extern toml=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtoml-cd71fbce840828ea.rlib --extern tempdir=/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtempdir-2cdf7b3a831e6ac5.rlib --extern delivery=/hab/cache/src/delivery-cli-0.0.32/target/release/libdelivery.rlib -L native=/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-8f82a1ac7a7f09d7/out -L native=/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-sys-extras-6cdd9aaab3f99a18/out -L native=/hab/pkgs/core/openssl/1.0.2h/20160708160802/lib`
error: linking with `cc` failed: exit code: 1
note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/hab/cache/src/delivery-cli-0.0.32/target/release/delivery.0.o" "-o" "/hab/cache/src/delivery-cli-0.0.32/target/release/delivery" "-Wl,--gc-sections" "-pie" "-Wl,-O1" "-nodefaultlibs" "-L" "/hab/cache/src/delivery-cli-0.0.32/target/release" "-L" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps" "-L" "/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-8f82a1ac7a7f09d7/out" "-L" "/hab/cache/src/delivery-cli-0.0.32/target/release/build/openssl-sys-extras-6cdd9aaab3f99a18/out" "-L" "/hab/pkgs/core/openssl/1.0.2h/20160708160802/lib" "-L" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "-Wl,-Bdynamic" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libenv_logger-54fa0d25029b02ef.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/libdelivery.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libregex-a3ad4db16bc20e1f.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtempdir-2cdf7b3a831e6ac5.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libaho_corasick-763321738616ae26.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libregex_syntax-4120f877c60021d8.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libhyper-893e263b09660bd1.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libcookie-391142603faeac26.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtraitobject-3d4dcec5d1662e96.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libmime-f137e5ecbeaa5435.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libnum_cpus-b1d45d517fa015d3.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl-8520cc35dff6bf9e.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libbitflags-10d625c8a1ca3e9d.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys_extras-ecdbfecdf6d02bbf.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libunicase-2e75ae83bf996d47.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libutf8_ranges-a6119bc781af556b.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtypeable-1604229584d39a42.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/librand-c724acb3942597d1.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtime-71756e48b8b5b73b.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libsolicit-8f0dfee0deffeb96.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libterm-585dc449d37783e7.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblazy_static-a81b08a56ec46bff.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libmemchr-eee90be3d2b5052f.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libuuid-ad64362ac96e59a8.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liburl-72387916abdb61ce.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libidna-cfd533a97becc7e1.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libunicode_bidi-7a56a7dec369a022.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libmatches-030a774745cc4f96.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libclap-4d255c56456af762.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libstrsim-0669373314ee49fc.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libvec_map-052ff1ed2f091ceb.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libansi_term-68e7c4af089a9086.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libbitflags-e87d150db0333415.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libunicode_normalization-f33127ef3e902b05.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libhttparse-9ed9b694220e1406.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libunicode_width-cece2f1ebe60be2d.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libtoml-cd71fbce840828ea.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/librustc_serialize-3bc953984ed46e7f.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblanguage_tags-1cb52046c41cf66a.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libhpack-320332c60c4dfc72.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblog-342ffb7444a9471d.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libthread_local-b1afb4264b575c63.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libthread_id-ed3f7011bd9c5aa2.rlib" "/hab/cache/src/delivery-cli-0.0.32/target/release/deps/liblibc-d9dba2869ce64308.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcollections-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_unicode-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/librand-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_jemalloc-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-d16b8f0e.rlib" "/hab/pkgs/core/rust/1.9.0/20160612081420/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-d16b8f0e.rlib" "-l" "util" "-l" "dl" "-l" "pthread" "-l" "gcc_s" "-l" "pthread" "-l" "c" "-l" "m" "-l" "rt" "-l" "util" "-l" "compiler-rt"
note: /hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `zlib_stateful_expand_block':
c_zlib.c:(.text+0x59): undefined reference to `inflate'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `zlib_stateful_compress_block':
c_zlib.c:(.text+0xea): undefined reference to `deflate'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `bio_zlib_free':
c_zlib.c:(.text+0x13e): undefined reference to `inflateEnd'
c_zlib.c:(.text+0x15d): undefined reference to `deflateEnd'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `zlib_stateful_finish':
c_zlib.c:(.text+0x1d0): undefined reference to `inflateEnd'
c_zlib.c:(.text+0x1d9): undefined reference to `deflateEnd'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `zlib_stateful_init':
c_zlib.c:(.text+0x272): undefined reference to `inflateInit_'
c_zlib.c:(.text+0x2f1): undefined reference to `deflateInit_'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `bio_zlib_ctrl':
c_zlib.c:(.text+0x564): undefined reference to `deflate'
c_zlib.c:(.text+0x63c): undefined reference to `zError'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `bio_zlib_write':
c_zlib.c:(.text+0x859): undefined reference to `deflate'
c_zlib.c:(.text+0x91c): undefined reference to `zError'
c_zlib.c:(.text+0x985): undefined reference to `deflateInit_'
/hab/cache/src/delivery-cli-0.0.32/target/release/deps/libopenssl_sys-d6cc5beb50faec31.rlib(c_zlib.o): In function `bio_zlib_read':
c_zlib.c:(.text+0xa4f): undefined reference to `inflate'
c_zlib.c:(.text+0xabc): undefined reference to `zError'
c_zlib.c:(.text+0xb31): undefined reference to `inflateInit_'
collect2: error: ld returned 1 exit status

error: aborting due to previous error
error: Could not compile `delivery`.
```

I could use some help troubleshooting that. I coped most of this from the [`hab` CLI plan](https://github.com/habitat-sh/habitat/blob/master/components/hab/plan.sh).