### PR TITLE
Update Erlang to 19.1

### DIFF
--- a/erlang/plan.sh
+++ b/erlang/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=erlang
 pkg_origin=core
-pkg_version=18.3
+pkg_version=19.1
 pkg_description="A programming language for massively scalable soft real-time systems."
 pkg_upstream_url="http://www.erlang.org/"
 pkg_dirname=otp_src_${pkg_version}
@@ -8,7 +8,7 @@ pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz
 pkg_filename=otp_src_${pkg_version}.tar.gz
-pkg_shasum=fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3
+pkg_shasum=fed4cbbc1ee5cc8efc2b8f14c3db97bfde1de967703f5f9a95f8ab6852737e23
 pkg_deps=(core/glibc core/zlib core/ncurses core/openssl core/sed)
 pkg_build_deps=(core/coreutils core/gcc core/make core/openssl core/perl core/m4)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Dave Long dlong@cagedata.com

Updates Erlang to 19.1
