### PR TITLE
coreutils 8.25 (updated)

### DIFF
--- a/coreutils/plan.sh
+++ b/coreutils/plan.sh
@@ -1,13 +1,15 @@
 pkg_name=coreutils
 pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=8.24
+pkg_version=8.25
+pkg_upstream_url=https://www.gnu.org/software/coreutils/
+pkg_description="Basic file, shell and text manipulation utilities of the GNU operating system."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv3')
+pkg_license=('GPL-3.0')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_distname/${pkg_distname}-${pkg_version}.tar.xz
-pkg_shasum=a2d75286a4b9ef3a13039c2da3868a61be4ee9f17d8ae380a35a97e506972170
+pkg_shasum=31e67c057a5b32a582f26408c789e11c2e8d676593324849dcf5779296cdce87
 pkg_deps=(core/glibc core/acl core/attr core/gmp core/libcap)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/m4 core/perl)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/m4 core/perl core/inetutils)
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/env)
 
@@ -16,7 +18,7 @@ do_build() {
   # and the `--enable-no-install-program` flag skips installation of binaries
   # that are provided by other pacakges.
   FORCE_UNSAFE_CONFIGURE=1 ./configure \
-    --prefix=$pkg_prefix \
+    --prefix="$pkg_prefix" \
     --enable-no-install-program=kill,uptime
   make
 }


### PR DESCRIPTION
coreutils 8.25 was released in January. Release notes are on the GNU
forum: http://savannah.gnu.org/forum/forum.php?forum_id=8445

- Metadata update
- ShellCheck style

Signed-off-by: Mike Fiedler <miketheman@gmail.com>