### PR TITLE
core/git depends on core/openssh

### DIFF
--- a/git/plan.sh
+++ b/git/plan.sh
@@ -17,6 +17,7 @@ pkg_deps=(
   core/gettext
   core/gcc-libs
   core/glibc
+  core/openssh
   core/perl
   core/zlib
 )


### PR DESCRIPTION
We need to depend on our own core/openssh package because that way we aren't relying or assuming on the underlying OS/distribution having the SSH binary.

This requires #96 - though the packages are uploaded to the depot already.