### PR TITLE
Add dotnet-core

### DIFF
--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,12 +1,25 @@
 pkg_name=curl
 pkg_origin=core
 pkg_version=7.47.1
+pkg_description="curl is an open source command line tool and library for
+  transferring data with URL syntax."
+pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=4e9d85028e754048887505a73638bf9b254c39582a191f43c95fe7de8e4d8005
-pkg_deps=(core/glibc core/openssl core/zlib)
-pkg_build_deps=(core/gcc core/make core/coreutils core/perl)
+pkg_deps=(
+  core/cacerts
+  core/glibc
+  core/openssl
+  core/zlib
+)
+pkg_build_deps=(
+  core/coreutils
+  core/gcc
+  core/make
+  core/perl
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -17,9 +30,10 @@ do_prepare() {
 }
 
 do_build() {
-  ./configure --prefix=${pkg_prefix} \
-              --with-ssl=$(pkg_path_for openssl) \
-              --with-zlib=$(pkg_path_for zlib) \
+  ./configure --prefix="$pkg_prefix" \
+              --with-ca-bundle="$(pkg_path_for cacerts)/ssl/certs/cacert.pem" \
+              --with-ssl="$(pkg_path_for openssl)" \
+              --with-zlib="$(pkg_path_for zlib)" \
               --disable-manual \
               --disable-ldap \
               --disable-ldaps \

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,0 +1,58 @@
+pkg_name=dotnet-core
+pkg_origin=core
+pkg_version=1.0.0-preview2-003121
+pkg_license=('Microsoft .NET Library')
+pkg_upstream_url=https://www.microsoft.com/net/core
+pkg_description=".NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.$pkg_version.tar.gz"
+pkg_shasum=204ceab7bc92c17d17691b0d5c1d54992fc78a969fc217a8423045875a4c63ed
+pkg_filename="dotnet-debian-x64.$pkg_version.tar.gz"
+pkg_deps=(
+  core/curl
+  core/gcc-libs
+  core/glibc
+  core/icu/52.1
+  core/krb5
+  core/libunwind
+  core/lttng-ust
+  core/openssl
+  core/util-linux
+  core/zlib
+)
+pkg_build_deps=(
+  core/patchelf
+)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
+  mkdir -p "$pkg_dirname"
+  tar xfz "$pkg_filename" -C "$pkg_dirname"
+}
+
+do_prepare() {
+  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
+    --set-rpath "$LD_RUN_PATH" \
+    ./dotnet
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  # Copy the files into the package
+  cp -a . "$pkg_prefix"
+
+  # Wrap the binary in a script that sets the library paths
+  mkdir -p "$pkg_prefix/bin"
+  cat > "$pkg_prefix/bin/dotnet" <<EOF
+#!/bin/sh
+export LD_LIBRARY_PATH="$pkg_prefix/lib:$LD_RUN_PATH:\$LD_LIBRARY_PATH"
+exec $pkg_prefix/dotnet \$@
+EOF
+  chmod +x "$pkg_prefix/bin/dotnet"
+}

--- a/krb5/plan.sh
+++ b/krb5/plan.sh
@@ -1,0 +1,35 @@
+pkg_origin=core
+pkg_name=krb5
+pkg_version=1.14.3
+pkg_description="Kerberos is a network authentication protocol. It is designed
+  to provide strong authentication for client/server applications by using
+  secret-key cryptography. "
+pkg_upstream_url=http://web.mit.edu/kerberos/www/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL-2.1')
+pkg_source="http://web.mit.edu/kerberos/dist/$pkg_name/${pkg_version%.*}/$pkg_name-$pkg_version.tar.gz"
+pkg_shasum=cd4620d520cf0df0dd8791309912df2bb20fcba76790b9fba4e25c1da08ff2c9
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/bison
+  core/busybox
+  core/gcc
+  core/m4
+  core/make
+  core/perl
+)
+pkg_bin_dirs=(bin sbin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  cd src || exit
+  do_default_build
+}
+
+do_install() {
+  cd src || exit
+  do_default_install
+}

--- a/lttng-ust/plan.sh
+++ b/lttng-ust/plan.sh
@@ -1,0 +1,27 @@
+pkg_origin=core
+pkg_name=lttng-ust
+pkg_version=2.8.1
+pkg_description="LTTng is an open source tracing framework for Linux."
+pkg_upstream_url=http://lttng.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-2.0' 'MIT')
+pkg_source=$pkg_upstream_url/files/$pkg_name/$pkg_name-$pkg_version.tar.bz2
+pkg_shasum=6e41349107e83e7b43c69ed358e48788ca2fd095bad61737b850e3f3d2c0508a
+pkg_deps=(
+  core/coreutils
+  core/gcc-libs
+  core/glibc
+  core/python2
+  core/userspace-rcu
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  fix_interpreter "$HAB_CACHE_SRC_PATH/$pkg_dirname/tools/lttng-gen-tp" core/coreutils bin/env
+}

--- a/userspace-rcu/plan.sh
+++ b/userspace-rcu/plan.sh
@@ -1,0 +1,21 @@
+pkg_origin=core
+pkg_name=userspace-rcu
+pkg_version=0.9.2
+pkg_description="liburcu is a LGPLv2.1 userspace RCU (read-copy-update) library.
+  This data synchronization library provides read-side access which scales
+  linearly with the number of cores."
+pkg_upstream_url=http://liburcu.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL-2.1')
+pkg_source=http://www.lttng.org/files/urcu/$pkg_name-$pkg_version.tar.bz2
+pkg_shasum=8f7fa313b1e0a3f742cea24ce63a39c0efe63e615a769e2961e55bd2663ecaa3
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)


### PR DESCRIPTION
Once you have it, you can `hab pkg exec core/dotnet-core dotnet`.

Adds:

* Fixes for the curl plan, mainly compiling in the path to the CA cert
  file so libcurl can verify certificates
* A [Kerberos5](http://web.mit.edu/kerberos/www/) plan
* A [LTTng](http://lttng.org/) plan
* An [userspace-rcu](http://liburcu.org/) plan

Requires ICU 52.1, which I'll get uploaded to the depot separately (we have
57.1 currently.)

![gif-keyboard-16939144066151847941](https://cloud.githubusercontent.com/assets/9912/17197755/5167bba6-5435-11e6-959b-17f59873f995.gif)