### PR TITLE
redis 3.2.3 (updated)

### DIFF
--- a/redis/plan.sh
+++ b/redis/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=redis
 pkg_origin=core
-pkg_version=3.2.1
+pkg_version=3.2.2
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url=http://redis.io/
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=df7bfb7b527d99981eba3912ae22703764eb19adda1357818188b22fdd09d5c9
+pkg_shasum=05cf63502b2248b5d39588962100bfa4fcb47dabd56931a8cb60b301b1d8daea
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc)
 pkg_deps=(core/glibc)

--- a/redis/plan.sh
+++ b/redis/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=redis
 pkg_origin=core
-pkg_version=3.2.2
+pkg_version=3.2.3
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url=http://redis.io/
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=05cf63502b2248b5d39588962100bfa4fcb47dabd56931a8cb60b301b1d8daea
+pkg_shasum=674e9c38472e96491b7d4f7b42c38b71b5acbca945856e209cb428fbc6135f15
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc)
 pkg_deps=(core/glibc)


### PR DESCRIPTION
Moderate-level upgrade due to server crash when using LSET with Lists,
as well as Sentinel fixes, and more!

Release notes here:
https://raw.githubusercontent.com/antirez/redis/3.2/00-RELEASENOTES