### PR TITLE
Enhance run time configuration possibilities for nginx

### DIFF
--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -22,6 +22,8 @@ http {
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
     gzip_disable "MSIE [1-6]\.";
 
+    {{cfg.http.global_ssl_password_file}}
+
     server {
         listen       80;
         server_name  localhost;
@@ -31,4 +33,9 @@ http {
             index  index.html index.htm;
         }
     }
+
+    {{cfg.http.include.additional_servers}}
+
 }
+
+{{cfg.include.additional_configuration_files}}

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -27,7 +27,7 @@ http {
         server_name  localhost;
 
         location / {
-            root   {{pkg.svc_data_path}};
+            root   {{cfg.http.www-data}};
             index  index.html index.htm;
         }
     }

--- a/nginx/default.toml
+++ b/nginx/default.toml
@@ -33,3 +33,5 @@ tcp_nodelay = "on"
 
 # http.keepalive_timeout: Timeout on client connection keepalive, in seconds. Default = 75
 keepalive_timeout = 60
+
+www-data = "/hab/svc/nginx/data"

--- a/nginx/default.toml
+++ b/nginx/default.toml
@@ -4,6 +4,7 @@
  #  # #  #  ###     #    #  # #    ##
  #   ##  #    #     #    #   ##   #  #
  #    #   ####      #    #    #  #    #
+
  # For help with NGINX Config Tuning, 
  # refer to: http://nginx.org/en/docs/http/ngx_http_core_module.html
 
@@ -18,6 +19,7 @@ worker_processes = 4
 [events]
 # worker_connections: Connections per Worker Process.  Default = 1024
 worker_connections = 1024
+
 
 
 #### HTTP Context Configuration
@@ -35,3 +37,12 @@ tcp_nodelay = "on"
 keepalive_timeout = 60
 
 www-data = "/hab/svc/nginx/data"
+global_ssl_password_file = "# ssl_password_file /home/hab/.ssh/tls/global.pass;"
+
+
+#### Extended Configuration
+[include]
+additional_configuration_files = ""
+
+[http.include]
+additional_servers = ""


### PR DESCRIPTION
Makes root path `cfg` configurable rather than `pkg` configurable.

Adds empty template variables for : 
- sites-enabled
- ssl_password_file
- other main context variables

