### PR TITLE
Update Valgrind to 3.12.0

### DIFF
--- a/valgrind/plan.sh
+++ b/valgrind/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=valgrind
 pkg_origin=core
-pkg_version=3.11.0
+pkg_version=3.12.0
 pkg_description="An instrumentation framework for building dynamic analysis tools"
 pkg_upstream_url="http://www.valgrind.org/"
 pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://www.valgrind.org/downloads/valgrind-${pkg_version}.tar.bz2"
-pkg_shasum=6c396271a8c1ddd5a6fb9abe714ea1e8a86fce85b30ab26b4266aeb4c2413b42
+pkg_shasum=67ca4395b2527247780f36148b084f5743a68ab0c850cb43e4a5b4b012cf76a1
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/which core/diffutils core/perl)
 pkg_include_dirs=(include)


### PR DESCRIPTION
Release notes: http://valgrind.org/docs/manual/dist.news.html
