### PR TITLE
allow polipo to start more than once

### DIFF
--- a/polipo/hooks/init
+++ b/polipo/hooks/init
@@ -1,5 +1,5 @@
 #!/bin/sh
 #
 
-mkdir {{pkg.svc_path}}/cache/
-mkdir {{pkg.svc_path}}/www/
+mkdir -p {{pkg.svc_path}}/cache/
+mkdir -p {{pkg.svc_path}}/www/


### PR DESCRIPTION
the `init` hook fails if polipo is started more than once.

```
root@0b7fbcc18b97:/src/components/sup# hab start core/polipo
hab-sup(MN): Starting core/polipo
hab-sup(GS): Supervisor 172.17.0.2: e4c636d1-4a19-4688-8902-f2ddac17e8e6
hab-sup(GS): Census polipo.default: df3544bb-4462-4ffa-ba20-acdf8f8b85e8
hab-sup(GS): Starting inbound gossip listener
hab-sup(GS): Starting outbound gossip distributor
hab-sup(GS): Starting gossip failure detector
hab-sup(CN): Starting census health adjuster
hab-sup(SC): Updated polipo.config
hab-sup(TP): Restarting because the service config was updated via the census
polipo(SV): Starting
^Cpolipo(SV): Stopping
hab-sup(SV): polipo - process 2206 died with signal 2
hab-sup(MN): Finished with core/polipo
root@0b7fbcc18b97:/src/components/sup# hab start core/polipo
hab-sup(MN): Starting core/polipo
hab-sup(GS): Supervisor 172.17.0.2: 70cdefce-7da0-4e5c-bd10-7481c0c40200
hab-sup(GS): Census polipo.default: eb098ca0-f8d4-4b13-bdde-35ec90fd3abf
hab-sup(GS): Starting inbound gossip listener
hab-sup(GS): Starting outbound gossip distributor
hab-sup(GS): Starting gossip failure detector
hab-sup(CN): Starting census health adjuster
hab-sup(SC): Updated polipo.config
hab-sup(TP): Restarting because the service config was updated via the census
hab-sup(PH)[src/package/hooks.rs:111:16]: Hook failed to run: init, 1, Failed
```