### PR TITLE
Support UTF8 encoding in pcre

### DIFF
--- a/pcre/plan.sh
+++ b/pcre/plan.sh
@@ -2,23 +2,27 @@ pkg_name=pcre
 pkg_origin=core
 pkg_version=8.38
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="A library that implements Perl 5-style regular expressions"
+pkg_upstream_url="http://www.pcre.org/"
 pkg_license=('bsd')
-pkg_source=http://ftp.csx.cam.ac.uk/pub/software/programming/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2
+pkg_source="http://ftp.csx.cam.ac.uk/pub/software/programming/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"
 pkg_shasum=b9e02d36e23024d6c02a2e5b25204b3a4fa6ade43e0a5f869f254f49535079df
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
 
 do_build() {
   ./configure \
-    --prefix=$pkg_prefix \
+    --prefix="$pkg_prefix" \
     --enable-unicode-properties \
+    --enable-utf \
     --enable-pcre16 \
     --enable-pcre32 \
     --enable-jit
-  make -j$(nproc)
+  make -j"$(nproc)"
 }
 
 do_check() {
@@ -29,7 +33,7 @@ do_install() {
   do_default_install
 
   # Install license file
-  install -Dm644 LICENCE $pkg_prefix/share/licenses/LICENSE
+  install -Dm644 LICENCE "$pkg_prefix/share/licenses/LICENSE"
 }
 
 


### PR DESCRIPTION
- Support UTF8
- Correct lint and shellcheck errors
- add `$pkg_pconfig_dirs`

Signed-off-by: Ben Dang <me@bdang.it>