### PR TITLE
Remove prefix from mongodb's pkg_svc_run

### DIFF
--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -6,6 +6,7 @@ pkg_description="High-performance, schema-free, document-oriented database"
 pkg_license=('AGPL-3.0')
 pkg_source=http://downloads.mongodb.org/src/${pkg_name}-src-r${pkg_version}.tar.gz
 pkg_shasum=25f8817762b784ce870edbeaef14141c7561eb6d7c14cd3197370c2f9790061b
+pkg_upstream_url=https://www.mongodb.com/
 pkg_filename=${pkg_name}-src-r${pkg_version}.tar.gz
 pkg_dirname=${pkg_name}-src-r${pkg_version}
 pkg_deps=(core/gcc-libs core/glibc core/openssl)
@@ -20,31 +21,29 @@ pkg_build_deps=(
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-pkg_svc_run="$pkg_prefix/bin/mongod --config $pkg_svc_config_path/mongod.conf"
+pkg_svc_run="mongod --config $pkg_svc_config_path/mongod.conf"
 pkg_svc_user=root
 pkg_svc_group=root
+pkg_expose=(27017)
 
 do_prepare() {
-    #WARNING:this build takes around 1 hour and 30 minutes to complete on
-    #        a macbook pro with an i5 and 8 GB RAM
-
-    #created a variable for our compilers
+    # created a variable for our compilers
     export CC="$(pkg_path_for core/gcc)/bin/gcc"
     export CXX="$(pkg_path_for core/gcc)/bin/g++"
 
-    #create variables for our include and library pathes in a scons friendly format
+    # create variables for our include and library pathes in a scons friendly format
     INCPATH=$(echo "$CFLAGS" | sed -e "s@-I@@g")
     export INCPATH=$(echo "$INCPATH" | sed -e "s@ @', '@g")
     LIBPATH=$(echo "$LDFLAGS" | sed -e "s@-L@@g")
     export LIBPATH=$(echo "$LIBPATH" | sed -e "s@ @', '@g")
 
-    #because scons dislikes saving our variables
-    #we will save our variables within the construct ourselves
+    # because scons dislikes saving our variables, we will save our
+    # variables within the construct ourselves
     sed -i "836s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
 }
 
 do_build() {
-    scons core --prefix="$pkg_prefix" --ssl
+    scons core --prefix="$pkg_prefix" --ssl -j$(nproc)
 }
 
 do_install() {


### PR DESCRIPTION
This commit removes the pkg_prefix from the pkg_svc_run in the mongodb
plan. It also adds the default port to pkg_expose. Finally, we run a
number of jobs in scons equal to the number of CPUs, which can cut the
build time in half.

Signed-off-by: Joshua Timberman <joshua@chef.io>