### PR TITLE
Update nginx to latest stable and install modules

### DIFF
--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.10.1
+pkg_version=1.10.2
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd')
 pkg_source=https://nginx.org/download/nginx-${pkg_version}.tar.gz
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801
+pkg_shasum=1045ac4987a396e2fa5d0011daf8987b612dd2f05181b67507da68cbe7d765c2
 pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)
@@ -57,6 +57,7 @@ do_build() {
 }
 
 do_install() {
+  make install
   mkdir -p "$pkg_prefix/sbin"
   cp "$HAB_CACHE_SRC_PATH/$pkg_dirname/objs/nginx" "$pkg_prefix/sbin"
 }


### PR DESCRIPTION
Build the latest stable release, 1.10.2.

Without `make install`, we don't actually get the modules that we're
compiling dynamically. 

Signed-off-by: Joshua Timberman <joshua@chef.io>