### PR TITLE
Disable python manylinux wheels

### DIFF
--- a/python/plan.sh
+++ b/python/plan.sh
@@ -49,9 +49,13 @@ do_build() {
 
 do_install() {
   do_default_install
+  SITE_PACKAGES="$pkg_prefix/lib/python3.5/site-packages"
 
   # link python3.5 to python for pkg_interpreters
   ln -rs "${pkg_prefix}/bin/python3.5" "${pkg_prefix}/bin/python"
+
+  # Disable manylinux wheel support
+  echo "manylinux1_compatible = False" > "$SITE_PACKAGES/_manylinux.py"
 
   # Upgrade to the latest pip
   "$pkg_prefix/bin/pip3" install --upgrade pip

--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -37,3 +37,14 @@ do_build() {
 do_check() {
   LD_LIBRARY_PATH=$PWD ./python -E -c 'import sqlite3'
 }
+
+do_install() {
+  do_default_install
+  SITE_PACKAGES="$pkg_prefix/lib/python2.7/site-packages"
+
+  # Disable manylinux wheel support
+  echo "manylinux1_compatible = False" > "$SITE_PACKAGES/_manylinux.py"
+
+  # Upgrade to the latest pip
+  "$pkg_prefix/bin/pip2" install --upgrade pip
+}


### PR DESCRIPTION
These changes add a `_manytlinux` module to Python that disables `manylinux1` wheels.

The justification for this is to eliminate false positives with pip installations and segfaults with python packages themselves. The segfaults are attributed to the disparity in library versions between CentOS 5 and Habitat. It is best to build binary python packages against Habitat's own libraries.

I have been working on Habitat specific [python wheel builds](https://github.com/georgemarshall/wheelhouse-plans) to help simplify packaing.