### PR TITLE
Update Git to version 2.10.0

### DIFF
--- a/git/plan.sh
+++ b/git/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=git
-pkg_version=2.7.4
+pkg_version=2.10.0
 pkg_origin=core
 pkg_description="Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
@@ -9,7 +9,7 @@ pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.kernel.org/pub/software/scm/git/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=7104c4f5d948a75b499a954524cb281fe30c6649d8abe20982936f75ec1f275b
+pkg_shasum=207cfce8cc0a36497abb66236817ef449a45f6ff9141f586bbe2aafd7bc3d90b
 pkg_deps=(
   core/cacerts
   core/curl


### PR DESCRIPTION
Git 2.8: https://github.com/blog/2131-git-2-8-has-been-released
Git 2.9: https://github.com/blog/2188-git-2-9-has-been-released
Git 2.10: https://github.com/blog/2242-git-2-10-has-been-released