### PR TITLE
cruft removal and readline-rb

### DIFF
--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -9,8 +9,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd
-pkg_deps=(core/glibc core/ncurses core/zlib core/libedit core/openssl core/libyaml
-          core/libiconv core/libffi)
+pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
@@ -22,12 +21,8 @@ do_build() {
     patch -p1 -i "$PLAN_CONTEXT/patches/ruby-2_1_3-no-mkmf.patch"
 
     ./configure "--prefix=$pkg_prefix" \
-                --with-out-ext=dbm \
                 --enable-shared \
-                --enable-libedit \
                 --disable-install-doc \
-                --without-gmp \
-                --without-gdbm \
                 "--with-openssl-dir=$(_resolve_dependency core/openssl)" \
                 "--with-libyaml-dir=$(_resolve_dependency core/libyaml)"
     make
@@ -35,7 +30,8 @@ do_build() {
 
 do_install() {
   do_default_install
-  gem update --system
+  gem update --system --no-document
+  gem install rb-readline --no-document
 }
 
 do_check() {

--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -7,6 +7,7 @@ pkg_description="A dynamic, open source programming language with a focus on \
 pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_upstream_url=https://www.ruby-lang.org/en/
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi)


### PR DESCRIPTION
This plan looks a bit plagiarized from the omnibus ruby script and
carries some cruft that badly needs to get removed.

libiconv hasn't been need in ruby forever.  We attempted to remove
it from omnibus, though, and broke people on upgrade in a minor
version because `$GREAT_NOKOGIRI_SADNESS`.  Lets not start going down
that road in habitat right from the start.

Most of the flags that disable gdbm/dbm/gmp seem pretty pointless
with the clean build system.  We had those in omnibus because we
had to in order to ignore any O/S provided libraries that might
get accidentally slurped up.  This is probably the biggest reason
about why habitat is a better build system than omnibus.

Also swapped out libedit for readline-rb since we're going to want
that instead down the road.  In that case the road actually is pretty
well trod and we know how it ends.

Now that iconv and libedit are gone, its possible ncurses could die
as well, along with some other deps but I'm not certain yet...