### PR TITLE
Revert "Use core/bash over /bin/bash in binutils & gcc plans"

### DIFF
--- a/binutils/plan.sh
+++ b/binutils/plan.sh
@@ -5,9 +5,8 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('gpl')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.bz2
 pkg_shasum=b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22
-pkg_deps=(core/bash core/glibc core/zlib)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/texinfo
-                core/expect core/dejagnu)
+pkg_deps=(core/glibc core/zlib)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/texinfo core/expect core/dejagnu)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -17,7 +16,7 @@ do_prepare() {
 
   # Add explicit linker instructions as the binutils we are using may have its
   # own dynamic linker defaults.
-  dynamic_linker="$(pkg_path_for core/glibc)/lib/ld-linux-x86-64.so.2"
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   export LDFLAGS
@@ -28,7 +27,9 @@ do_prepare() {
   export CFLAGS="$CFLAGS -static-libgcc"
   build_line "Updating CFLAGS=$CFLAGS"
 
-  bash="$(pkg_path_for core/bash)/bin/bash"
+  # TODO: For the wrapper scripts to function correctly, we need the full
+  # path to bash. Until a bash plan is created, we're going to wing this...
+  bash=/bin/bash
 
   # Make `--enable-new-dtags` the default so that the linker sets `RUNPATH`
   # instead of `RPATH` in ELF binaries. This is important as `RPATH` is
@@ -52,8 +53,8 @@ do_prepare() {
 
   cat $PLAN_CONTEXT/custom-libs.patch \
     | sed -e "s,@dynamic_linker@,$dynamic_linker,g" \
-      -e "s,@glibc_lib@,$(pkg_path_for core/glibc)/lib,g" \
-      -e "s,@zlib_lib@,$(pkg_path_for core/zlib)/lib,g" \
+      -e "s,@glibc_lib@,$(pkg_path_for glibc)/lib,g" \
+      -e "s,@zlib_lib@,$(pkg_path_for zlib)/lib,g" \
     | patch -p1
 
   # We don't want to search for libraries in system directories such as `/lib`,
@@ -90,7 +91,7 @@ do_check() {
     # This testsuite is pretty sensitive to its environment, especially when
     # libraries and headers are being flown in from non-standard locations.
     original_LD_RUN_PATH="$LD_RUN_PATH"
-    export LD_LIBRARY_PATH="$LD_RUN_PATH:$(pkg_path_for core/gcc)/lib"
+    export LD_LIBRARY_PATH="$LD_RUN_PATH:$(pkg_path_for gcc)/lib"
     unset LD_RUN_PATH
 
     make check LDFLAGS=""
@@ -144,6 +145,7 @@ _wrap_binary() {
     > "$bin"
   chmod 755 "$bin"
 }
+
 
 # ----------------------------------------------------------------------------
 # **NOTICE:** What follows are implementation details required for building a

--- a/gcc/plan.sh
+++ b/gcc/plan.sh
@@ -8,20 +8,20 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_distname/${pkg_distname}-${pkg_version}/${pkg_distname}-${pkg_version}.tar.bz2
 pkg_shasum=5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad
-pkg_deps=(core/bash core/glibc core/zlib core/gmp core/mpfr core/libmpc core/binutils)
+pkg_deps=(core/glibc core/zlib core/gmp core/mpfr core/libmpc core/binutils)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/gawk core/m4 core/texinfo core/perl core/inetutils core/expect core/dejagnu)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
 do_prepare() {
-  glibc="$(pkg_path_for core/glibc)"
-  binutils="$(pkg_path_for core/binutils)"
+  glibc="$(pkg_path_for glibc)"
+  binutils="$(pkg_path_for binutils)"
   headers="$glibc/include"
 
   # Add explicit linker instructions as the binutils we are using may have its
   # own dynamic linker defaults.
-  dynamic_linker="$(pkg_path_for core/glibc)/lib/ld-linux-x86-64.so.2"
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   build_line "Updating LDFLAGS=$LDFLAGS"
@@ -43,16 +43,18 @@ do_prepare() {
   build_line "Setting CXXFLAGS=$CXXFLAGS"
 
   # Ensure gcc can find the headers for zlib
-  CPATH="$(pkg_path_for core/zlib)/include"
+  CPATH="$(pkg_path_for zlib)/include"
   export CPATH
   build_line "Setting CPATH=$CPATH"
 
   # Ensure gcc can find the shared libs for zlib
-  LIBRARY_PATH="$(pkg_path_for core/zlib)/lib"
+  LIBRARY_PATH="$(pkg_path_for zlib)/lib"
   export LIBRARY_PATH
   build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
 
-  bash="$(pkg_path_for core/bash)/bin/bash"
+  # TODO: For the wrapper scripts to function correctly, we need the full
+  # path to bash. Until a bash plan is created, we're going to wing this...
+  bash=/bin/bash
 
   # Tell gcc not to look under the default `/lib/` and `/usr/lib/` directories
   # for libraries
@@ -121,13 +123,13 @@ do_build() {
   mkdir "../${pkg_name}-build"
   pushd "../${pkg_name}-build" > /dev/null
     SED=sed \
-    LD="$(pkg_path_for core/binutils)/bin/ld" \
-    AS="$(pkg_path_for core/binutils)/bin/as" \
+    LD="$(pkg_path_for binutils)/bin/ld" \
+    AS="$(pkg_path_for binutils)/bin/as" \
     "../$pkg_dirname/configure" \
       --prefix="$pkg_prefix" \
-      --with-gmp="$(pkg_path_for core/gmp)" \
-      --with-mpfr="$(pkg_path_for core/mpfr)" \
-      --with-mpc="$(pkg_path_for core/libmpc)" \
+      --with-gmp="$(pkg_path_for gmp)" \
+      --with-mpfr="$(pkg_path_for mpfr)" \
+      --with-mpc="$(pkg_path_for libmpc)" \
       --with-native-system-header-dir="$headers" \
       --enable-languages=c,c++,fortran \
       --enable-lto \
@@ -276,6 +278,7 @@ wrap_binary() {
     > "$bin"
   chmod 755 "$bin"
 }
+
 
 # ----------------------------------------------------------------------------
 # **NOTICE:** What follows are implementation details required for building a


### PR DESCRIPTION
This reverts commit 22c8f2fb1bfba3d732def3a9e115b1aca9ba879b.

The revert is due to the introduction of a cyclic dependency which
prevents us from running the build-dependent-order.rb script for release
activities.

@reset We can circle back on this post-release to determine what is the
correct solution here.