### PR TITLE
[tomcat8] fix function syntax for busybox shell

### DIFF
--- a/tomcat8/hooks/init
+++ b/tomcat8/hooks/init
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function debug { if [ ! -z "$DEBUG" ]; then echo "$*"; fi }
+debug() { if [ ! -z "$DEBUG" ]; then echo "$*"; fi }
 
 echo "Preparing TOMCAT_HOME..."
 


### PR DESCRIPTION
Ran into an issue where package would not pass the init phase (process `Aborted`).

See also
http://bash.cumulonim.biz/BashPitfalls.html#function_foo.28.29