### PR TITLE
Fix startup of tomcat8

### DIFF
--- a/tomcat8/hooks/init
+++ b/tomcat8/hooks/init
@@ -1,6 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-debug() { if [ ! -z "$DEBUG" ]; then echo "$*"; fi }
+debug() {
+  if [ ! -z "$DEBUG" ]; then
+    echo "$*"
+  fi
+}
 
 echo "Preparing TOMCAT_HOME..."
 
@@ -21,8 +25,7 @@ debug "pkg.svc_static_path   = {{pkg.svc_static_path}}"
 debug "pkg.svc_var_path      = {{pkg.svc_var_path}}"
 
 # Move directories that ship in the package into place
-
-cp -R {{pkg.path}}/tc {{pkg.svc_var_path}}/
+cp -a {{pkg.path}}/tc {{pkg.svc_var_path}}/
 
 # Symlink config files into $TOMCAT_HOME/conf
 for file in $(cd {{pkg.svc_config_path}}; ls -1)

--- a/tomcat8/hooks/run
+++ b/tomcat8/hooks/run
@@ -9,4 +9,4 @@ export TOMCAT_HOME="{{pkg.svc_var_path}}/tc"
 export CATALINA_OPTS="{{cfg.server.catalina-opts}}"
 
 echo "Executing Tomcat here: ${TOMCAT_HOME}/bin/catalina.sh"
-exec ${TOMCAT_HOME}/bin/catalina.sh run
+exec chpst -u hab:hab ${TOMCAT_HOME}/bin/catalina.sh run

--- a/tomcat8/plan.sh
+++ b/tomcat8/plan.sh
@@ -4,13 +4,19 @@ pkg_origin=core
 pkg_version=8.5.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
+pkg_description="The Apache Tomcat software is an open source implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies."
 pkg_upstream_url="http://tomcat.apache.org/"
 pkg_source=http://apache.mirrors.pair.com/tomcat/tomcat-8/v${pkg_version}/bin/apache-tomcat-${pkg_version}.tar.gz
 pkg_shasum=155cf7f09e13c63b8301ddc8c37d90be64bc3d5e9ddf163c4f10a6406a49a191
-pkg_deps=(core/jdk8)
+
+pkg_deps=(
+  core/jdk8
+  core/coreutils
+)
 pkg_expose=(8080 8443)
 
 pkg_svc_user="root"
+pkg_svc_group="root"
 
 # The default implementation extracts your tarball source file into HAB_CACHE_SRC_PATH. The
 # supported archives are: .tar, .tar.bz2, .tar.gz, .tar.xz, .rar, .zip, .Z, .7z. If the file


### PR DESCRIPTION
This commit fixes the startup of core/tomcat8:

* Ensure that we're using bash
* Correct the function definition for the debug function in the init
  hook
* Use -a instead of -R for the cp command
* Set both the user and group to root so the init script works
* Use chpst (from busybox-static) to set the privileges of tomcat to run
  as hab:hab

Signed-off-by: jtimberman <joshua@chef.io>