### PR TITLE
sudo 1.8.17p1 (new plan)

### DIFF
--- a/sudo/plan.sh
+++ b/sudo/plan.sh
@@ -1,0 +1,56 @@
+pkg_name=sudo
+pkg_origin=core
+pkg_version=1.8.17p1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Execute a command as another user"
+pkg_upstream_url="https://www.sudo.ws/"
+pkg_license=('ISC')
+pkg_source=ftp://ftp.sudo.ws/pub/sudo/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=c690d707fb561b3ecdf6a6de5563bc0b769388eff201c851edbace408bb155cc
+pkg_build_deps=(
+  core/diffutils
+  core/file
+  core/gcc
+  core/make
+)
+pkg_deps=(
+  core/coreutils
+  core/glibc
+  core/vim
+)
+pkg_bin_dirs=(bin sbin)
+pkg_include_dirs=(include)
+
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+
+  # Export variables to the direct path of executables
+  MVPROG="$(pkg_path_for coreutils)/bin/mv"
+  export MVPROG
+  VIPROG="$(pkg_path_for vim)/bin/vi"
+  export VIPROG
+}
+
+do_build() {
+  ./configure --prefix="$pkg_prefix" --with-editor="$VIPROG" --with-env-editor
+  make
+}
+
+do_check() {
+  # Due to how file permissions are preserved during packaging, we must
+  # set a particular file to be owned by root for the `testsudoers/test3`
+  # regression test, which compares sudo permissions against a file with
+  # root ownership.
+  chown root:root plugins/sudoers/regress/testsudoers/test3.d/root
+
+  make check
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}


### PR DESCRIPTION
A plan for the most awesome tool to run commands as another user.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

This plan works, but may contain a controversial concept around `visudo`, so I'd appreciate some thoughts on this.

The visudo command is an admin-helper that performs manipulation of an /etc/sudoers file, typically in `vi`, which is included in the runtime deps of this plan.
This is overridable via setting the `EDITOR` environment variable to the desired editor (nano, pico, etc)

The `visudo` command also prodives a utility function to test a sudoers file syntax for accuracy via `visudo -c`.

Is there a problem with declaring a runtime dependency on an editor for a security package?

cc @habitat-sh/habitat-core-plans-maintainers