### PR TITLE
Updating else syntax for Handlebars on haproxy config.

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -21,7 +21,7 @@ backend default
     server {{ip}} {{ip}}:{{port}}
 {{~/if}}
 {{~/each}}
-{{~else}}
+{{else}}
 {{~#each cfg.server}}
     server {{name}} {{host_or_ip}}:{{port}}
 {{~/each}}


### PR DESCRIPTION
Having the `~` in front of `else` worked on older version of hab, but the version of the handlebars crate has been bumped a couple of times since then.  Likely something changed in the handlebars crate since I added this logic originally.

Verified that this syntax uses config values if no backend binding is specified.

Fixes #166

Signed-off-by: Nolan Davidson <ndavidson@chef.io>