### PR TITLE
Add icu52 plan and pin to dotnet-core

### DIFF
--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/curl
   core/gcc-libs
   core/glibc
-  core/icu/52.1
+  core/icu52
   core/krb5
   core/libunwind
   core/lttng-ust

--- a/icu52/plan.sh
+++ b/icu52/plan.sh
@@ -1,10 +1,10 @@
 pkg_origin=core
-pkg_name=icu
-pkg_version=57.1
+pkg_name=icu52
+pkg_version=52.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Unicode-TOU")
 pkg_source="http://download.icu-project.org/files/icu4c/${pkg_version}/icu4c-$(printf "%s" "$pkg_version" | tr . _)-src.tgz"
-pkg_shasum=ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581
+pkg_shasum=2f4d5e68d4698e87759dbdc1a586d053d96935787f79961d192c477b029d8092
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
I've already published these to the depot, but these are the changes necessary to get the `dotnet-core` plan building again