### PR TITLE
Add uwsgi and uwsgi-example.

### DIFF
--- a/uwsgi/.gitignore
+++ b/uwsgi/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+results/

--- a/uwsgi/hooks/run
+++ b/uwsgi/hooks/run
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# libpcre.so.1 is not found even though core/pcre is listed as a build **and**
+# runtime dependency. Without adding the pcre lib path to LD_LIBRARY_PATH the
+# error is:
+#     # hab start tvaughan/uwsgi
+#     [snip]
+#     uwsgi(O): /hab/pkgs/tvaughan/uwsgi/2.0.15/20170410165204/bin/uwsgi: error while loading shared libraries: libpcre.so.1: cannot open shared object file: No such file or directory
+# Please note:
+#     # ldd /hab/pkgs/tvaughan/uwsgi/2.0.15/20170410165204/bin/uwsgi | grep pcre
+#     libpcre.so.1 => not found
+LD_LIBRARY_PATH="$(hab pkg path core/pcre)/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH
+
+# For some reason uwsgi writes **everything** to stderr. Unless we rewrite
+# stderr to stdout there is no output. How does one tell hab to output stderr?
+exec 2>&1
+
+exec "$(hab pkg path core/uwsgi)/bin/uwsgi" "$@"

--- a/uwsgi/plan.sh
+++ b/uwsgi/plan.sh
@@ -1,0 +1,22 @@
+pkg_name=uwsgi
+pkg_description="uWSGI application server container"
+pkg_upstream_url=https://github.com/unbit/uwsgi
+# $HAB_ORIGIN overrides pkg_origin.
+pkg_origin=origin
+pkg_version=2.0.15
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("GPL-2.0")
+pkg_source=https://github.com/unbit/${pkg_name}/archive/${pkg_version}.tar.gz
+pkg_shasum=251f0670628ce9b9f4c2b4288a7ea921e2ddb3d5e886b6aa2358273573e6fdcf
+pkg_dirname=${pkg_name}-${pkg_version}
+pkg_deps=(core/pcre core/python)
+pkg_build_deps=(core/gcc core/make)
+pkg_bin_dirs=(bin)
+
+do_build() {
+    make
+}
+
+do_install() {
+    install -D uwsgi "$pkg_prefix"/bin/uwsgi
+}


### PR DESCRIPTION
This "works" but only because I've added some workarounds for a few problems.

This https://github.com/habitat-sh/core-plans/compare/master...carrete:add-uwsgi?expand=1#diff-89fc7442f3ee6ab495334475cdc65181R16 is a workaround for https://github.com/habitat-sh/core-plans/pull/316.

This https://github.com/habitat-sh/core-plans/compare/master...carrete:add-uwsgi?expand=1#diff-56bbd3510ee85122159e94eb5d254409R3 is because libpcre.so is not in `LD_LIBRARY_PATH`.

My hope is that we can resolve the problems that led to the workarounds, and then merge this pull-request with the workarounds removed. I also know that I need to sign-off on these commits per https://github.com/habitat-sh/core-plans/blob/master/CONTRIBUTING.md#signing-your-commits.

When I build and run this in a studio, and then in another terminal make a request to the supervisor I see:

    $ curl -i 192.168.4.234:3000
    HTTP/1.1 200 OK
    Content-Length: 22
    Content-Type: text/html
    Date: 2016-12-01T16:25:20.541634

    <h1>Hello, World!</h1>
