### PR TITLE
Resolve stack error on recursive dependencies

### DIFF
--- a/bin/build-dependent-order.rb
+++ b/bin/build-dependent-order.rb
@@ -89,9 +89,13 @@ ARGF.each_line do |file|
   # Parse out the package identifier and the dependencies from the Bash program
   ident, _, deps_str = raw.partition(/\n/)
   # Add the package ident to a key in an "all deps" hash with the value being
-  # an array of dependency package identifiers
+  # an array of dependency package identifiers, but drop ourself so we
+  # don't an infinitely recursive result set. This would happen if we
+  # depend on a previous version of ourself, for example, `go`
+  # requires `go` to build a newer `go`
   all_deps.add(ident, deps_str.split(' ')
-    .map { |d| d.split('/').first(2).join('/') })
+    .map { |d| d.split('/').first(2).join('/') }
+    .reject { |i| i == ident })
   # Add the pacakge ident to a key in a "plan" hash with the value being
   # the path to the directory containing the relevant `plan.sh`
   ident_to_plan[ident] = \


### PR DESCRIPTION
In the event that a plan loads and depends on a previous version of
itself - for example `go` - we will get a stack error when trying to
get the dependency list out of the `build-dependent-order.rb` script.

This commit fixes this by using Ruby's `#reject` method. We would
possibly want to use `#grep_v`, but it's not available in all Rubies,
so here we are.

Signed-off-by: jtimberman <joshua@chef.io>