### PR TITLE
Add Seth Chisamore to Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,10 +13,11 @@ To become a maintainer, open a pull request to this list.
 
 ## Maintainers
 
+* [Seth Chisamore](https://github.com/schisamo)
 * [Elliott Davis](https://github.com/elliott-davis)
+* [Mike Fiedler](https://github.com/miketheman)
 * [Fletcher Nichol](https://github.com/fnichol)
 * [Dave Parfitt](https://github.com/metadave)
 * [Nathan L Smith](https://github.com/smith)
 * [Joshua Timberman](https://github.com/jtimberman)
 * [Jamie Winsor](https://github.com/reset)
-* [Mike Fiedler](https://github.com/miketheman)


### PR DESCRIPTION
Maybe I can stop badgering @elliott-davis now...!

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @habitat-sh/habitat-core-maintainers @habitat-sh/habitat-core-plans-maintainers