### PR TITLE
Fix all PKG_CONFIG_PATH workarounds

### DIFF
--- a/autogen/plan.sh
+++ b/autogen/plan.sh
@@ -9,14 +9,9 @@ pkg_source="http://ftp.gnu.org/gnu/autogen/rel${pkg_version}/autogen-${pkg_versi
 pkg_shasum=0b8681d9724c481d3b726b5a9e81d3d09dc7f307d1a801c76d0a30d8f843d20a
 pkg_deps=(core/glibc core/gcc-libs core/guile core/libxml2 core/zlib)
 pkg_build_deps=(core/gcc core/make core/pkg-config core/diffutils core/which core/perl)
-pkg_lib_dirs=(lib)
-pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
-
-do_prepare() {
-  PKG_CONFIG_PATH="$(pkg_path_for guile)/lib/pkgconfig"
-  export PKG_CONFIG_PATH
-}
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
 
 do_check() {
   make check

--- a/bdwgc/plan.sh
+++ b/bdwgc/plan.sh
@@ -9,15 +9,10 @@ pkg_source="http://www.hboehm.info/gc/gc_source/gc-${pkg_version}.tar.gz"
 pkg_shasum=e5ca9b628b765076b6ab26f882af3a1a29cde786341e08b9f366604f74e4db84
 pkg_deps=(core/glibc core/libatomic_ops)
 pkg_build_deps=(core/gcc core/make core/diffutils core/pkg-config)
+pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
 pkg_dirname="gc-${pkg_version}"
-
-do_prepare() {
-  PKG_CONFIG_PATH="$(pkg_path_for libatomic_ops)/lib/pkgconfig"
-  export PKG_CONFIG_PATH
-}
 
 do_check() {
   make check

--- a/fontconfig/plan.sh
+++ b/fontconfig/plan.sh
@@ -18,14 +18,10 @@ pkg_build_deps=(core/gcc core/make core/coreutils core/python
                 core/pkg-config core/freetype core/expat
                 core/diffutils core/libtool core/m4 core/automake
                 core/autoconf core/file)
-pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
 
 do_prepare() {
-  export PKG_CONFIG_PATH
-  PKG_CONFIG_PATH="$(pkg_path_for freetype)/lib/pkgconfig:$(pkg_path_for expat)/lib/pkgconfig"
-  build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-
   # Set freetype paths
   export FREETYPE_CFLAGS="$CFLAGS"
   build_line "Setting FREETYPE_CFLAGS=$FREETYPE_CFLAGS"

--- a/freetype/plan.sh
+++ b/freetype/plan.sh
@@ -10,14 +10,6 @@ pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=371e707aa522acf5b15ce93f11183c725b8ed1ee8546d7b3af549863045863a2
 pkg_deps=(core/glibc core/libpng core/zlib core/bzip2)
 pkg_build_deps=(core/gcc core/make core/coreutils core/pkg-config core/diffutils)
-pkg_lib_dirs=(lib)
-pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
-
-do_build() {
-    PKG_CONFIG_PATH="$(pkg_path_for zlib)/lib/pkgconfig"
-    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for libpng)/lib/pkgconfig"
-    export PKG_CONFIG_PATH
-    ./configure --prefix="$pkg_prefix"
-    make
-}
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -37,9 +37,6 @@ do_prepare() {
   export CXXFLAGS="${CXXFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
   export CPPFLAGS="${CPPFLAGS} -Wdate-time"
   export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic-functions -Wl,-z,relro"
-
-  export PKG_CONFIG_PATH
-  PKG_CONFIG_PATH="$(pkg_path_for guile)/lib/pkgconfig"
 }
 
 do_build() {

--- a/guile/plan.sh
+++ b/guile/plan.sh
@@ -17,15 +17,12 @@ pkg_deps=(core/bdwgc
   core/libunistring
   core/readline)
 pkg_build_deps=(core/diffutils core/gcc core/make core/pkg-config)
+pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
 
 do_prepare() {
-  PKG_CONFIG_PATH="$(pkg_path_for libffi)/lib/pkgconfig"
-  PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for bdwgc)/lib/pkgconfig"
   LDFLAGS="-lgcc_s ${LDFLAGS}"
-  export PKG_CONFIG_PATH
   export LDFLAGS
 }
 

--- a/imagemagick/plan.sh
+++ b/imagemagick/plan.sh
@@ -15,11 +15,6 @@ pkg_lib_dirs=(lib)
 pkg_dirname=ImageMagick-${pkg_version}
 
 do_build() {
-    PKG_CONFIG_PATH="$(pkg_path_for zlib)/lib/pkgconfig"
-    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for libpng)/lib/pkgconfig"
-    PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for xz)/lib/pkgconfig"
-    export PKG_CONFIG_PATH
-    build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
     CC="gcc -std=gnu99" ./configure --prefix=$pkg_prefix
     make
 }

--- a/libatomic_ops/plan.sh
+++ b/libatomic_ops/plan.sh
@@ -9,9 +9,9 @@ pkg_source="http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${pkg_version
 pkg_shasum=bf210a600dd1becbf7936dd2914cf5f5d3356046904848dcfd27d0c8b12b6f8f
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
+pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
 
 do_check() {
   make check

--- a/libffi/plan.sh
+++ b/libffi/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=libffi
 pkg_version=3.2.1
 pkg_origin=core
-pkg_license=('mit')
+pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=ftp://sourceware.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
@@ -12,6 +12,6 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(lib/${pkg_name}-${pkg_version}/include)
 
 do_build() {
-    ./configure --prefix=${pkg_prefix} --disable-multi-os-directory
+    ./configure --prefix="${pkg_prefix}" --disable-multi-os-directory
     make
 }

--- a/libpng/plan.sh
+++ b/libpng/plan.sh
@@ -10,9 +10,9 @@ pkg_shasum=b36a3c124622c8e1647f360424371394284f4c6c4b384593e478666c59ff42d3
 pkg_deps=(core/glibc core/zlib)
 pkg_build_deps=(core/gcc core/make core/coreutils core/diffutils
                 core/autoconf core/automake)
-pkg_lib_dirs=(lib)
-pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
 
 do_build() {
   _zlib_dir=$(pkg_path_for zlib)

--- a/libsodium/plan.sh
+++ b/libsodium/plan.sh
@@ -9,5 +9,5 @@ pkg_shasum=c0f191d2527852641e0a996b7b106d2e04cbc76ea50731b2d0babd3409301926
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/autoconf core/automake core/diffutils core/patch core/make core/gcc core/sed)
-pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/mg/plan.sh
+++ b/mg/plan.sh
@@ -16,8 +16,6 @@ do_prepare() {
       -e "s,@clens_prefix@,$(pkg_path_for clens),g" \
       -e "s,@libbsd_prefix@,$(pkg_path_for libbsd),g" \
     | patch -p1
-
-  export PKG_CONFIG_PATH=$(pkg_path_for libbsd)/lib/pkgconfig
 }
 do_build() {
   make \

--- a/netcat-openbsd/plan.sh
+++ b/netcat-openbsd/plan.sh
@@ -38,9 +38,6 @@ do_prepare() {
     build_line "Applying patch: $patchfile"
     patch -i "$HAB_CACHE_SRC_PATH/$patchfile"
   done <"$HAB_CACHE_SRC_PATH/series"
-
-  PKG_CONFIG_PATH="$(pkg_path_for libbsd)/lib/pkgconfig"
-  export PKG_CONFIG_PATH
 }
 
 do_build() {

--- a/pixman/plan.sh
+++ b/pixman/plan.sh
@@ -8,20 +8,14 @@ pkg_source="https://www.cairographics.org/releases/pixman-${pkg_version}.tar.gz"
 pkg_shasum=21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e
 pkg_deps=(core/glibc core/gcc-libs core/libpng core/zlib)
 pkg_build_deps=(core/gcc core/make core/pkg-config core/diffutils core/file)
-pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
 
 do_prepare() {
     if [[ ! -r /usr/bin/file ]]; then
         ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
         _clean_file=true
     fi
-}
-
-do_build() {
-    export PKG_CONFIG_PATH="$(pkg_path_for libpng)/lib/pkgconfig"
-    ./configure --prefix=$pkg_prefix
-    make
 }
 
 do_check() {

--- a/wget/plan.sh
+++ b/wget/plan.sh
@@ -33,11 +33,6 @@ EOF
 }
 
 _wget_common_prepare() {
-  PKG_CONFIG_PATH="$(pkg_path_for openssl)/lib/pkgconfig"
-  PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(pkg_path_for zlib)/lib/pkgconfig"
-  export PKG_CONFIG_PATH
-  build_line "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-
   # Purge the codebase (mostly tests & build Perl scripts) of the hardcoded
   # reliance on `/usr/bin/env`.
   grep -lr '/usr/bin/env' . | while read f; do

--- a/zeromq/plan.sh
+++ b/zeromq/plan.sh
@@ -6,12 +6,8 @@ pkg_source=http://download.zeromq.org/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378
 pkg_deps=(core/glibc core/gcc-libs core/libsodium)
 pkg_build_deps=(core/gcc core/coreutils core/make core/pkg-config core/patchelf)
-pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-
-do_prepare() {
-  export PKG_CONFIG_PATH=$(pkg_path_for libsodium)/lib/pkgconfig
-}
+pkg_lib_dirs=(lib)
 
 do_install() {
   do_default_install


### PR DESCRIPTION
There might be issues with CI because I did not fix "non-valid" licenses and paths without inverted commas.

Build order:
1. libatomic_ops
2. bdwgc (depends on `libatomic_ops`)
3. libffi (`guile` depends on it)
4. expat
5. guile
6. zlib
7. xz
8. libpng
9. freetype
10. libsodium
11. libbsd
12. openssl
13. zeromq
14. pixman
15. fontconfig
16. gdb
17. imagemagick
18. netcat-openbsd
19. autogen
20. mg
21. wget

Not all but most of the packages do require this exact order(from zeromq and further, the order does not matter).
Every package was built in this order(without `DO_CHECK=true`).