### PR TITLE
Don't copy in upload message script

### DIFF
--- a/bin/copy-depot-upload-message.sh
+++ b/bin/copy-depot-upload-message.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Take the last build information and put it into a message that you can paste
-# into GitHub as a comment. Copy it to the clipboard.
-source ./results/last_build.env
-echo "[$pkg_ident](https://app.habitat.sh/#/pkgs/$pkg_ident) has been built and uploaded to the depot. :sparkling_heart:" | pbcopy

--- a/bin/depot-upload-message.sh
+++ b/bin/depot-upload-message.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Take the last build information and put it into a message that you can paste
+# into GitHub as a comment.
+source ./results/last_build.env
+echo "[$pkg_ident](https://app.habitat.sh/#/pkgs/$pkg_ident) has been built and uploaded to the depot. :sparkling_heart:"


### PR DESCRIPTION
I wanted to use this in a studio but I didn't have `pbcopy` in there so
I made it do less.

![temple](https://cloud.githubusercontent.com/assets/9912/16885551/b5b7e040-4a94-11e6-94b5-37179ec72a15.gif)
