### PR TITLE
support generic cpu builds

### DIFF
--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -2,7 +2,7 @@ pkg_origin=core
 pkg_name=haproxy
 pkg_version=1.6.5
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
-pkg_license=('GPL-2.0', 'LGPL-2.1')
+pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source=http://www.haproxy.org/download/1.6/src/haproxy-1.6.5.tar.gz
 pkg_shasum=c4b3fb938874abbbbd52782087117cc2590263af78fdce86d64e4a11acfe85de
 pkg_svc_run='bin/haproxy -f config/haproxy.conf -db'
@@ -30,6 +30,6 @@ do_build() {
 }
 
 do_install() {
-  mkdir -p $pkg_prefix/bin
-  cp haproxy $pkg_prefix/bin
+  mkdir -p "$pkg_prefix"/bin
+  cp haproxy "$pkg_prefix"/bin
 }

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,9 +1,11 @@
 pkg_origin=core
 pkg_name=haproxy
+pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
 pkg_version=1.6.5
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source=http://www.haproxy.org/download/1.6/src/haproxy-1.6.5.tar.gz
+pkg_upstream_url="http://git.haproxy.org/git/haproxy-1.6.git/"
 pkg_shasum=c4b3fb938874abbbbd52782087117cc2590263af78fdce86d64e4a11acfe85de
 pkg_svc_run='bin/haproxy -f config/haproxy.conf -db'
 pkg_expose=(8080)

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -22,7 +22,7 @@ pkg_bin_dirs=(bin)
 do_build() {
   make USE_PCRE=1 \
        USE_PCRE_JIT=1 \
-       CPU=native \
+       CPU=generic \
        TARGET=linux2628 \
        USE_OPENSSL=1 \
        USE_ZLIB=1 \

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -22,7 +22,6 @@ pkg_bin_dirs=(bin)
 do_build() {
   make USE_PCRE=1 \
        USE_PCRE_JIT=1 \
-       CPU=generic \
        TARGET=linux2628 \
        USE_OPENSSL=1 \
        USE_ZLIB=1 \


### PR DESCRIPTION
CPU=native builds fail on processors that are too “different” than the original build machine (different instruction sets for the CPU model?).

Signed-off-by: Blake Irvin <blake.irvin@gmail.com>