### PR TITLE
support httpchk

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -12,6 +12,9 @@ frontend http-in
     default_backend default
 
 backend default
+{{#if cfg.httpchk}}
+    option httpchk {{cfg.httpchk}}
+{{~/if}}
 {{#if bind.has_backend }}
 {{~#each bind.backend.members}}
 {{~#if alive }}

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -1,6 +1,7 @@
 maxconn = 32
 mode = "http"
 bind = "*:80"
+httpchk = "GET /favicon.ico"
 
 [[server]]
 name = "first"

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -1,7 +1,7 @@
 maxconn = 32
 mode = "http"
 bind = "*:80"
-httpchk = "GET /favicon.ico"
+httpchk = "GET /"
 
 [[server]]
 name = "first"


### PR DESCRIPTION
This is useful if we want to HAProxy to quickly respond to slow or unresponsive backend servers.

Signed-off-by: Blake Irvin <blake.irvin@gmail.com>