### PR TITLE
Explicitly link tcl with gcc_s

### DIFF
--- a/dejagnu/plan.sh
+++ b/dejagnu/plan.sh
@@ -1,7 +1,9 @@
 pkg_name=dejagnu
 pkg_origin=core
 pkg_version=1.5.3
-pkg_license=('gplv2+')
+pkg_license=('GPL-2.0')
+pkg_upstream_url="https://www.gnu.org/software/dejagnu/"
+pkg_description="A framework for testing other programs."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=099b8e364ca1d6248f8e1d32168c4b12677abff4253bbbb4a8ac8cdd321e3f19
@@ -16,8 +18,7 @@ do_check() {
   #
   # Provide `runtest' with a log name, otherwise it tries to run `whoami`,
   # which fails when in a chroot.
-  LOGNAME="dejagnu-logger" make check \
-    LD_LIBRARY_PATH="$(pkg_path_for gcc)/lib" < /dev/zero
+  LOGNAME="dejagnu-logger" make check < /dev/zero
 }
 
 do_install() {
@@ -26,7 +27,7 @@ do_install() {
   # Set an absolute path `expect` in the `runtest` binary
   sed \
     -e "s,expectbin=expect,expectbin=$(pkg_path_for expect)/bin/expect,g" \
-    -i $pkg_prefix/bin/runtest
+    -i "$pkg_prefix/bin/runtest"
 }
 
 

--- a/expect/plan.sh
+++ b/expect/plan.sh
@@ -2,6 +2,8 @@ pkg_name=expect
 pkg_origin=core
 pkg_version=5.45
 pkg_license=('custom')
+pkg_description="A tool for automating interactive applications"
+pkg_upstream_url="http://expect.sourceforge.net/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://downloads.sourceforge.net/project/$pkg_name/Expect/${pkg_version}/${pkg_name}${pkg_version}.tar.gz
 pkg_shasum=b28dca90428a3b30e650525cdc16255d76bb6ccd65d448be53e620d95d5cc040
@@ -21,24 +23,22 @@ do_prepare() {
 
 do_build() {
   ./configure \
-    --prefix=$pkg_prefix \
-    --exec-prefix=$pkg_prefix \
-    --with-tcl=$(pkg_path_for tcl)/lib \
-    --with-tclinclude=$(pkg_path_for tcl)/include
+    --prefix="$pkg_prefix" \
+    --exec-prefix="$pkg_prefix" \
+    --with-tcl="$(pkg_path_for tcl)/lib" \
+    --with-tclinclude="$(pkg_path_for tcl)/include"
   make
 }
 
 do_check() {
-  # The test suite looks for `libgcc_s`, so we'll add it to the
-  # `LD_LIBRARY_PATH`.
-  make test LD_LIBRARY_PATH="$(pkg_path_for gcc)/lib"
+  make test
 }
 
 do_install() {
-  make install LD_LIBRARY_PATH="$(pkg_path_for gcc)/lib"
+  make install
 
   # Add an absolute path to `tclsh` in each script binary
-  find $pkg_prefix/bin \
+  find "$pkg_prefix/bin" \
     -type f \
     -exec sed -e "s,exec tclsh,exec $(pkg_path_for tcl)/bin/tclsh,g" -i {} \;
 }

--- a/tcl/plan.sh
+++ b/tcl/plan.sh
@@ -2,11 +2,13 @@ pkg_name=tcl
 pkg_origin=core
 pkg_version=8.6.4
 pkg_license=('custom')
+pkg_description="Tool Command Language -- A dynamic programming language."
+pkg_upstream_url="http://www.tcl.tk/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://heanet.dl.sourceforge.net/project/tcl/Tcl/${pkg_version}/${pkg_name}${pkg_version}-src.tar.gz
 pkg_shasum=9e6ed94c981c1d0c5f5fefb8112d06c6bf4d050a7327e95e71d417c416519c8d
 pkg_dirname=${pkg_name}${pkg_version}
-pkg_deps=(core/glibc core/zlib)
+pkg_deps=(core/glibc core/gcc-libs core/zlib)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -14,8 +16,9 @@ pkg_lib_dirs=(lib)
 
 do_build() {
   pushd unix > /dev/null
+    export LDFLAGS="-lgcc_s ${LDFLAGS}"
     ./configure \
-      --prefix=$pkg_prefix \
+      --prefix="$pkg_prefix" \
       --enable-threads \
       --enable-64bit
     make
@@ -27,7 +30,8 @@ do_build() {
     #
     # Thanks to: http://www.linuxfromscratch.org/blfs/view/stable/general/tcl.html
     # Thanks to: https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/tcl
-    local srcdir=$(abspath ..)
+    local srcdir
+    srcdir=$(abspath ..)
     local tdbcver=tdbc1.0.3
     local itclver=itcl4.0.3
     sed \
@@ -54,13 +58,13 @@ do_install() {
     make install-private-headers
 
     # Many packages expect a file named tclsh, so create a symlink
-    ln -sfv tclsh${pkg_version%.?} $pkg_prefix/bin/tclsh
+    ln -sfv "tclsh${pkg_version%.?}" "$pkg_prefix/bin/tclsh"
 
-    chmod -v 755 $pkg_prefix/lib/libtcl${pkg_version%.?}.so
-    ln -sfv libtcl${pkg_version%.?}.so $pkg_prefix/lib/libtcl.so
+    chmod -v 755 "$pkg_prefix/lib/libtcl${pkg_version%.?}.so"
+    ln -sfv "libtcl${pkg_version%.?}.so" "$pkg_prefix/lib/libtcl.so"
 
     # Install license file
-    install -Dm644 ../license.terms ${pkg_prefix}/share/licenses/LICENSE
+    install -Dm644 ../license.terms "${pkg_prefix}/share/licenses/LICENSE"
   popd > /dev/null
 }
 


### PR DESCRIPTION
tclsh would fail on exit with an error about pthread_cance:

    # /hab/pkgs/core/tcl/8.6.4/20160612080859/bin/tclsh
    % exit
    libgcc_s.so.1 must be installed for pthread_cancel to work
    Aborted
    # echo $?
    134

Similarly tools built on tcl would fail at exit:

    # /hab/pkgs/core/expect/5.45/20160612081035/bin/expect
    expect1.1> exit
    libgcc_s.so.1 must be installed for pthread_cancel to work
    Aborted
    # echo $?
    134

Explicitly linking with gcc_s solves this problem without requiring
users set LD_LIBRARY_PATH when running tcl-based applications.

Signed-off-by: Steven Danna <steve@chef.io>