### PR TITLE
Added SC2140 to list of shellcheck excludes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Some default checks of ShellCheck can be turned off, since they aren't
 necessarily applicable in plans. The following options work well:
 
 ```
-shellcheck --shell=bash --exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154
+shellcheck --shell=bash --exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154,SC2140
 ```
 
 If ShellCheck is installed, you can run this (and other checks) locally with:


### PR DESCRIPTION
SC2140 is a style focused shellcheck rule that looks for ineffectual quotations and suggests their removal.
https://github.com/koalaman/shellcheck/wiki/SC2140

Because many of our `core-plans` include a block like so:
```
pkg_description="Here is a super awesome package description for my thing :tm:"
```
We end up with SC errors when running it against many of our packages. This brings the contribution docs in line with the style many of our packages are already using.

