### PR TITLE
Moved the consul client to the config file

### DIFF
--- a/consul/config/basic_config.json
+++ b/consul/config/basic_config.json
@@ -2,5 +2,7 @@
   "datacenter": "{{cfg.server.datacenter}}",
   "data_dir": "{{cfg.server.data-dir}}",
   "log_level": "{{cfg.server.loglevel}}",
+  "client_addr": "{{cfg.client.bind}}",
   "server": {{cfg.server.mode}}
+
 }

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -5,7 +5,7 @@ exec 2>&1
 SERVERMODE={{cfg.server.mode}}
 
 if [ "$SERVERMODE" = true ] ; then
-  exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -client {{cfg.client.bind}} -config-file={{pkg.svc_config_path}}/basic_config.json
+  exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json
 else
   exec consul agent -dev
 fi


### PR DESCRIPTION
- `client_addr` allows for client to be declared in the config file.

Signed-off-by: JJ Asghar <jj@chef.io>