### PR TITLE
Mosh Plan

### DIFF
--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -7,17 +7,19 @@ pkg_description="Remote Terminal application that allows roaming, supports inter
 editing of users keystrokes"
 pkg_upstream_url=https://mosh.mit.edu
 pkg_source=https://mosh.mit.edu/mosh-${pkg_version}.tar.gz
-pkg_shasum=637adb7f67406447e9264d30468fe69a6d5e8f97518ef133d794cdc65483fa54
-pkg_build_deps=(core/gcc core/make core/glibc)
-pkg_deps=(core/glibc)
+pkg_shasum=1af809e5d747c333a852fbf7acdbf4d354dc4bbc2839e3afe5cf798190074be3
+pkg_build_deps=(core/coreutils core/patch core/autoconf core/automake core/gcc core/make core/glibc core/protobuf core/zlib core/openssl core/pkg-config core/ncurses)
+pkg_deps=(core/glibc core/gcc-libs)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
 do_build() {
-     ./configure
+   PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
+   PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
+   export PKG_CONFIG_PATH
+     ./configure --prefix=$pkg_prefix
      make
-     make install
  }
 
 

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -22,4 +22,8 @@ do_build() {
      make
  }
 
+ do_install() {
+      make install
+ }
+
 

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -15,11 +15,10 @@ pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
 do_build() {
-   PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
-   PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
-   export PKG_CONFIG_PATH
-   build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-   ./configure --prefix=$pkg_prefix
-   make
+    PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
+    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
+    export PKG_CONFIG_PATH
+    build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
+    ./configure --prefix=$pkg_prefix
+    make
  }
-

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -19,6 +19,6 @@ do_build() {
     PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
     export PKG_CONFIG_PATH
     build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-    ./configure --prefix=$pkg_prefix
+    ./configure --prefix="${pkg_prefix}"
     make
  }

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -14,7 +14,7 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
-do_build() {
+do_prepare() {
     PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
     PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
     export PKG_CONFIG_PATH

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -1,0 +1,23 @@
+pkg_name=mosh
+pkg_origin=core
+pkg_version=1.2.5
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('OCB-An-Authenticated-Encryption-Scheme')
+pkg_description="Remote Terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and lines
+editing of users keystrokes"
+pkg_upstream_url=https://mosh.mit.edu
+pkg_source=https://mosh.mit.edu/mosh-${pkg_version}.tar.gz
+pkg_shasum=637adb7f67406447e9264d30468fe69a6d5e8f97518ef133d794cdc65483fa54
+pkg_build_deps=(core/gcc core/make core/glibc)
+pkg_deps=(core/glibc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+do_build() {
+     ./configure
+     make
+     make install
+ }
+
+

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -18,6 +18,7 @@ do_build() {
    PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
    export PKG_CONFIG_PATH
+   build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
    ./configure --prefix=$pkg_prefix
    make
  }

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -18,12 +18,7 @@ do_build() {
    PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for protobuf)/lib/pkgconfig"
    export PKG_CONFIG_PATH
-     ./configure --prefix=$pkg_prefix
-     make
+   ./configure --prefix=$pkg_prefix
+   make
  }
-
- do_install() {
-      make install
- }
-
 

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -2,7 +2,7 @@ pkg_name=mosh
 pkg_origin=core
 pkg_version=1.2.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('OCB-An-Authenticated-Encryption-Scheme')
+pkg_license=('GPL-3.0')
 pkg_description="Remote Terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and lines
 editing of users keystrokes"
 pkg_upstream_url="https://mosh.mit.edu"

--- a/mosh/plan.sh
+++ b/mosh/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('OCB-An-Authenticated-Encryption-Scheme')
 pkg_description="Remote Terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and lines
 editing of users keystrokes"
-pkg_upstream_url=https://mosh.mit.edu
+pkg_upstream_url="https://mosh.mit.edu"
 pkg_source=https://mosh.mit.edu/mosh-${pkg_version}.tar.gz
 pkg_shasum=1af809e5d747c333a852fbf7acdbf4d354dc4bbc2839e3afe5cf798190074be3
 pkg_build_deps=(core/coreutils core/patch core/autoconf core/automake core/gcc core/make core/glibc core/protobuf core/zlib core/openssl core/pkg-config core/ncurses)


### PR DESCRIPTION
Start of Mosh plan.

Mosh seems to require ncurses 5, only v6.0 is currently on Core Origin. should rebuild mosh against ncurses 6.