### PR TITLE
add net-tools, readline to inspec

### DIFF
--- a/inspec/plan.sh
+++ b/inspec/plan.sh
@@ -11,12 +11,14 @@ pkg_source=false
 pkg_deps=(
   core/coreutils
   core/ruby
+  core/net-tools
 )
 pkg_build_deps=(
   core/bundler
   core/coreutils
   core/gcc
   core/make
+  core/readline
 )
 pkg_bin_dirs=(bin)
 

--- a/net-tools/config.h
+++ b/net-tools/config.h
@@ -1,0 +1,75 @@
+/*
+* config.h      Automatically generated configuration includefile
+*
+* NET-TOOLS     A collection of programs that form the base set of the
+*               NET-3 Networking Distribution for the LINUX operating
+*               system.
+*
+*               DO  NOT  EDIT  DIRECTLY
+*
+*/
+
+/*
+ *
+ * Internationalization
+ *
+ * The net-tools package has currently been translated to French,
+ * German and Brazilian Portugese.  Other translations are, of
+ * course, welcome.  Answer `n' here if you have no support for
+ * internationalization on your system.
+ *
+ */
+#define I18N 0
+
+/*
+ *
+ * Protocol Families.
+ *
+ */
+#define HAVE_AFUNIX 1
+#define HAVE_AFINET 1
+#define HAVE_AFINET6 0
+#define HAVE_AFIPX 1
+#define HAVE_AFATALK 1
+#define HAVE_AFAX25 0
+#define HAVE_AFNETROM 1
+#define HAVE_AFROSE 0
+#define HAVE_AFX25 0
+#define HAVE_AFECONET 0
+#define HAVE_AFDECnet 0
+#define HAVE_AFASH 0
+
+/*
+ *
+ * Device Hardware types.
+ *
+ */
+#define HAVE_HWETHER 1
+#define HAVE_HWARC 1
+#define HAVE_HWSLIP 1
+#define HAVE_HWPPP 1
+#define HAVE_HWTUNNEL 1
+#define HAVE_HWSTRIP 0
+#define HAVE_HWTR 0
+#define HAVE_HWAX25 0
+#define HAVE_HWROSE 0
+#define HAVE_HWNETROM 1
+#define HAVE_HWX25 0
+#define HAVE_HWFR 1
+#define HAVE_HWSIT 0
+#define HAVE_HWFDDI 0
+#define HAVE_HWHIPPI 0
+#define HAVE_HWASH 0
+#define HAVE_HWHDLCLAPB 0
+#define HAVE_HWIRDA 1
+#define HAVE_HWEC 0
+
+/*
+ *
+ * Other Features.
+ *
+ */
+#define HAVE_FW_MASQUERADE 0
+#define HAVE_IP_TOOLS 0
+#define HAVE_MII 0
+

--- a/net-tools/fix_default.patch
+++ b/net-tools/fix_default.patch
@@ -1,0 +1,60 @@
+diff --git a/hostname.c b/hostname.c
+index 8793fb9..b250cff 100644
+--- a/hostname.c
++++ b/hostname.c
+@@ -78,6 +78,7 @@ static void setnname(char *nname)
+             fprintf(stderr, _("%s: name too long\n"), program_name);
+             break;
+         default:
++            ;
+         }
+ 	exit(1);
+     }
+@@ -98,6 +99,7 @@ static void sethname(char *hname)
+ 	    fprintf(stderr, _("%s: name too long\n"), program_name);
+ 	    break;
+ 	default:
++        ;
+ 	}
+ 	exit(1);
+     };
+@@ -117,6 +119,7 @@ static void setdname(char *dname)
+ 	    fprintf(stderr, _("%s: name too long\n"), program_name);
+ 	    break;
+ 	default:
++        ;
+ 	}
+ 	exit(1);
+     };
+@@ -174,6 +177,7 @@ static void showhname(char *hname, int c)
+ 	printf("%s\n", hp->h_name);
+ 	break;
+     default:
++        ;
+     }
+ }
+ 
+diff --git a/lib/inet_sr.c b/lib/inet_sr.c
+index 6d010d5..a1de8c9 100644
+--- a/lib/inet_sr.c
++++ b/lib/inet_sr.c
+@@ -105,6 +105,7 @@ static int INET_setroute(int action, int options, char **args)
+     case 2:
+        isnet = 0; break;
+     default:
++       ;
+     }
+ 
+     /* Fill in the other fields. */
+diff --git a/nameif.c b/nameif.c
+index 8d79b50..bcfcb8a 100644
+--- a/nameif.c
++++ b/nameif.c
+@@ -218,6 +218,7 @@ int main(int ac, char **av)
+ 		if (c == -1) break;
+ 		switch (c) { 
+ 		default:
++            ;
+ 		case '?':
+ 			usage(); 
+ 		case 'c':

--- a/net-tools/plan.sh
+++ b/net-tools/plan.sh
@@ -1,0 +1,24 @@
+pkg_name=net-tools
+pkg_distname=$pkg_name
+pkg_origin=core
+pkg_version=1.60
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-2.0')
+pkg_source=http://downloads.sourceforge.net/net-tools/${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=7ae4dd6d44d6715f18e10559ffd270511b6e55a8900ca54fbebafe0ae6cf7d7b
+pkg_dirname=${pkg_distname}-${pkg_version}
+pkg_deps=(core/glibc core/coreutils)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin sbin)
+
+do_build() {
+    patch -p1 -i "${PLAN_CONTEXT}/fix_default.patch"
+    cp "${PLAN_CONTEXT}/config.h" "${HAB_CACHE_SRC_PATH}/${pkg_dirname}/config.h"
+    make
+}
+
+do_install() {
+    make install BASEDIR="${pkg_prefix}"
+}


### PR DESCRIPTION
- `Inspec` relies on `netstat` to check open ports.
- `net-tools` doesn't compile with `default` switch blocks, the included patch simply adds `;` characters to each `default` block.