### PR TITLE
Remove dep on jdk8 in Tomcat8 plan

### DIFF
--- a/tomcat8/hooks/run
+++ b/tomcat8/hooks/run
@@ -4,7 +4,16 @@ exec 2>&1
 
 echo "Starting Apache Tomcat"
 
-export JAVA_HOME=$(hab pkg path core/jdk8)
+if `hab pkg path core/jdk8`; then
+  export JAVA_HOME=$(!!)
+elif `hab pkg path core/jdk7`; then
+  export JAVA_HOME=$(!!)
+fi
+if [ -z ${JAVA_HOME+x} ]; then
+  echo "Cannot start Tomcat without core/jdk8 or core/jdk7"
+  exit 1
+fi
+
 export TOMCAT_HOME="{{pkg.svc_var_path}}/tc"
 export CATALINA_OPTS="{{cfg.server.catalina-opts}}"
 

--- a/tomcat8/plan.sh
+++ b/tomcat8/plan.sh
@@ -1,18 +1,14 @@
 pkg_name=tomcat8
 pkg_description="An open source implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies."
 pkg_origin=core
-pkg_version=8.5.5
+pkg_version=8.5.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="The Apache Tomcat software is an open source implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies."
 pkg_upstream_url="http://tomcat.apache.org/"
-pkg_source=http://apache.mirrors.pair.com/tomcat/tomcat-8/v${pkg_version}/bin/apache-tomcat-${pkg_version}.tar.gz
-pkg_shasum=123ba0c010267d54caf984872d3cb449ae29bbd956fa17467185e0c2b3ecae45
-
-pkg_deps=(
-  core/jdk8
-  core/coreutils
-)
+pkg_source=http://archive.apache.org/dist/tomcat/tomcat-8/v${pkg_version}/bin/apache-tomcat-${pkg_version}.tar.gz
+pkg_shasum=d72234baa373234aa9ed78e8331ac1ce47d2e07a262dafce35d17389825bc8b7
+pkg_deps=(core/coreutils)
 pkg_expose=(8080 8443)
 
 # The default implementation extracts your tarball source file into HAB_CACHE_SRC_PATH. The


### PR DESCRIPTION
This bumps Tomcat to 8.5.9 and removes the runtime dependency on `core/jdk8`. We're removing this for two reasons:

1. Tomcat can run with either `core/jdk7` or `core/jdk8` and we don't have a concept of features or optional packages
1. We aren't sure which version of Java the consumers of the Tomcat package will be using and they'll be specifying it themselves

In the occasion where you do want to run just Tomcat and you haven't installed either the `core/jdk8` or `core/jdk7` package, the run hook will error out and prompt the user to install either.