### PR TITLE
Make ssh-keygen idempotent in init

### DIFF
--- a/openssh/hooks/init
+++ b/openssh/hooks/init
@@ -1,7 +1,21 @@
 #!/bin/bash
 
 mkdir -p {{pkg.svc_var_path}}/empty
-ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
-ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
-ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
-ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""
+
+# Generate the keys if they do not exist - restarting sshd would cause
+# this to fail, e.g., on package upgrade
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_dsa_key ]; then
+  ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_rsa_key ]; then
+  ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_ed25519_key ]; then
+  ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key ]; then
+  ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""
+fi


### PR DESCRIPTION
When starting core/openssh, the init script needs to create the host keys for the system. However, it needs to ensure that it doesn't run this when the keys already exist for two reasons:

* Existence of the keys will cause ssh-keygen to fail if the service is restarted, e.g., on upgrade
* A user might want to manage their host keys outside of habitat with their own secrets management, with Chef, or in their base OS image

Signed-off-by: jtimberman <joshua@chef.io>