### PR TITLE
Update go to 1.6.3

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,10 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.6.2
-pkg_license=('bsd')
+pkg_version=1.6.3
+pkg_description="Go is an open source programming language that makes it easy to
+  build simple, reliable, and efficient software."
+pkg_upstream_url=https://golang.org/
+pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/${pkg_name}${pkg_version}.src.tar.gz
-pkg_shasum=787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63f1bccc
+pkg_shasum=6326aeed5f86cf18f16d6dc831405614f855e2d416a91fd3fdc334f772345b00
 pkg_dirname=$pkg_name
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go/1.4.3 core/perl)
@@ -18,7 +21,8 @@ do_prepare() {
   export CGO_ENABLED=1
   build_line "Setting CGO_ENABLED=$CGO_ENABLED"
 
-  export GOROOT="$(pwd)"
+  export GOROOT
+  GOROOT="$PWD"
   build_line "Setting GOROOT=$GOROOT"
   export GOBIN="$GOROOT/bin"
   build_line "Setting GOBIN=$GOBIN"
@@ -31,11 +35,13 @@ do_prepare() {
   # Building Go after 1.5 requires a previous version of Go to bootstrap with.
   # This environment variable tells the build system to use our 1.4.x release
   # as the bootstrapping Go.
-  export GOROOT_BOOTSTRAP="$(pkg_path_for go)"
+  export GOROOT_BOOTSTRAP
+  GOROOT_BOOTSTRAP="$(pkg_path_for go)"
   build_line "Setting GOROOT_BOOTSTRAP=$GOROOT_BOOTSTRAP"
 
   # Add `cacerts` to the SSL certificate lookup chain
-  cat $PLAN_CONTEXT/cacerts.patch \
+  # shellcheck disable=SC2002
+  cat "$PLAN_CONTEXT/cacerts.patch" \
     | sed -e "s,@cacerts@,$(pkg_path_for cacerts)/ssl/cert.pem,g" \
     | patch -p1
 
@@ -61,15 +67,15 @@ do_check() {
   # add symlinks if they are not already present
   local _clean_cmds=()
   if [[ ! -r /bin/pwd ]]; then
-    ln -sv $(pkg_path_for coreutils)/bin/pwd /bin/pwd
+    ln -sv "$(pkg_path_for coreutils)/bin/pwd" /bin/pwd
     _clean_cmds+=(/bin/pwd)
   fi
   if [[ ! -r /usr/bin/env ]]; then
-    ln -sv $(pkg_path_for coreutils)/bin/env /usr/bin/env
+    ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
     _clean_cmds+=(/usr/bin/env)
   fi
   if [[ ! -r /bin/hostname ]]; then
-    ln -sv $(pkg_path_for inetutils)/bin/hostname /bin/hostname
+    ln -sv "$(pkg_path_for inetutils)/bin/hostname" /bin/hostname
     _clean_cmds+=(/bin/hostname)
   fi
 
@@ -79,27 +85,27 @@ do_check() {
 
   # Clean up any symlinks that were added to support the build's test suite.
   for cmd in "${_clean_cmds[@]}"; do
-    rm -fv $cmd
+    rm -fv "$cmd"
   done
 }
 
 do_install() {
-  cp -av bin src lib doc misc $pkg_prefix/
+  cp -av bin src lib doc misc "$pkg_prefix/"
 
-  mkdir -pv $pkg_prefix/bin $pkg_prefix/pkg
-  cp -av pkg/{linux_$GOARCH,tool} $pkg_prefix/pkg/
+  mkdir -pv "$pkg_prefix/bin" "$pkg_prefix/pkg"
+  cp -av pkg/{linux_$GOARCH,tool} "$pkg_prefix/pkg/"
   if [[ -d "pkg/linux_${GOARCH}_race" ]]; then
-    cp -av pkg/linux_${GOARCH}_race $pkg_prefix/pkg/
+    cp -av pkg/linux_${GOARCH}_race "$pkg_prefix/pkg/"
   fi
 
   # For godoc
-  install -v -Dm644 favicon.ico $pkg_prefix/favicon.ico
+  install -v -Dm644 favicon.ico "$pkg_prefix/favicon.ico"
 
   # Install the license
-  install -v -Dm644 LICENSE $pkg_prefix/share/licenses/LICENSE
+  install -v -Dm644 LICENSE "$pkg_prefix/share/licenses/LICENSE"
 
   # Remove unneeded Windows files
-  rm -fv $pkg_prefix/src/*.bat
+  rm -fv "$pkg_prefix/src/*.bat"
 }
 
 do_strip() {


### PR DESCRIPTION
Fixes CVE-2016-5386. See
https://groups.google.com/forum/#!topic/golang-announce/7jZDOQ8f8tM

Also make ShellCheck fixes for plan and add upstream URL and
description.

![gif-keyboard-2198425278094310093](https://cloud.githubusercontent.com/assets/9912/16956803/71c7029a-4d9f-11e6-80e7-a20f0cb9138a.gif)
