### PR TITLE
Update musl to 1.1.15

### DIFF
--- a/musl/plan.sh
+++ b/musl/plan.sh
@@ -1,10 +1,12 @@
 pkg_name=musl
 pkg_origin=core
-pkg_version=1.1.14
+pkg_version=1.1.15
+pkg_description="A clean, efficient and standards-conformant libc implementation."
 pkg_license=('mit')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.musl-libc.org/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=35f6c00c84a6091bd5dab29eedde7508dae755ead92dcc0239f3677d1055b9b5
+pkg_source=https://www.musl-libc.org/releases/${pkg_name}-${pkg_version}.tar.gz
+pkg_upstream_url=https://www.musl-libc.org/
+pkg_shasum=97e447c7ee2a7f613186ec54a93054fe15469fe34d7d323080f7ef38f5ecb0fa
 pkg_deps=()
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_bin_dirs=(bin)
@@ -21,16 +23,16 @@ do_prepare() {
 
 do_build() {
   ./configure \
-    --prefix=$pkg_prefix \
-    --syslibdir=$pkg_prefix/lib
-  make -j$(nproc)
+    --prefix="$pkg_prefix" \
+    --syslibdir="$pkg_prefix"/lib
+  make -j"$(nproc)"
 }
 
 do_install() {
   do_default_install
 
   # Install license
-  install -Dm0644 COPYRIGHT $pkg_prefix/share/licenses/COPYRIGHT
+  install -Dm0644 COPYRIGHT "$pkg_prefix"/share/licenses/COPYRIGHT
 }
 
 


### PR DESCRIPTION
Highlights include fixes for serious bugs in memmem, ungetwc, and putenv.

Signed-off-by: Eivind Uggedal <eivind@uggedal.com>