### PR TITLE
Updates to php5 plan

### DIFF
--- a/php5/plan.sh
+++ b/php5/plan.sh
@@ -10,30 +10,50 @@ pkg_source=https://php.net/get/${pkg_distname}-${pkg_version}.tar.bz2/from/this/
 pkg_filename=${pkg_distname}-${pkg_version}.tar.bz2
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_shasum=facd280896d277e6f7084b60839e693d4db68318bfc92085d3dc0251fd3558c7
-pkg_deps=(core/libxml2)
-pkg_build_deps=(core/bison2 core/gcc core/make core/re2c)
-pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/coreutils
+  core/curl
+  core/glibc
+  core/libxml2
+  core/openssl
+  core/zlib
+)
+pkg_build_deps=(
+  core/bison2
+  core/gcc
+  core/make
+  core/re2c
+)
+pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_interpreters=(bin/php)
 
-do_prepare() {
-  # The configure script expects libxml2 binaries to either be in `/usr/bin`, `/usr/local/bin` or be
-  # passed in as a configure param. Instead of overriding the entire do_build, symlink the
-  # required executable into place.
-  if [[ ! -r /usr/bin/xml2-config ]]; then
-    ln -sv "$(pkg_path_for libxml2)/bin/xml2-config" /usr/bin/xml2-config
-    _clean_xml2=true
-  fi
+do_build() {
+  ./configure --prefix="$pkg_prefix" \
+    --enable-exif \
+    --enable-fpm \
+    --enable-mbstring \
+    --enable-opcache \
+    --with-curl="$(pkg_path_for curl)" \
+    --with-libxml-dir="$(pkg_path_for libxml2)" \
+    --with-openssl="$(pkg_path_for openssl)" \
+    --with-xmlrpc \
+    --with-zlib="$(pkg_path_for zlib)"
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # Modify PHP-FPM config so it will be able to run out of the box. To run a real
+  # PHP-FPM application you would want to supply your own config with
+  # --fpm-config <file>.
+  mv "$pkg_prefix/etc/php-fpm.conf.default" "$pkg_prefix/etc/php-fpm.conf"
+  # Run as the hab user by default, as it's more likely to exist than nobody.
+  sed -i "s/nobody/hab/g" "$pkg_prefix/etc/php-fpm.conf"
 }
 
 do_check() {
   make test
-}
-
-do_end() {
-  # Clean up the `xml2-config` link, if we set it up.
-  if [[ -n "$_clean_xml2" ]]; then
-    rm -fv /usr/bin/xml2-config
-  fi
 }


### PR DESCRIPTION
* Stop doing the thing where we symlink into /usr/bin for xml2-config;
  found a way to do this with a variable
* Add glibc as a direct, rather than transitive dep, because it is
* Add curl, exif, fpm, mbstring, opcache, openssl, zlib, and xmlrpc support
* Add sbin to bin_dirs (that's where php-fpm goes)

Fixes #327

![giphy4](https://cloud.githubusercontent.com/assets/9912/21029727/b68a2c96-bd60-11e6-9e75-c85a7b8d0510.gif)
