### PR TITLE
Example of broken thread usage in core/python.

### DIFF
--- a/broken-python/.gitignore
+++ b/broken-python/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+results/

--- a/broken-python/broken-python.py
+++ b/broken-python/broken-python.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: python -*-
+
+import random
+import time
+
+from threading import Thread
+
+
+def do_nothing(i):
+    print("Thread %d has started" % i)
+    time.sleep(random.randint(0, 3))
+    print("Thread %d is done" % i)
+
+threads = [Thread(target=do_nothing, args=(i,)) for i in range(3)]
+
+for thread in threads:
+    thread.start()
+
+for thread in threads:
+    thread.join()

--- a/broken-python/hooks/run
+++ b/broken-python/hooks/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+exec python {{pkg.path}}/broken-python.py

--- a/broken-python/plan.sh
+++ b/broken-python/plan.sh
@@ -6,7 +6,7 @@ pkg_version=0.1.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source=https://github.com/habitat-sh/core-plans
-pkg_deps=(core/gcc-libs core/glibc core/python)
+pkg_deps=(core/python)
 
 do_download() {
     return 0

--- a/broken-python/plan.sh
+++ b/broken-python/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=broken-python
+pkg_description="Example of broken thread usage in core/python."
+# $HAB_ORIGIN overrides pkg_origin.
+pkg_origin=origin
+pkg_version=0.1.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_source=https://github.com/habitat-sh/core-plans
+pkg_deps=(core/gcc-libs core/glibc core/python)
+
+do_download() {
+    return 0
+}
+
+do_verify() {
+    return 0
+}
+
+do_unpack() {
+    return 0
+}
+
+do_prepare() {
+    cp $PLAN_CONTEXT/*.py $HAB_CACHE_SRC_PATH/$pkg_dirname
+}
+
+do_build() {
+    return 0
+}
+
+do_install() {
+    cp *.py $pkg_prefix
+}


### PR DESCRIPTION
When this is built and run inside a studio the error looks like:

    # hab start tvaughan/broken-python
    broken-python(SV): Starting
    libgcc_s.so.1 must be installed for pthread_cancel to work
    hab-sup(SV): broken-python - process 12867 died with signal 6
    hab-sup(SV): broken-python - Service exited

The problem is that `libgcc_s.so` is not linked with the core/python binary even though core/python lists lib-gcc in pkg_deps. Please see: https://github.com/habitat-sh/core-plans/blob/05e9e9ab106fea1a046283a7050026e9f8fedb6f/python/plan.sh#L15. Witness:

    # ldd /hab/pkgs/core/python/3.5.2/20161102165726/bin/python
    linux-vdso.so.1 (0x00007ffe50fad000)
    libpython3.5m.so.1.0 => /hab/pkgs/core/python/3.5.2/20161102165726/lib/libpython3.5m.so.1.0 (0x00007f3db1d91000)
    libpthread.so.0 => /hab/pkgs/core/glibc/2.22/20160612063629/lib/libpthread.so.0 (0x00007f3db1b74000)
    libdl.so.2 => /hab/pkgs/core/glibc/2.22/20160612063629/lib/libdl.so.2 (0x00007f3db1970000)
    libutil.so.1 => /hab/pkgs/core/glibc/2.22/20160612063629/lib/libutil.so.1 (0x00007f3db176d000)
    libssl.so.1.0.0 => /hab/pkgs/core/openssl/1.0.2j/20161102155324/lib/libssl.so.1.0.0 (0x00007f3db14fc000)
    libcrypto.so.1.0.0 => /hab/pkgs/core/openssl/1.0.2j/20161102155324/lib/libcrypto.so.1.0.0 (0x00007f3db10a9000)
    libz.so.1 => /hab/pkgs/core/zlib/1.2.8/20161015000012/lib/libz.so.1 (0x00007f3db0e8e000)
    libm.so.6 => /hab/pkgs/core/glibc/2.22/20160612063629/lib/libm.so.6 (0x00007f3db0b90000)
    libc.so.6 => /hab/pkgs/core/glibc/2.22/20160612063629/lib/libc.so.6 (0x00007f3db07ec000)
    /hab/pkgs/core/glibc/2.22/20160612063629/lib/ld-linux-x86-64.so.2 (0x00007f3db22c3000)

This can be worked around with `LD_PRELOAD=/path/to/lib/libgcc_s.so` but I'm sure this isn't the right solution.

This is on Ubuntu 16.04.01 x86_64 and hab version 0.13.1/20161114235527.

I don't intend to have this pull-request merged. My thought is that the diff could prove useful fodder for discussion and this discussion would stay in the habitat-sh/core-plans repo. If I create an issue and point at the diff https://github.com/carrete/core-plans/compare/master...broken-python the conversation could end up fragmented between the two repositories.

