### PR TITLE
Adds a powershell plan for powershell

### DIFF
--- a/powershell/plan.ps1
+++ b/powershell/plan.ps1
@@ -1,0 +1,34 @@
+$pkg_name="powershell"
+$pkg_origin="core"
+$pkg_version="6.0.0-alpha.14"
+$pkg_license=@("MIT")
+$pkg_upstream_url="https://msdn.microsoft.com/powershell"
+$pkg_description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets."
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_source="https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.14/powershell-$pkg_version-win7-x64.zip"
+$pkg_shasum="689e59c8a97a7f6f136104a56be397d9456d46069aa2c1121bbda421c14852f8"
+$pkg_filename="powershell-$pkg_version-win7-x64.zip"
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Unpack {
+  Expand-Archive -Path "$HAB_CACHE_SRC_PATH/$pkg_filename" -DestinationPath "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+function Invoke-Install {
+  Copy-Item . "$pkg_prefix/bin" -Recurse -Force
+}
+
+function Invoke-Check() {
+  $versionTable = ./powershell.exe -command '$PSVersionTable'
+  $passed = $false
+
+  $versionTable | % {
+    if($_.Trim().StartsWith('GitCommitId')) {
+        $passed = $_.Trim().EndsWith($pkg_version)
+    }
+  }
+
+  if(!$passed) {
+    Write-Error "Check failed to confirm powershell version as $pkg_version"
+  }
+}


### PR DESCRIPTION
*Note*: we should not upload to the depot until the target awareness is deployed.

There are two items worthy of mention here:

## This is a binary build

This is not a source build like the bash based plan. My initial attempt was to do just that. I ran into issues with both the cpp build tools and the msbuild installer. The cpp build tools essentially installs a minimal visual studio and visual studio checks that there is only one install on the machine. I then discovered that the MSBuild tools would suffice but because it is MSI based, it enforces one install per machine. Typically I would extract the binaries from the msi and then install them "manually" but it was not clear how to do that for an EXE based installer. I'm hoping this is possible but not worth the time right now.

## This installs the win7 binaries.

There are powershell core ditributions for win10, win8 and win7. Because these are .NET Core based, they could possibly be portable accross all versions. The only difference I see based on a cursory scan of the binaries is that the older versions have more files. Specifically, the older versions include api-set files that provide runtime redirection of win32 APIs. I'm not super familiar with how these work and there is not alot of documentation. I'm hoping that their existence on the newer OS is just ignored. I ran the win 7 powershell distribution on a windows 10 machine without issue but its possible there are edge cases where this might be dangerous.

Ideally we want to have one package work accross all versions. I have asked on the powershell team's gitter chat room if anyone knows if running the win7 distribution on newer OSs is dangerous. We should keep an eye on this for now.
