### PR TITLE
:snowflake: redis template bind addresses

### DIFF
--- a/redis/config/redis.config
+++ b/redis/config/redis.config
@@ -63,7 +63,7 @@ tcp-backlog {{cfg.tcp-backlog}}
 # bind 192.168.1.100 10.0.0.1
 # bind 127.0.0.1
 {{~#if cfg.bind}}
-bind {{cfg.bind}}
+bind {{#each cfg.bind}}{{this}} {{/each}}
 {{~/if}}
 
 # Protected mode is a layer of security protection, in order to avoid that


### PR DESCRIPTION
The current examples of the `bind` directive show the ability to use an
array of strings, but the template implementation currently renders the
array as itself.

Using the `#each` notation, we step into the directive if there are any
values and render each out with a space delimiter.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>