### PR TITLE
Update pre-commit configuration for exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,15 +5,15 @@
     -   id: check-merge-conflict
     -   id: check-symlinks
     -   id: check-yaml
+        exclude: config/.*$
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-    exclude: config/.*$
 -   repo: git://github.com/detailyang/pre-commit-shell
     sha: 28f9ecf7857d17ebd9d1715cb5bf208c9e8e2bdd
     hooks:
     -   id: shell-lint
         args: ["--exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154"]
-    exclude: config/.*$
+        exclude: config/.*$
 -   repo: local
     hooks:
     -   id: check-default-variables


### PR DESCRIPTION
In #131 we added some exclusion filters for files that are templated and
are not expected to pass a real linting.
The placement of said configuration was not accurate - the directives
must follow the check they are modifying.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>