### PR TITLE
Fix and update dotnet-core and add powershell

### DIFF
--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=1.0.0-preview2-003121
-pkg_license=('Microsoft .NET Library')
+pkg_version=1.0.0-preview3-003930
+pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.microsoft.com/download/1/5/2/1523EBE1-3764-4328-8961-D1BD8ECA9295/dotnet-dev-debian-x64.$pkg_version.tar.gz"
-pkg_shasum=204ceab7bc92c17d17691b0d5c1d54992fc78a969fc217a8423045875a4c63ed
+pkg_source="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$pkg_version/dotnet-dev-debian-x64.$pkg_version.tar.gz"
+pkg_shasum=67f88e6b3973435b43d7f4b615faf7c44f311debbab9139c38043cd19c0e5f76
 pkg_filename="dotnet-debian-x64.$pkg_version.tar.gz"
 pkg_deps=(
   core/curl
@@ -29,14 +29,15 @@ pkg_bin_dirs=(bin)
 
 do_unpack() {
   # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
-  mkdir -p "$pkg_dirname"
-  tar xfz "$pkg_filename" -C "$pkg_dirname"
+  mkdir -p "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  tar xfz "$HAB_CACHE_SRC_PATH/$pkg_filename" -C "$HAB_CACHE_SRC_PATH/$pkg_dirname"
 }
 
 do_prepare() {
-  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
-    --set-rpath "$LD_RUN_PATH" \
-    ./dotnet
+  find -type f -name 'dotnet' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
 }
 
 do_build() {
@@ -44,15 +45,17 @@ do_build() {
 }
 
 do_install() {
-  # Copy the files into the package
-  cp -a . "$pkg_prefix"
+  cp -a . "$pkg_prefix/bin"
+}
 
-  # Wrap the binary in a script that sets the library paths
-  mkdir -p "$pkg_prefix/bin"
-  cat > "$pkg_prefix/bin/dotnet" <<EOF
-#!/bin/sh
-export LD_LIBRARY_PATH="$pkg_prefix/lib:$LD_RUN_PATH:\$LD_LIBRARY_PATH"
-exec $pkg_prefix/dotnet \$@
-EOF
-  chmod +x "$pkg_prefix/bin/dotnet"
+do_check() {
+  mkdir dotnet-new
+  pushd dotnet-new
+  ../dotnet new
+  popd
+  rm -rf dotnet-new
+}
+
+do_strip() {
+  return 0
 }

--- a/powershell/filesystemprovider.patch
+++ b/powershell/filesystemprovider.patch
@@ -1,0 +1,15 @@
+--- src/System.Management.Automation/namespaces/FileSystemProvider.cs
++++ src/System.Management.Automation/namespaces/FileSystemProvider.cs
+@@ -940,8 +940,9 @@
+                         // add the filesystem with the root "/" to the initial drive list,
+                         // otherwise path handling will not work correctly because there
+                         // is no : available to separate the filesystems from each other
+-                        if (root != StringLiterals.DefaultPathSeparatorString)
+-                            continue;
++                        if (root != StringLiterals.DefaultPathSeparatorString
++                            && newDriveName == StringLiterals.DefaultPathSeparatorString)
++                            root = StringLiterals.DefaultPathSeparatorString;
+ #endif
+ 
+                         // Porting notes: On non-windows platforms .net can report two
+

--- a/powershell/plan.sh
+++ b/powershell/plan.sh
@@ -1,0 +1,125 @@
+pkg_name=powershell
+pkg_origin=core
+pkg_version=6.0.0-alpha.12
+pkg_license=('MIT')
+pkg_upstream_url=https://msdn.microsoft.com/powershell
+pkg_description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/PowerShell/PowerShell"
+pkg_deps=(
+  core/dotnet-core
+  core/gcc
+  core/glibc
+  core/gcc-libs
+  core/icu/52.1
+  core/util-linux
+  core/krb5
+  core/libunwind
+  core/lttng-ust
+  core/openssl
+)
+pkg_build_deps=(
+  core/patchelf
+  core/cmake
+  core/make
+  core/patch
+  core/git
+)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  pushd "$HAB_CACHE_SRC_PATH"
+  rm -rf "PowerShell"
+  # Important to recursively clone submodules.
+  # This is why we do not download source
+  git clone -b v$pkg_version --recursive "$pkg_source"
+  popd
+}
+
+do_unpack() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_prepare() {
+  pushd "$HAB_CACHE_SRC_PATH/PowerShell"
+  git --git-dir=".git" describe --dirty --abbrev=60 > "powershell.version"
+
+  # This fixes an issue where PS Drive paths do not
+  # resolve correctly in the docker based studio and
+  # results in modules not loading and leaving out
+  # several core commands. This causes the "/" drive to
+  # mount to "/" and not "/dev"
+  patch -p0 -i "${PLAN_CONTEXT}/filesystemprovider.patch"
+  popd
+
+  rm -rf "${HAB_CACHE_SRC_PATH:?}/${pkg_dirname:?}"
+  cp -r "$HAB_CACHE_SRC_PATH/PowerShell" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  rm -rf "$HAB_CACHE_SRC_PATH/PowerShell"
+}
+
+do_build() {
+  dotnet restore
+  find /root/.nuget -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+
+  pushd src/ResGen
+  dotnet build
+  find -type f -name 'resgen' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+  dotnet run
+  popd
+
+  pushd src/TypeCatalogParser
+  dotnet build --runtime ubuntu.14.04-x64
+  find -type f -name 'TypeCatalogParser' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+  bin/Debug/netcoreapp1.0/ubuntu.14.04-x64/TypeCatalogParser
+  popd
+
+  pushd src/TypeCatalogGen
+  dotnet build
+  find -type f -name 'TypeCatalogGen' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+  dotnet run ../Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CorePsTypeCatalog.cs powershell.inc
+  popd
+
+  pushd src/libpsl-native
+  cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_INSTALL_PREFIX="$pkg_prefix" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    .
+  make -j
+  popd
+
+  pushd src/powershell-unix
+  find -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+  dotnet build --configuration Linux
+  popd
+}
+
+do_install() {
+  cp powershell.version "$pkg_prefix"
+  pushd src/powershell-unix
+  dotnet publish --configuration Linux --output "$pkg_prefix/bin"
+  find "$pkg_prefix/bin" -type f -name 'powershell' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find "$pkg_prefix/bin" -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+  popd
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
This PR was originally to build coreclr from source. I got a long way down that road and learned alot but ended up discovering the value is not worth the cost. The cost being many hours to build the native clr binaries and eventually in the later artifacts, dotnet installs dotnet to build the managed dotnet stack. So it would be a long trip down a rabbit hole to unravel all of that.

Properly relocating the built bits, a binary plan should work fine and runs the accompanying powershell source build on moby linux succesfully.

One change this takes from the previous donet-core plan is to more aggressively patchelf the binaries instead of using the wrapper to set a LD_LIBRARY_PATH. That strategy works when using the dotnet cli but the built .net artifacts will break if calling them directly, which is common.