### PR TITLE
ncurses5 package

### DIFF
--- a/ncurses/plan.sh
+++ b/ncurses/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ncurses
 pkg_origin=core
-pkg_version=6.0
+pkg_version=5.0
 pkg_license=('ncurses')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260

--- a/ncurses/v5.0/plan.sh
+++ b/ncurses/v5.0/plan.sh
@@ -1,0 +1,66 @@
+pkg_name=ncurses
+pkg_origin=core
+pkg_version=5.0
+pkg_license=('ncurses')
+pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=a58bbcfd2a4fd82b2609cf3d700d1933df6140dad45b4af83fdc5d23a61c29df
+pkg_deps=(core/glibc core/gcc-libs)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  ./configure --prefix=$pkg_prefix \
+    --with-termlib \
+    --with-cxx-binding \
+    --with-cxx-shared \
+    --without-ada \
+    --enable-sigwinch \
+    --enable-pc-files \
+    --enable-symlinks \
+    --enable-widec \
+    --enable-ext-colors \
+    --without-debug \
+    --with-normal \
+    --enable-overwrite \
+    --disable-rpath-hack
+  make
+}
+
+do_install() {
+  make install
+
+  # Many packages that use Ncurses will compile just fine against the widechar
+  # libraries, but won't know to look for them. Create linker scripts and
+  # symbolic links to allow older and non-widec compatible programs to build
+  # properly
+  #
+  # Thanks to: http://clfs.org/view/sysvinit/x86_64-64/final-system/ncurses.html
+  local maj=$(echo $pkg_version | cut -d "." -f 1)
+  local maj_min=$(echo $pkg_version | cut -d "." -f 1-2)
+  for x in curses ncurses form panel menu tinfo; do
+    echo "INPUT(-l${x}w)" > $pkg_prefix/lib/lib${x}.so
+    ln -sv lib${x}w.so $pkg_prefix/lib/lib${x}.so.$maj
+    ln -sv lib${x}w.so $pkg_prefix/lib/lib${x}.so.$maj_min
+  done
+  ln -sfv libncursesw.so $pkg_prefix/lib/libcursesw.so
+  ln -sfv libncursesw.a $pkg_prefix/lib/libcursesw.a
+  ln -sfv libncursesw.a $pkg_prefix/lib/libcurses.a
+
+  # Install the license, which comes from the README
+  install -dv $pkg_prefix/share/licenses
+  grep -B 100 '$Id' README > $pkg_prefix/share/licenses/LICENSE
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(core/gcc)
+fi

--- a/ncurses5/plan.sh
+++ b/ncurses5/plan.sh
@@ -1,8 +1,9 @@
-pkg_name=ncurses
+pkg_name=ncurses5
 pkg_origin=core
 pkg_version=5.0
 pkg_license=('ncurses')
-pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
+pkg_source=http://ftp.gnu.org/gnu/ncurses/ncurses-${pkg_version}.tar.gz
+pkg_dirname=ncurses-$pkg_version
 pkg_shasum=a58bbcfd2a4fd82b2609cf3d700d1933df6140dad45b4af83fdc5d23a61c29df
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
@@ -24,7 +25,7 @@ do_build() {
     --without-debug \
     --with-normal \
     --enable-overwrite \
-    --disable-rpath-hack
+    --disable-rpath-hack  
   make
 }
 


### PR DESCRIPTION
Proposed ncurses5 package also per convo in PR#63. As an example Mosh requires ncurses v5.0, it seems like support for major versions with multiple plans makes sense. 