### PR TITLE
using npm start results in multiple child processes upon reconfigure

### DIFF
--- a/nodejs-tutorial-app/plan.sh
+++ b/nodejs-tutorial-app/plan.sh
@@ -17,7 +17,7 @@ do_build () {
 
 do_install() {
   # Copy our source files from HAB_CACHE_SRC_PATH to the nodejs-tutorial-app
-  # package.  This is so that when Habitat calls "npm start" at start-up, we
+  # package.  This is so that when Habitat calls "node server.js" at start-up, we
   # have the source files included in the package.
   cp package.json $pkg_prefix/
   cp server.js $pkg_prefix/


### PR DESCRIPTION
Solution:
change npm start to node server.js, this skips the additional
process that npm start creates

see: https://github.com/habitat-sh/habitat/issues/1340
Signed-off-by: Dave Parfitt dparfitt@chef.io
