### PR TITLE
Allow Redis protected-mode to be a tunable.

### DIFF
--- a/redis/config/redis.config
+++ b/redis/config/redis.config
@@ -66,6 +66,27 @@ tcp-backlog {{cfg.tcp-backlog}}
 bind {{cfg.bind}}
 {{~/if}}
 
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+{{~#if cfg.protected-mode}}
+protected-mode {{cfg.protected-mode}}
+{{~/if}}
+
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.

--- a/redis/default.toml
+++ b/redis/default.toml
@@ -24,8 +24,7 @@ tcp-backlog = 511
 bind = []
 
 # By default, run Redis in protected mode.
-# Uncomment to disable.
-# protected-mode = "no"
+protected-mode = "yes"
 
 # Listen on a unix socket
 # unixsocket = "/tmp/redis.sock"

--- a/redis/default.toml
+++ b/redis/default.toml
@@ -23,6 +23,10 @@ tcp-backlog = 511
 # bind = [] - listen on all interfaces
 bind = []
 
+# By default, run Redis in protected mode.
+# Uncomment to disable.
+# protected-mode = "no"
+
 # Listen on a unix socket
 # unixsocket = "/tmp/redis.sock"
 # unixsocketperm = 700


### PR DESCRIPTION
We use Redis to show off leader election in Habitat. Redis 3.2.3 added protected mode by default, which means that out-of-the-box, leader election won't work because this can't be disabled using the current config template that dates from pre-Redis 3.2.x.

In a _production_ environment you would set `masterauth` and `requirepass` appropriately rather than turning this off, but for the purposes of field demos it's easier to turn off one setting because you can do it with a single environment variable rather than having to `cat` two settings into the Habitat supervisor using a TOML file.