### PR TITLE
Add a plan for OpenSSH

### DIFF
--- a/openssh/config/sshd_config
+++ b/openssh/config/sshd_config
@@ -1,0 +1,133 @@
+#	$OpenBSD: sshd_config,v 1.98 2016/02/17 05:29:04 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+# The default requires explicit activation of protocol 1
+#Protocol 2
+
+# HostKey for protocol version 1
+#HostKey /etc/ssh/ssh_host_key
+# HostKeys for protocol version 2
+HostKey {{pkg.svc_config_path}}/ssh_host_rsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_dsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_ecdsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_ed25519_key
+
+# Lifetime and size of ephemeral version 1 server key
+#KeyRegenerationInterval 1h
+#ServerKeyBits 1024
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+# obsoletes QuietMode and FascistLogging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#RSAAuthentication yes
+PubkeyAuthentication {{cfg.pubkey_authentication}}
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#RhostsRSAAuthentication no
+# similar for protocol version 2
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# RhostsRSAAuthentication and HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication {{cfg.password_authentication}}
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	{{cfg.pkg_path}}/libexec/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/openssh/default.toml
+++ b/openssh/default.toml
@@ -1,0 +1,2 @@
+pubkey_authentication = 'yes'
+password_authentication = 'yes'

--- a/openssh/hooks/init
+++ b/openssh/hooks/init
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p {{pkg.svc_var_path}}/empty
+ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
+ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
+ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
+ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""

--- a/openssh/hooks/run
+++ b/openssh/hooks/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+exec 2>&1
+exec $(hab pkg path core/openssh)/sbin/sshd -D -f {{pkg.svc_config_path}}/sshd_config

--- a/openssh/plan.sh
+++ b/openssh/plan.sh
@@ -1,0 +1,26 @@
+pkg_origin=core
+pkg_name=openssh
+pkg_version=7.2p2
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('bsd')
+pkg_source=http://ftp3.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=a72781d1a043876a224ff1b0032daa4094d87565a68528759c1c2cab5482548c
+pkg_bin_dirs=(bin sbin libexec)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_deps=(core/glibc core/openssl core/zlib)
+pkg_build_deps=(core/coreutils core/gcc core/make)
+
+do_build() {
+  ./configure --prefix=${pkg_prefix} \
+              --sysconfdir=${pkg_svc_path}/config \
+              --localstatedir=${pkg_svc_path}/var \
+              --datadir=${pkg_svc_data_path} \
+              --with-privsep-user=hab \
+              --with-privsep-path=${pkg_svc_var_path}/empty
+  make
+}
+
+do_install() {
+  make install-nosysconf
+}

--- a/openssh/plan.sh
+++ b/openssh/plan.sh
@@ -13,12 +13,12 @@ pkg_deps=(core/glibc core/openssl core/zlib)
 pkg_build_deps=(core/coreutils core/gcc core/make)
 
 do_build() {
-  ./configure --prefix=${pkg_prefix} \
-              --sysconfdir=${pkg_svc_path}/config \
-              --localstatedir=${pkg_svc_path}/var \
-              --datadir=${pkg_svc_data_path} \
+  ./configure --prefix="${pkg_prefix}" \
+              --sysconfdir="${pkg_svc_path}/config" \
+              --localstatedir="${pkg_svc_path}/var" \
+              --datadir="${pkg_svc_data_path}" \
               --with-privsep-user=hab \
-              --with-privsep-path=${pkg_svc_var_path}/empty
+              --with-privsep-path="${pkg_svc_var_path}/empty"
   make
 }
 

--- a/openssh/plan.sh
+++ b/openssh/plan.sh
@@ -2,6 +2,7 @@ pkg_origin=core
 pkg_name=openssh
 pkg_version=7.2p2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Provides OpenSSH client and server."
 pkg_license=('bsd')
 pkg_source=http://ftp3.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=a72781d1a043876a224ff1b0032daa4094d87565a68528759c1c2cab5482548c


### PR DESCRIPTION
This is so we have an SSH binary that can be used by other packages such as core/git so we don't make an assumption that the underlying OS / distribution has SSH available. Also includes sshd configuration.

Signed-off-by: jtimberman <joshua@chef.io>