### PR TITLE
Fix path for httpd binary

### DIFF
--- a/httpd/plan.sh
+++ b/httpd/plan.sh
@@ -13,7 +13,7 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_expose=(80 443)
-pkg_svc_run="$pkg_prefix/bin/httpd -DFOREGROUND -f $pkg_svc_config_path/httpd.conf"
+pkg_svc_run="httpd -DFOREGROUND -f $pkg_svc_config_path/httpd.conf"
 pkg_svc_user="root"
 pkg_svc_group="root"
 


### PR DESCRIPTION
In habitat 0.9.3, the plan build script no longer uses `$pkg_prefix`
in front of the command specified by the `pkg_svc_run` because as long
as the "bin" directory is specified in `pkg_bin_dirs`, the program for
the service will be in the `$PATH` environment variable.

This means we also do not need to specify it in the `$pkg_svc_run`
variable in our plans. And in fact, the `$pkg_prefix` variable itself
isn't populated at the time that a plan is sourced by the build
script, so this will be an empty value, and result in the `run` script
getting rendered as, e.g., `/bin/httpd`.

Signed-off-by: jtimberman <joshua@chef.io>