### PR TITLE
Add MS Sql Server vNext for linux and update asp.net sample to use it

### DIFF
--- a/aspnet-sample/config/appsettings.json
+++ b/aspnet-sample/config/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "ConnectionStrings": {
+{{~#if bind.has_database}}
+    "DefaultConnection": "Server={{bind.database.members[0].ip}},{{bind.database.members[0].port}};Database=MyDatabase;User Id=sa;Password=Pass@word1;"
+{{~else}}
+    "DefaultConnection": "Server={{cfg.database_host}},{{cfg.database_port}};Database=MyDatabase;User Id=sa;Password=Pass@word1;"
+{{~/if}}
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/aspnet-sample/default.toml
+++ b/aspnet-sample/default.toml
@@ -1,1 +1,3 @@
 port = 8090
+database_port = 1433
+database_host = "127.0.0.1"

--- a/aspnet-sample/plan.sh
+++ b/aspnet-sample/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=aspnet-sample
 pkg_origin=core
-pkg_version=0.1.9
+pkg_version=0.2.0
 pkg_source=https://github.com/mwrock/habitat-${pkg_name}/archive/v${pkg_version}.tar.gz
-pkg_shasum=50ffcbe1c0b49acb84365c2157445047b360345c7361e67827093f962852de4d
+pkg_shasum=cfc79dcbebb8c7baccc48e05277a7a4d96e36a26cfde87e42017ef6191692419
 pkg_upstream_url=https://github.com/mwrock/habitat-aspnet-sample
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')

--- a/aspnet-sample/plan.sh
+++ b/aspnet-sample/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=aspnet-sample
 pkg_origin=core
-pkg_version=0.2.0
+pkg_version=0.2.1
 pkg_source=https://github.com/mwrock/habitat-${pkg_name}/archive/v${pkg_version}.tar.gz
-pkg_shasum=cfc79dcbebb8c7baccc48e05277a7a4d96e36a26cfde87e42017ef6191692419
+pkg_shasum=eb49a0858802d80ec7ced1ea553e87666a255ed0d324c2bd7d2fe8347912d04e
 pkg_upstream_url=https://github.com/mwrock/habitat-aspnet-sample
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')

--- a/libcxx/plan.sh
+++ b/libcxx/plan.sh
@@ -1,0 +1,99 @@
+pkg_name=libcxx
+pkg_origin=core
+pkg_version=3.9.0
+pkg_license=('NCSA')
+pkg_description="A new implementation of the C++ standard library, targeting C++11"
+pkg_upstream_url=http://libcxx.llvm.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename=${pkg_name}-${pkg_version}.src.tar.xz
+pkg_source=http://llvm.org/releases/${pkg_version}/${pkg_name}-${pkg_version}.src.tar.xz
+pkg_shasum=d0b38d51365c6322f5666a2a8105785f2e114430858de4c25a86b49f227f5b06
+pkg_build_deps=(
+  core/cmake
+  core/llvm
+  core/make
+)
+pkg_deps=(
+  core/gcc
+  core/glibc
+  core/util-linux
+  core/zlib
+)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  do_default_download
+
+  build_line "Downloading libcxxabi"
+  download_file http://llvm.org/releases/${pkg_version}/libcxxabi-${pkg_version}.src.tar.xz \
+    libcxxabi-${pkg_version}.src.tar.xz \
+    b037a92717856882e05df57221e087d7d595a2ae9f170f7bc1a23ec7a92c8019
+}
+
+do_unpack() {
+  mkdir -p "$HAB_CACHE_SRC_PATH/${pkg_dirname}/libcxx"
+  pushd "$HAB_CACHE_SRC_PATH/${pkg_dirname}/libcxx"
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" --strip 1
+  popd
+
+  mkdir -p "$HAB_CACHE_SRC_PATH/${pkg_dirname}/libcxxabi"
+  pushd "$HAB_CACHE_SRC_PATH/${pkg_dirname}/libcxxabi"
+  tar xf "$HAB_CACHE_SRC_PATH/libcxxabi-${pkg_version}.src.tar.xz" --strip 1
+  popd
+}
+
+do_prepare() {
+  do_default_prepare
+
+  # Without these links, the clang linker fails. I not been able to find any
+  # workaround for this. The library paths do not impact the search paths for these files
+  clang_path=$(dirname "$(find "$(pkg_path_for llvm)/lib/clang" -type d -name include)")
+  export clang_path
+
+  ln -sf "$(pkg_path_for glibc)/lib/crtn.o"  "$clang_path/crtn.o"
+  ln -sf "$(pkg_path_for glibc)/lib/crt1.o"  "$clang_path/crt1.o"
+  ln -sf "$(pkg_path_for glibc)/lib/crti.o"  "$clang_path/crti.o"
+
+  CC="$(pkg_path_for llvm)/bin/clang"
+  export CC
+  CXX="$(pkg_path_for llvm)/bin/clang++"
+  export CXX
+}
+
+do_build() {
+  pushd libcxxabi
+  cmake \
+    -DCMAKE_INSTALL_PREFIX="$pkg_prefix" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS --gcc-toolchain=$(pkg_path_for gcc)" \
+    -DCMAKE_C_FLAGS="$CFLAGS --gcc-toolchain=$(pkg_path_for gcc)" \
+    -DLIBCXXABI_LIBCXX_PATH=../libcxx \
+    .
+  make
+  popd
+
+  cmake \
+    -DCMAKE_INSTALL_PREFIX="$pkg_prefix" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS --gcc-toolchain=$(pkg_path_for gcc)" \
+    -DCMAKE_C_FLAGS="$CFLAGS --gcc-toolchain=$(pkg_path_for gcc)" \
+    -DLIBCXX_CXX_ABI=libcxxabi \
+    -DLIBCXX_CXX_ABI_LIBRARY_PATH=libcxxabi/lib \
+    -DLIBCXX_CXX_ABI_INCLUDE_PATHS=libcxxabi/include \
+    libcxx
+  make
+}
+
+do_install() {
+  pushd libcxxabi
+  make install-libcxxabi
+  popd
+
+  make install-libcxx
+}
+
+do_end() {
+  rm "$clang_path/crtn.o"
+  rm "$clang_path/crt1.o"
+  rm "$clang_path/crti.o"
+}

--- a/mssql/default.toml
+++ b/mssql/default.toml
@@ -1,0 +1,2 @@
+sa_password = "Pass@word1"
+port = 1433

--- a/mssql/hooks/init
+++ b/mssql/hooks/init
@@ -1,12 +1,15 @@
 #!/bin/sh
-jemalloc_path=$(find / -type f -name libjemalloc.so.2)
+exec  2>&1
+
+cd {{pkg.path}} || exit
+jemalloc_path="$(readlink -f "$(find ../../../../core/jemalloc -type f -name libjemalloc.so.2)")"
 ln -sf $jemalloc_path "$(dirname $jemalloc_path)/libjemalloc.so.1"
 
 if [ ! -f /var/opt/mssql/data/master.mdf ]; then
-  SQLSERVR_SA_PASSWORD="{{cfg.sa_password}}" {{pkg.path}}/bin/sqlservr --setup 2>&1
+  SQLSERVR_SA_PASSWORD="{{cfg.sa_password}}" {{pkg.path}}/bin/sqlservr --setup
 fi
 
-{{pkg.path}}/bin/mssql-conf accept-eula 2>&1
-{{pkg.path}}/bin/mssql-conf set defaultdatadir {{pkg.svc_data_path}} 2>&1
-{{pkg.path}}/bin/mssql-conf set defaultlogdir {{pkg.svc_data_path}} 2>&1
-{{pkg.path}}/bin/mssql-conf set tcpport {{cfg.port}} 2>&1
+{{pkg.path}}/bin/mssql-conf accept-eula
+{{pkg.path}}/bin/mssql-conf set defaultdatadir {{pkg.svc_data_path}}
+{{pkg.path}}/bin/mssql-conf set defaultlogdir {{pkg.svc_data_path}}
+{{pkg.path}}/bin/mssql-conf set tcpport {{cfg.port}}

--- a/mssql/hooks/init
+++ b/mssql/hooks/init
@@ -1,0 +1,12 @@
+#!/bin/sh
+jemalloc_path=$(find / -type f -name libjemalloc.so.2)
+ln -sf $jemalloc_path "$(dirname $jemalloc_path)/libjemalloc.so.1"
+
+if [ ! -f /var/opt/mssql/data/master.mdf ]; then
+  SQLSERVR_SA_PASSWORD="{{cfg.sa_password}}" {{pkg.path}}/bin/sqlservr --setup 2>&1
+fi
+
+{{pkg.path}}/bin/mssql-conf accept-eula 2>&1
+{{pkg.path}}/bin/mssql-conf set defaultdatadir {{pkg.svc_data_path}} 2>&1
+{{pkg.path}}/bin/mssql-conf set defaultlogdir {{pkg.svc_data_path}} 2>&1
+{{pkg.path}}/bin/mssql-conf set tcpport {{cfg.port}} 2>&1

--- a/mssql/hooks/run
+++ b/mssql/hooks/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec {{pkg.path}}/bin/sqlservr 2>&1

--- a/mssql/plan.sh
+++ b/mssql/plan.sh
@@ -1,0 +1,55 @@
+pkg_name=mssql
+pkg_origin=core
+pkg_version=14.0.1.246-6
+pkg_license=('MICROSOFT PRE-RELEASE SOFTWARE LICENSE')
+pkg_upstream_url=https://www.microsoft.com/en-us/sql-server/sql-server-vnext-including-Linux
+pkg_description="Microsoft SQL Server for Linux"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://packages.microsoft.com/ubuntu/16.04/mssql-server/pool/main/m/mssql-server/mssql-server_${pkg_version}_amd64.deb"
+pkg_shasum=508557ba5aaa76a99d3218dd0d74f69aae36cc508bd79e06fbc2e38126a69b2c
+pkg_filename="mssql-server_${pkg_version}_amd64.deb"
+pkg_svc_user="root"
+pkg_svc_group="root"
+pkg_expose=(1433)
+
+pkg_deps=(
+  core/libcxx
+  core/gcc-libs
+  core/glibc
+  core/jemalloc
+  core/openssl
+  core/python2
+)
+
+pkg_build_deps=(
+  core/dpkg
+  core/patchelf
+)
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+do_unpack() {
+  dpkg -x "$HAB_CACHE_SRC_PATH/$pkg_filename" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  cp -a opt/mssql/bin "$pkg_prefix"
+  cp -a opt/mssql/lib "$pkg_prefix"
+
+  PYTHONPATH="$(pkg_path_for core/python2)"
+  sed -i "s#/usr/bin/python#$PYTHONPATH/bin/python#" "$pkg_prefix/lib/mssql-conf/mssql-conf.py"
+
+  find "$pkg_prefix/bin" -type f -name '*' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
+  find "$pkg_prefix/lib" -type f -name '*.so*' \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
Adds a mssql plan and one of its dependencies libc++ (a member of the llvm family).

A few things to note:
1. You need to run the service in a environment with at least 4GB memory
2. The `sa_password` config setting SETS the sa password if the master databases have never been initialized. It is not used to "access" the db
3. Currently several files including the master db files MUST be stored under `/var/opt/mssql` and you cant use a symlink. However, that is only for common systemwide files. The `init` hook will ensure that user DBs go to `svc_data_path`.
4. The `pkg_svc_user` must have write permissions on `/var/opt` so thats why the default is `root` here.