### PR TITLE
change /bin/sh to /bin/bash to fix upload script

### DIFF
--- a/bin/depot-upload-message.sh
+++ b/bin/depot-upload-message.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Take the last build information and put it into a message that you can paste
 # into GitHub as a comment.


### PR DESCRIPTION
The `source` command seems to fail if we don't use `/bin/bash`.
Signed-off-by: Dave Parfitt <dparfitt@chef.io>