### PR TITLE
rust metadata (updated)

### DIFF
--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,9 @@
 pkg_name=rust
 pkg_origin=core
 pkg_version=1.13.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Safe, concurrent, practical language"
+pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
 _url_base=http://static.rust-lang.org/dist
 pkg_source=$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
PR #290 updated Rust, but failed the build and merge to master due to
violations in the package metadata.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>