### PR TITLE
Ensure Logstash only logs to the console

### DIFF
--- a/logstash/config/logstash.conf
+++ b/logstash/config/logstash.conf
@@ -1,6 +1,8 @@
 input {
   file {
-    path => "{{pkg.svc_var_path}}/log/logstash-plain.log"
+    path => "{{pkg.path}}/DEPS"
+    start_position => "beginning"
+    sincedb_path => "{{pkg.svc_var_path}}/sincedb"
   }
 }
 output {

--- a/logstash/hooks/init
+++ b/logstash/hooks/init
@@ -3,4 +3,3 @@
 exec 2>&1
 
 mkdir -p {{pkg.svc_var_path}}/data
-mkdir -p {{pkg.svc_var_path}}/log

--- a/logstash/hooks/run
+++ b/logstash/hooks/run
@@ -4,6 +4,10 @@ exec 2>&1
 
 export USE_RUBY=1
 
+# The `path.logs' config is no-op as we disable all file based logging
+# via a custom `log4j2.properites' file. We only set it so a hard-coded
+# and confusing `puts' message is not printed during startup. Habitat
+# apps should just print log messages to the console!
 exec {{pkg.path}}/bin/logstash \
   --path.config {{pkg.svc_config_path}} \
   --path.data {{pkg.svc_var_path}}/data \

--- a/logstash/log4j2.properties
+++ b/logstash/log4j2.properties
@@ -1,0 +1,16 @@
+status = error
+name = LogstashPropertiesConfig
+
+appender.console.type = Console
+appender.console.name = plain_console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %m%n
+
+appender.json_console.type = Console
+appender.json_console.name = json_console
+appender.json_console.layout.type = JSONLayout
+appender.json_console.layout.compact = true
+appender.json_console.layout.eventEol = true
+
+rootLogger.level = ${sys:ls.log.level}
+rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console

--- a/logstash/plan.sh
+++ b/logstash/plan.sh
@@ -26,4 +26,7 @@ do_install() {
   rm -rf "$pkg_prefix/data"
   rm -rf "$pkg_prefix/vendor/jruby"
   fix_interpreter "${pkg_prefix}/bin/*" core/bash bin/sh
+
+  # Ensure we only print to the console
+  cp "${PLAN_CONTEXT}/log4j2.properties" "$pkg_prefix/settings/"
 }


### PR DESCRIPTION
Logstash 5+ controls all file-based logging via the `log4j2.properites` file. We need to package a special version of this file that excludes any file appenders as Habitat apps should just log to the console. Packaging this properties file also allows any plans that wrap `core/logstash` to just leverage this file and not need to provide their own copy.

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @elliott-davis 