### PR TITLE
elasticsearch updates for latest habitat

### DIFF
--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -79,11 +79,11 @@
   #
   # Path to log files:
   #
-  logs =    "/hab/svc/elasticsearch/logs"
+  logs =    "/hab/svc/elasticsearch/var/logs"
   #
   # Path to plugins:
   #
-  plugins = "/hab/svc/elasticsearch/var"
+  plugins = "/hab/svc/elasticsearch/var/plugins"
   #
   # Path to scripts directory
   #

--- a/elasticsearch/hooks/init
+++ b/elasticsearch/hooks/init
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-mkdir -p {{pkg.svc_path}}/logs
-mkdir -p {{pkg.svc_data_path}}
+mkdir -p {{pkg.svc_var_path}}/logs
+mkdir -p {{pkg.svc_var_path}}/plugins
 mkdir -p {{pkg.svc_config_path}}/scripts
-chown -R hab:hab {{pkg.svc_path}}

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=elasticsearch
 pkg_origin=core
-pkg_version=2.3.3
+pkg_version=2.4.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Revised BSD')
 pkg_source=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=5fe0a6887432bb8a8d3de2e79c9b81c83cfa241e6440f0f0379a686657789165
+pkg_shasum=23a369ef42955c19aaaf9e34891eea3a055ed217d7fbe76da0998a7a54bbe167
 pkg_deps=(core/glibc core/server-jre)
-pkg_bin_dirs=(bin)
+pkg_bin_dirs=(es/bin)
 pkg_lib_dirs=(lib)
-pkg_svc_run="es/bin/elasticsearch --default.path.conf=$pkg_svc_config_path"
+pkg_svc_run="elasticsearch --default.path.conf=$pkg_svc_config_path"
 pkg_expose=(9200 9300)
 
 do_build() {
@@ -20,6 +20,10 @@ do_install() {
   build_line "Copying files from $PWD"
   # Elasticsearch is greedy when grabbing config files from /bin/..
   # so we need to put the untemplated config dir out of reach
+  install -vDm644 README.textile $pkg_prefix/share/README.textile
+  install -vDm644 LICENSE.txt $pkg_prefix/share/licenses/LICENSE.txt
+  install -vDm644 NOTICE.txt $pkg_prefix/share/licenses/NOTICE.txt
+
   mkdir -p $pkg_prefix/es
-  cp -r * $pkg_prefix/es
+  cp -a bin lib modules $pkg_prefix/es
 }


### PR DESCRIPTION
This commit updates elasticsearch for changes in the latest version of
Habitat, as well as updating elasticsearch itself to 2.4.1.

First, habitat runs the init script as "hab", so we need to have the
logs directory located in a place that hab has write access, like
`pkg_svc_var_path`, so the logs will be in
`/hab/svc/elasticsearch/var/logs`.

Next, the elasticsearch package itself used to have a plugins directory.
It wasn't being created, so startup would fail with a rather misleading
message:

```
elasticsearch(O): Exception in thread "main" java.lang.IllegalStateException: Could not load plugin descriptor for existing plugin [logs]. Was the plugin built before 2.0?
elasticsearch(O): Likely root cause: java.nio.file.NoSuchFileException: /hab/svc/elasticsearch/var/logs/plugin-descriptor.properties
```

Once the plugins directory was created, startup succeeds. No properties
file was actually necessary.

Lastly, we change the bin dir to `es/bin`, and remove `es/bin` from the
`pkg_svc_run` variable because we no longer use the `pkg_prefix` in the
generated run script.

As a bonus! We "install" the license and readme info into the package,
rather than copying it wholesale with the other directories.

![gif-keyboard-14409664673424519613](https://cloud.githubusercontent.com/assets/12483/19202770/2b842cd2-8c91-11e6-93d7-6ed6efa8f626.gif)
