### PR TITLE
Add `PLAN_CONTEXT` variable to build order ruby scripts.

### DIFF
--- a/bin/build-dependent-order.rb
+++ b/bin/build-dependent-order.rb
@@ -71,6 +71,7 @@ bash_prog.write(<<'EOF')
 set -e
 STUDIO_TYPE=stage1
 FIRST_PASS=true
+PLAN_CONTEXT=$(pwd)/$(dirname $1)
 
 cd $(dirname $1)
 source $(basename $1)

--- a/bin/build-order.rb
+++ b/bin/build-order.rb
@@ -53,6 +53,7 @@ bash_prog.write(<<'EOF')
 set -e
 STUDIO_TYPE=stage1
 FIRST_PASS=true
+PLAN_CONTEXT=$(pwd)/$(dirname $1)
 
 cd $(dirname $1)
 source $(basename $1)


### PR DESCRIPTION
This change is to support a refactoring in the Habitat core repo to
source and share one version file across multiple components. As the
paths vary it was necessary to use the `$PLAN_CONTEXT` variable to
compute the correct directory to the `VERSION` file. This change adds
the `PLAN_CONTEXT` variable in the Plan-sourcing inlined Bash program
and will make all Plans sourcable once again.

/cc @reset