### PR TITLE
add zlib support to boost

### DIFF
--- a/boost/plan.sh
+++ b/boost/plan.sh
@@ -1,5 +1,7 @@
 pkg_name=boost
 pkg_origin=core
+pkg_description='Boost provides free peer-reviewed portable C++ source libraries.'
+pkg_upstream_url='http://www.boost.org/'
 pkg_version=1.61.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('Boost Software License')
@@ -25,15 +27,21 @@ pkg_build_deps=(
   core/libxslt
   core/openssl
   core/which
+  core/zlib
 )
 
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 do_build() {
-  ./bootstrap.sh --prefix=$pkg_prefix
+  ./bootstrap.sh --prefix="$pkg_prefix"
 }
 
 do_install() {
-  ./b2 install --prefix=$pkg_prefix -q --debug-configuration -s NO_BZIP2=1
+  export NO_BZIP2=1
+  export ZLIB_LIBPATH
+  ZLIB_LIBPATH="$(pkg_path_for core/zlib)/lib"
+  export ZLIB_INCLUDE
+  ZLIB_INCLUDE="$(pkg_path_for core/zlib)/include"
+  ./b2 install --prefix="$pkg_prefix" -q --debug-configuration
 }


### PR DESCRIPTION
I needed a Boost built with zlib support for [a hyper-critical infrastructure component](https://docs.mapcrafter.org/builds/stable/index.html). These changes worked for me to build a `robbkidd/boost` package with zlib and a follow-on build of the hyper-critical component.

I'm not certain of the impact of building this support into the core package, so I'm opening the PR for discussion and consideration. I note that none of the other core plans depend on `core/boost`. mysql comes close, but depends on an earlier version via `core/boost159`.