### PR TITLE
Add symlink to missing `python` interpreter.

### DIFF
--- a/python/plan.sh
+++ b/python/plan.sh
@@ -47,6 +47,10 @@ do_build() {
 
 do_install() {
   do_default_install
+
+  # link python3.5 to python for pkg_interpreters
+  ln -rs ${pkg_prefix}/bin/python3.5 ${pkg_prefix}/bin/python
+
   # Upgrade to the latest pip
   "$pkg_prefix/bin/pip3" install --upgrade pip
 }


### PR DESCRIPTION
Discovered that one of the pkg_interpreters that was defined isn't created with the standard build of Python 3.5. Added a symlink to resolve it and support the expectation that a bin/python interpreter would exist.