### PR TITLE
[rust,cargo-nightly] Add wrapper for `cargo` to set SSL certs.

### DIFF
--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -8,7 +8,7 @@ pkg_dirname=${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu
 pkg_shasum=f189303d52b37c8bb694b9d9739ae73ffa926cbdeffde1d5d6a5c6e811940293
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
-pkg_deps=(core/glibc core/gcc-libs core/zlib core/gcc core/cacerts)
+pkg_deps=(core/glibc core/gcc-libs core/zlib core/gcc core/cacerts core/busybox-static)
 pkg_build_deps=(core/patchelf core/findutils core/coreutils)
 
 _target_sources=(
@@ -82,6 +82,22 @@ do_install() {
       ./install.sh --prefix=$($pkg_prefix/bin/rustc --print sysroot)
     popd > /dev/null
   done; unset i
+
+  # Add a wrapper for cargo to properly set SSL certificates
+  wrap_with_cert_path cargo
+}
+
+wrap_with_cert_path() {
+  local bin="$pkg_prefix/bin/$1"
+  build_line "Adding wrapper $bin to ${bin}.real"
+  mv -v "$bin" "${bin}.real"
+  cat <<EOF > "$bin"
+#!$(pkg_path_for busybox-static)/bin/sh
+set -e
+export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+exec ${bin}.real \$@
+EOF
+  chmod -v 755 "$bin"
 }
 
 do_strip() {

--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -26,7 +26,7 @@ do_download() {
   # skip re-downloading if already present and verified
   for i in $(seq 0 $((${#_target_sources[@]} - 1))); do
     p="${_target_sources[$i]}"
-    download_file $p $(basename $p) ${_target_shasums[$i]}
+    download_file "$p" "$(basename "$p")" "${_target_shasums[$i]}"
   done; unset i p
 }
 
@@ -35,17 +35,17 @@ do_verify() {
 
   # Verify all target sources against their shasums
   for i in $(seq 0 $((${#_target_sources[@]} - 1))); do
-    verify_file $(basename ${_target_sources[$i]}) ${_target_shasums[$i]}
+    verify_file "$(basename "${_target_sources[$i]}")" "${_target_shasums[$i]}"
   done; unset i
 }
 
 do_unpack() {
   do_default_unpack
 
-  pushd $HAB_CACHE_SRC_PATH/$pkg_dirname > /dev/null
+  pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname" > /dev/null
     # Unpack all targets inside the main source directory
     for i in $(seq 0 $((${#_target_sources[@]} - 1))); do
-      tar xf $HAB_CACHE_SRC_PATH/$(basename ${_target_sources[$i]})
+      tar xf "$HAB_CACHE_SRC_PATH/$(basename "${_target_sources[$i]}")"
     done; unset i
   popd > /dev/null
 }
@@ -55,7 +55,7 @@ do_build() {
 }
 
 do_install() {
-  ./install.sh --prefix=$pkg_prefix --disable-ldconfig
+  ./install.sh --prefix="$pkg_prefix" --disable-ldconfig
 
   # Update the dynamic linker & set `RUNPATH` for all ELF binaries under `bin/`
   for b in rustc cargo rustdoc; do
@@ -69,17 +69,18 @@ do_install() {
   #    SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem \
 
     # Set `RUNPATH` for all shared libraries under `lib/`
-  find $pkg_prefix/lib -name *.so \
-    | xargs -I '%' patchelf \
+  find "$pkg_prefix/lib" -name "*.so" -print0 \
+    | xargs -0 -I '%' patchelf \
       --set-rpath "$LD_RUN_PATH" \
       %
 
   # Install all targets
+  local dir
   for i in $(seq 0 $((${#_target_sources[@]} - 1))); do
-    local dir="$(basename ${_target_sources[$i]/%.tar.gz/})"
-    pushd $HAB_CACHE_SRC_PATH/$pkg_dirname/$dir > /dev/null
+    dir="$(basename "${_target_sources[$i]/%.tar.gz/}")"
+    pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname/$dir" > /dev/null
       build_line "Installing $dir target for Rust"
-      ./install.sh --prefix=$($pkg_prefix/bin/rustc --print sysroot)
+      ./install.sh --prefix="$("$pkg_prefix/bin/rustc" --print sysroot)"
     popd > /dev/null
   done; unset i
 


### PR DESCRIPTION
This change adds a wrapper script for `cargo` in both the rust and
cargo-nightly plans to depend on and set a suitable set of SSL
root certificates.

Prior to this change, and plans that built Rust projects with cargo
would have to export OpenSSL's `CA_CERT_FILE` environment variable,
otherwise fetching dependencies or registry snapshots would fail. Rather
than pushing the reponsibility onto each downstream Plan, this change
"owns" that job as it is an implementation detail after all.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>