### PR TITLE
Marklap python interpreter

### DIFF
--- a/python/plan.sh
+++ b/python/plan.sh
@@ -47,7 +47,7 @@ do_build() {
 
 do_install() {
   # link python3.5 to python for pkg_interpreters
-  ln -rs ${pkg_prefix}/bin/python3.5 ${pkg_prefix}/python
+  ln -rs ${pkg_prefix}/bin/python3.5 ${pkg_prefix}/bin/python
   do_default_install
   # Upgrade to the latest pip
   "$pkg_prefix/bin/pip3" install --upgrade pip

--- a/python/plan.sh
+++ b/python/plan.sh
@@ -46,6 +46,8 @@ do_build() {
 }
 
 do_install() {
+  # link python3.5 to python for pkg_interpreters
+  ln -rs ${pkg_prefix}/bin/python3.5 ${pkg_prefix}/python
   do_default_install
   # Upgrade to the latest pip
   "$pkg_prefix/bin/pip3" install --upgrade pip


### PR DESCRIPTION
Discovered that one of the `pkg_interpreters` that was defined isn't created with the standard build of Python 3.5. Added a symlink to resolve it and support the expectation that a bin/python interpreter would exist.