### PR TITLE
Update tar to 1.29

### DIFF
--- a/tar/plan.sh
+++ b/tar/plan.sh
@@ -1,10 +1,12 @@
 pkg_name=tar
 pkg_origin=core
-pkg_version=1.28
+pkg_version=1.29
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv3+')
+pkg_description="GNU Tar provides the ability to create tar archives, as well as various other kinds of manipulation."
+pkg_upstream_url=https://www.gnu.org/software/tar/
+pkg_license=('GPL-3.0')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=6a6b65bac00a127a508533c604d5bf1a3d40f82707d56f20cefd38a05e8237de
+pkg_shasum=cae466e6e58c7292355e7080248f244db3a4cf755f33f4fa25ca7f9a7ed09af0
 pkg_deps=(core/glibc core/acl core/attr)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_bin_dirs=(bin)
@@ -12,14 +14,13 @@ pkg_bin_dirs=(bin)
 do_build() {
   # * `FORCE_UNSAFE_CONFIGURE` forces the test for `mknod` to be run as root
   FORCE_UNSAFE_CONFIGURE=1 ./configure \
-    --prefix=$pkg_prefix
+    --prefix="$pkg_prefix"
   make
 }
 
 do_check() {
   make check
 }
-
 
 # ----------------------------------------------------------------------------
 # **NOTICE:** What follows are implementation details required for building a


### PR DESCRIPTION
1.29 adds the `--clamp-mtime` option, which some tools depend on.

Also add a description and upstream URL and correct the license format.

![gif-keyboard-3448739940144560556](https://cloud.githubusercontent.com/assets/9912/19448618/3870f09a-9468-11e6-95ec-9efa4ba7c808.gif)
