### PR TITLE
Update bundler version

### DIFF
--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bundler
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.13.3
+pkg_version=1.13.7
 pkg_origin=core
 pkg_license=('bundler')
 pkg_source=nosuchfile.tar.gz

--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -4,6 +4,9 @@ pkg_version=1.13.7
 pkg_origin=core
 pkg_license=('bundler')
 pkg_source=nosuchfile.tar.gz
+pkg_description="The Ruby language dependency manager"
+pkg_upstream_url=https://bundler.io/
+
 pkg_deps=(core/glibc core/ruby)
 pkg_build_deps=(core/ruby)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
When using an older version of bundler with a Gemfile.lock that has a
bundler version, you get a warning. Let's update to the current
version and avoid that warning, shall we?

Also, we get several bugfixes according to the bundler changelog

https://github.com/bundler/bundler/blob/018f9b81948a99bead40a0f91d8384b9dd4a80f2/CHANGELOG.md

Signed-off-by: Joshua Timberman <joshua@chef.io>