### PR TITLE
Update curl to 7.51.0

### DIFF
--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.47.1
+pkg_version=7.51.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=4e9d85028e754048887505a73638bf9b254c39582a191f43c95fe7de8e4d8005
+pkg_shasum=65b5216a6fbfa72f547eb7706ca5902d7400db9868269017a8888aa91d87977c
 pkg_deps=(
   core/cacerts
   core/glibc


### PR DESCRIPTION
This addresses the following CVEs:

 - CVE-2016-8615: cookie injection for other servers
 - CVE-2016-8616: case insensitive password comparison
 - CVE-2016-8617: OOB write via unchecked multiplication
 - CVE-2016-8618: double-free in curl_maprintf
 - CVE-2016-8619: double-free in krb5 code
 - CVE-2016-8620: glob parser write/read out of bounds
 - CVE-2016-8621: curl_getdate read out of bounds
 - CVE-2016-8622: URL unescape heap overflow via integer truncation
 - CVE-2016-8623: Use-after-free via shared cookies
 - CVE-2016-8624: invalid URL parsing with '#'
 - CVE-2016-8625: IDNA 2003 makes curl use wrong host

Signed-off-by: Steven Danna <steve@chef.io>