### PR TITLE
Update to GDB 7.11.1 and add support for python scripting, lzma, TUI and expat

### DIFF
--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -1,32 +1,77 @@
 pkg_name=gdb
 pkg_origin=core
-pkg_version=7.11
+pkg_version=7.11.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv3')
-pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
-pkg_shasum=7a434116cb630d77bb40776e8f5d3937bed11dea56bafebb4d2bc5dd389fe5c1
-pkg_deps=(core/glibc core/readline core/zlib core/python)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/texinfo)
+pkg_license=('GPL-3.0')
+pkg_description="GDB, the GNU Project debugger, allows you to see what is going on 'inside' another program while it executes -- or what another program was doing at the moment it crashed."
+pkg_upstream_url=https://www.gnu.org/software/gdb/
+pkg_source=http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz
+pkg_shasum=e9216da4e3755e9f414c1aa0026b626251dfc57ffe572a266e98da4f6988fc70
+pkg_deps=(
+  core/glibc
+  core/readline
+  core/zlib
+  core/xz
+  core/ncurses
+  core/expat
+  core/python
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/expect
+  core/dejagnu
+  core/patch
+  core/make
+  core/gcc
+  core/texinfo
+)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
+  export CXXFLAGS="${CXXFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
+  export CPPFLAGS="${CPPFLAGS} -Wdate-time"
+  export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic-functions -Wl,-z,relro"
+}
+
 do_build() {
   ./configure \
-    --prefix=$pkg_prefix \
+    --build=x86_64-linux-gnu \
+    --host=x86_64-linux-gnu \
+    --prefix="${pkg_prefix}" \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --libexecdir="${prefix}/lib/gdb" \
+    --enable-tui \
+    --disable-maintainer-mode \
+    --disable-dependency-tracking \
+    --disable-silent-rules \
+    --disable-gdbtk \
+    --disable-shared \
+    --with-pkgversion="The Habitat Maintainers ${pkg_version}/${pkg_release}" \
     --with-system-readline \
-    --with-system-zlib
-  make
+    --with-system-zlib \
+    --with-lzma \
+    --with-expat \
+    --without-guile \
+    --without-babeltrace \
+    --with-system-gdbinit=/etc/gdb/gdbinit \
+    --with-python=python3
+
+  make -j "$(nproc)"
 }
 
 do_check() {
-  make check
+  make -j "$(nproc)" check
 }
 
 do_install() {
   do_default_install
 
   # Clean up files that ship with binutils and may conflict
-  rm -fv $pkg_prefix/lib/{libbfd,libopcodes}.a
-  rm -fv $pkg_prefix/include/{ansidecl,bfd,bfdlink,dis-asm,plugin-api,symcat}.h
-  rm -fv $pkg_prefix/share/info/bfd.info
+  rm -fv "${pkg_prefix}/lib/{libbfd,libopcodes}.a"
+  rm -fv "${pkg_prefix}/include/{ansidecl,bfd,bfdlink,dis-asm,plugin-api,symcat}.h"
+  rm -fv "${pkg_prefix}/share/info/bfd.info"
 }

--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -41,9 +41,9 @@ do_build() {
     --build=x86_64-linux-gnu \
     --host=x86_64-linux-gnu \
     --prefix="${pkg_prefix}" \
-    --sysconfdir=/etc \
-    --localstatedir=/var \
-    --libexecdir="${prefix}/lib/gdb" \
+    --sysconfdir="${pkg_svc_config_path}" \
+    --localstatedir="${pkg_svc_var_path}" \
+    --libexecdir="${pkg_prefix}/lib/gdb" \
     --enable-tui \
     --disable-maintainer-mode \
     --disable-dependency-tracking \


### PR DESCRIPTION
Update to GDB 7.11.1 and add support for python scripting and expat.

Since coreutils are used, add multiple jobs to "make" with nproc(from coreutils).

Add core/expect and core/dejagnu dependencies to be able to run "do_check".
Bring the entire build process closer to Ubuntu's.

Tested inside a clean Alpine container.

--
Note that even though `make check` runs now, over 300 tests fail(~27000 pass)