### PR TITLE
Allow for mongodb to be run completely in insecure mode for demos.

### DIFF
--- a/mongodb/config/mongod.conf
+++ b/mongodb/config/mongod.conf
@@ -94,8 +94,11 @@ net:
 {{~/if}}
 
 security:
+   {{~#if cfg.mongod.security.cluster_auth_mode}}
    clusterAuthMode: {{cfg.mongod.security.cluster_auth_mode}}
-   javascriptEnabled:  {{cfg.mongod.security.javascript_enabled}}
+   {{~/if}}
+   javascriptEnabled: {{cfg.mongod.security.javascript_enabled}}
+   authorization: {{cfg.mongod.security.authorization}}
    {{~#if cfg.mongod.security.key_file}}
    keyFile: {{cfg.mongod.security.key_file}}
    {{~/if}}


### PR DESCRIPTION
This is accomplished by the following:
- Allow for clusterAuthMode to be totally empty. The MongoDB docs say the default is actually "keyFile", but explicitly putting `clusterAuthMode = "keyFile"` has the effect of turning authorization on even if security.authorization is disabled.
- Make `security.authorization` actually tunable (the value was previously settable in `default.toml`, but not actually passed through to the `mongod.conf`)

To run a demo with MongoDB in an unprivileged mode (and to allow others to connect to it) it's only required to inject a TOML into the ring with these contents:

```
[mongod.net]
bind_ip = "0.0.0.0"

[mongod.security]
cluster_auth_mode = ""
```
