### PR TITLE
Add plan for mysql

### DIFF
--- a/mysql/config/init.sql
+++ b/mysql/config/init.sql
@@ -1,0 +1,10 @@
+UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N' WHERE user = 'root';
+DELETE FROM mysql.user WHERE USER LIKE '';
+DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
+{{#if cfg.app_username}}
+CREATE USER '{{cfg.app_username}}'@'%' IDENTIFIED BY '{{cfg.app_password}}';
+GRANT ALL PRIVILEGES ON *.* TO '{{cfg.app_username}}'@'%';
+{{/if}}
+FLUSH PRIVILEGES;
+DELETE FROM mysql.db WHERE db LIKE 'test%';
+DROP DATABASE IF EXISTS test ;

--- a/mysql/config/my.cnf
+++ b/mysql/config/my.cnf
@@ -1,0 +1,50 @@
+
+# Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+#
+# The MySQL Community Server configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysqld_safe]
+pid-file = {{pkg.svc_var_path}}/mysqld.pid
+socket   = {{pkg.svc_var_path}}/mysqld.sock
+nice     = 0
+
+[mysqld]
+skip-host-cache
+skip-name-resolve
+user            = {{pkg.svc_user}}
+pid-file        = {{pkg.svc_var_path}}/mysqld.pid
+socket          = {{pkg.svc_var_path}}/mysqld.sock
+port            = {{cfg.port}}
+basedir         = {{pkg.path}}
+datadir         = {{pkg.svc_data_path}}
+tmpdir          = /tmp
+lc-messages-dir = {{pkg.path}}/share/mysql
+explicit_defaults_for_timestamp
+
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+{{#if cfg.bind}}
+bind-address = {{cfg.bind}}
+{{/if}}
+
+log-error    = {{pkg.svc_var_path}}/error.log
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0

--- a/mysql/default.toml
+++ b/mysql/default.toml
@@ -1,0 +1,6 @@
+port = 3306
+bind = "127.0.0.1"
+root_password = ""
+app_username = false
+app_password = false
+password_column_name = "authentication_string"

--- a/mysql/hooks/init
+++ b/mysql/hooks/init
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+exec 2>&1
+
+set -eo pipefail
+
+if [ ! -d {{pkg.svc_data_path}}/mysql ]; then
+  mysqld --defaults-file={{pkg.svc_path}}/config/my.cnf \
+         --explicit-defaults-for-timestamp \
+         --datadir={{pkg.svc_data_path}} \
+         --init-file={{pkg.svc_config_path}}/init.sql \
+         --initialize \
+         --user=hab
+fi

--- a/mysql/hooks/run
+++ b/mysql/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+
+mysqld_safe --defaults-file={{pkg.svc_config_path}}/my.cnf \
+            --datadir={{pkg.svc_data_path}} \
+            --user=hab

--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -1,0 +1,63 @@
+pkg_name=mysql
+pkg_origin=core
+pkg_version=5.7.14
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('GPL-2.0')
+pkg_source=http://dev.mysql.com/get/Downloads/MySQL-5.7/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=f7415bdac2ca8bbccd77d4f22d8a0bdd7280b065bd646a71a506b77c7a8bd169
+
+pkg_upstream_url=https://www.mysql.com/
+pkg_description=$(cat << EOF
+Starts MySQL with a basic configuration. Configurable at run time:
+
+* root_password: the password for the mysql root user, empty by default
+* app_username: the username for an application that will connect to the database server, false by default
+* app_password: the password for the app user
+* bind: the bind address to listen for connections, default 127.0.0.1
+
+Set the app_username and app_password at runtime to have that user created, it won't be otherwise.
+EOF
+)
+
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/coreutils
+  core/sed
+  core/gawk
+  core/grep
+  core/pcre
+  core/procps-ng
+  core/inetutils
+  core/ncurses
+  core/openssl
+)
+
+pkg_build_deps=(
+  core/cmake
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  # -- MySQL currently requires boost_1_59_0
+  core/boost159
+)
+
+pkg_svc_user="hab"
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  cmake . -DLOCAL_BOOST_DIR="$(pkg_path_for core/boost159)" \
+          -DBOOST_INCLUDE_DIR="$(pkg_path_for core/boost159)"/include \
+          -DWITH_BOOST="$(pkg_path_for core/boost159)" \
+          -DWITH_SSL=yes \
+          -DCMAKE_INSTALL_PREFIX="$pkg_prefix"
+  make
+}
+
+do_check() {
+  ctest
+}


### PR DESCRIPTION
Create `mysql.toml`:

```toml
root_password = "zanzibar"
app_username  = "soup"
app_password  = "bananas"
bind          = "0.0.0.0"
```

Start it up:

```
HAB_MYSQL="$(cat mysql.toml)" hab start core/mysql
```

Connect from another system:

```
mysql -u soup -h 172.17.0.3 -p
Enter password: bananas
```

And victory is yours!

The default `root_password` is empty - so it should be set at runtime. The default bind address is localhost, so that's probably not usable for most people with application connectivity needs. The app username and password are false, so they won't get rendered if they're not set at run time.