### PR TITLE
add core/inspec deprecation notice

### DIFF
--- a/inspec/README.md
+++ b/inspec/README.md
@@ -1,0 +1,3 @@
+# Deprecation notice
+
+The `core/inspec` package has been moved to `chef/inspec`. As a result, `core/inspec` will no longer be maintained.

--- a/inspec/plan.sh
+++ b/inspec/plan.sh
@@ -1,9 +1,8 @@
 pkg_name=inspec
 pkg_origin=core
 pkg_version=0.27.0
-pkg_description="InSpec is an open-source testing framework for infrastructure
-  with a human- and machine-readable language for specifying compliance,
-  security and policy requirements."
+pkg_description="The core/inspec package has been deprecated in favor
+  of chef/inspec"
 pkg_upstream_url=https://github.com/chef/inspec
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')


### PR DESCRIPTION
Inspec is now being shipped as chef/inspec.

Signed-off-by: Dave Parfitt <dparfitt@chef.io>