### PR TITLE
enable basic web interface for haproxy statistics

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -23,3 +23,14 @@ backend default
     server {{name}} {{host_or_ip}}:{{port}}
 {{~/each}}
 {{~/if}}
+
+{{#if cfg.stats_enable}}
+backend stats
+    stats enable
+    server stats {{cfg.stats_bind}}
+    stats uri {{cfg.stats_uri}}
+    stats realm {{cfg.stats_realm}}
+{{#if cfg.stats_user}}
+    stats auth {{cfg.stats_user}}:{{cfg.stats_password}}
+{{/if}}
+{{/if}}

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -2,6 +2,13 @@ maxconn = 32
 mode = "http"
 bind = "*:80"
 
+stats_enable = false
+stats_bind = "*:8000"
+stats_realm = "haproxy_stats"
+stats_uri = "/haproxy_stats"
+stats_user = ""
+stats_password = ""
+
 [[server]]
 name = "first"
 host_or_ip = "172.17.0.3"


### PR DESCRIPTION
Note that if a user doesn’t explicitly configure credentials the route will be accessible to anyone. Alternatively we could force password choice?

Signed-off-by: Blake Irvin <blake.irvin@gmail.com>