### PR TITLE
Fixes for fontconfig

### DIFF
--- a/fontconfig/plan.sh
+++ b/fontconfig/plan.sh
@@ -2,10 +2,18 @@ pkg_name=fontconfig
 pkg_version=2.11.94
 pkg_origin=core
 pkg_license=('fontconfig')
+pkg_description="Fontconfig is a library for configuring and
+  customizing font access."
+pkg_upstream_url=https://www.freedesktop.org/wiki/Software/fontconfig/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.freedesktop.org/software/fontconfig/release/${pkg_name}-${pkg_version}.tar.bz2
 pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
 pkg_shasum=d763c024df434146f3352448bc1f4554f390c8a48340cef7aa9cc44716a159df
-pkg_deps=(core/glibc)
+pkg_deps=(
+  core/bzip2
+  core/glibc
+  core/zlib
+)
 pkg_build_deps=(core/gcc core/make core/coreutils core/python
                 core/pkg-config core/freetype core/expat
                 core/diffutils core/libtool core/m4 core/automake
@@ -14,6 +22,22 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 do_prepare() {
+  export PKG_CONFIG_PATH
+  PKG_CONFIG_PATH="$(pkg_path_for freetype)/lib/pkgconfig:$(pkg_path_for expat)/lib/pkgconfig"
+  build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
+
+  # Set freetype paths
+  export FREETYPE_CFLAGS="$CFLAGS"
+  build_line "Setting FREETYPE_CFLAGS=$FREETYPE_CFLAGS"
+  export FREETYPE_LIBS
+  FREETYPE_LIBS="$LDFLAGS -Wl,--rpath -Wl,$(pkg_path_for freetype)/lib -lfreetype -lz"
+  build_line "Setting FREETYPE_LIBS=$FREETYPE_LIBS"
+
+  # Add "freetype2" to include path
+  export CFLAGS
+  CFLAGS="$CFLAGS -I$(pkg_path_for freetype)/include/freetype2"
+  build_line "Setting CFLAGS=$CFLAGS"
+
   # Borrowing this pro tip from ArchLinux!
   # https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fontconfig#n34
   # this seems to run libtoolize though...
@@ -27,12 +51,9 @@ do_prepare() {
 }
 
 do_build() {
-  export PKG_CONFIG_PATH="$(pkg_path_for freetype)/lib/pkgconfig:$(pkg_path_for expat)/lib/pkgconfig"
-
-  ./configure --sysconfdir=${pkg_prefix}/etc \
-              --prefix=${pkg_prefix} \
+  ./configure --sysconfdir="$pkg_prefix/etc" \
+              --prefix="$pkg_prefix" \
               --disable-static \
-              --mandir=${pkg_prefix}/man
+              --mandir="$pkg_prefix/man"
   make
-  make install
 }


### PR DESCRIPTION
* Add description/upstream url/maintainer
* Add deps on zlib and bzip2, needed by binaries
* Move environment variable setting into `do_prepare`
* Set `FREETYPE_CFLAGS`, `FREETYPE_LIBS`, and `CFLAGS` to values that
  make this build
* Remove `make install` from `do_build` because it already happens in
  `do_install`

# Frequently Asked Questions

## How did this even work before?

¯\\(°_o)/¯

![gif-keyboard-3139157889721788269](https://cloud.githubusercontent.com/assets/9912/17202847/70f5d648-5461-11e6-9885-8fa158d5e5a0.gif)
