### PR TITLE
use `--no-locale` with initdb

### DIFF
--- a/postgresql/hooks/init
+++ b/postgresql/hooks/init
@@ -13,6 +13,7 @@ if [[ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]]; then
   initdb -U {{cfg.initdb_superuser_name}} \
          -E {{cfg.initdb_encoding}} \
          -D {{pkg.svc_data_path}} \
-         --pwfile {{cfg.initdb_pwfile}} && \
+         --pwfile {{cfg.initdb_pwfile}} \
+         --no-locale && \
   rm {{pkg.svc_config_path}}/pwfile
 fi


### PR DESCRIPTION
We use this flag to get around locale issues on certain Linux or container flavors - without it, and without a complete set of LOCALE environment variables, initdb can fail.

Signed-off-by: Blake Irvin <blake.irvin@gmail.com>
Signed-off-by: Arash Zandi <arash.zandi@gmail.com>