### PR TITLE
Update to Rust 1.14.0.

### DIFF
--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.13.0
+pkg_version=1.14.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Safe, concurrent, practical language"
 pkg_upstream_url="https://www.rust-lang.org/"
@@ -8,7 +8,7 @@ pkg_license=('Apache-2.0' 'MIT')
 _url_base=http://static.rust-lang.org/dist
 pkg_source=$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz
 pkg_dirname=${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu
-pkg_shasum=95f4c372b1b81ac1038161e87e932dd7ab875d25c167a861c3949b0f6a65516d
+pkg_shasum=c71325cfea1b6f0bdc5189fa4c50ff96f828096ff3f7b5056367f9685d6a4d04
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_deps=(core/glibc core/gcc-libs core/zlib core/gcc core/cacerts core/busybox-static)
@@ -19,7 +19,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-  921890bef0c4f1d20434faa7da22c10b2169057a1dc31f650a4a1491a88bc529
+  3ffcf483c2266cf6199a1e0daf1c3746e11ae0d1202d3af3fcd52cecfdc13da5
 )
 
 do_download() {


### PR DESCRIPTION
https://blog.rust-lang.org/2016/12/22/Rust-1.14.html
