### PR TITLE
Exclude ShellCheck rule 1090

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
     sha: 28f9ecf7857d17ebd9d1715cb5bf208c9e8e2bdd
     hooks:
     -   id: shell-lint
-        args: ["--exclude=SC1091,SC2034,SC2039,SC2148,SC2153,SC2154"]
+        args: ["--exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154"]
 -   repo: local
     hooks:
     -   id: check-default-variables

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Some default checks of ShellCheck can be turned off, since they aren't
 necessarily applicable in plans. The following options work well:
 
 ```
-shellcheck --shell=bash --exclude=SC1091,SC2034,SC2039,SC2148,SC2153,SC2154
+shellcheck --shell=bash --exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154
 ```
 
 If ShellCheck is installed, you can run this (and other checks) locally with:


### PR DESCRIPTION
[SC1090](https://github.com/koalaman/shellcheck/wiki/SC1090) is not
really helpful in a plan, since we usually don't have a direct reference
to the thing we're sourcing while editing a plan. This disables it in
the pre-commit.

![gif-keyboard-10514014500973638807](https://cloud.githubusercontent.com/assets/9912/16957319/85ad042e-4da1-11e6-8ec9-2b7c3bcd294e.gif)
