### PR TITLE
Typo in mongodb and missing !/bin/sh

### DIFF
--- a/mongodb/hooks/init
+++ b/mongodb/hooks/init
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 #
 
 mkdir -p {{pkg.svc_data_path}}/db

--- a/rabbitmq/hooks/init
+++ b/rabbitmq/hooks/init
@@ -1,1 +1,4 @@
+#!/bin/sh
+#
+
 mkdir -p {{pkg.svc_var_path}} {{pkg.svc_config_path}}


### PR DESCRIPTION
- Found a typo in mongodb
- Didn't have the /bin/sh header for rabbit

Signed-off-by: JJ Asghar  <jj@chef.io>