### PR TITLE
Fixes for jruby1 and logstash2

### DIFF
--- a/jruby1/plan.sh
+++ b/jruby1/plan.sh
@@ -6,9 +6,18 @@ pkg_description="A high performance, stable, fully threaded Java implementation 
 pkg_upstream_url=https://github.com/jruby/jruby
 pkg_source=https://github.com/jruby/jruby/archive/${pkg_version}.tar.gz
 pkg_shasum=4e17872bc38cf6c0ff238a365d2046e36e3149d0d381df2198fd949902602c9c
-pkg_license=('EPL 1.0, GPL 2 and LGPL 2.1')
-pkg_deps=(core/glibc core/jre8 core/bash)
-pkg_build_deps=(core/which core/make core/jdk8 core/coreutils)
+pkg_license=('EPL 1.0' 'GPL-2.0' 'LGPL-2.1')
+pkg_deps=(
+  core/bash
+  core/coreutils
+  core/glibc
+  core/jre8
+)
+pkg_build_deps=(
+  core/jdk8
+  core/make
+  core/which
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -22,10 +31,7 @@ do_build() {
 
 do_install() {
   cp -R ./* "$pkg_prefix/"
-  for binstub in ${pkg_prefix}/bin/*; do
-    [[ -f $binstub ]] && sed -e "s#/usr/bin/env bash#$(pkg_path_for bash)/bin/bash#" -i "$binstub"
-    [[ -f $binstub ]] && sed -e "s#/usr/bin/env jruby#${pkg_prefix}/bin/jruby#" -i "$binstub"
-  done
+  fix_interpreter "$pkg_prefix/bin/*" core/coreutils bin/env
 
   # Remove *.so for other platforms...they cause `do_strip()' to fail
   # with `Unable to recognise the format' errors

--- a/logstash2/plan.sh
+++ b/logstash2/plan.sh
@@ -2,13 +2,17 @@ pkg_origin=core
 pkg_name=logstash2
 pkg_version=2.4.1
 pkg_description="Logstash is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite 'stash.'"
-pkg_upstream_url=https://github.com/elastic/logstash
+pkg_upstream_url=https://www.elastic.co/products/logstash
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=(Apache-2.0)
+pkg_license=("Apache-2.0")
 pkg_source=https://download.elastic.co/logstash/logstash/logstash-${pkg_version}.tar.gz
 pkg_shasum=957647af07e54c7d18c6e3b543030edae461d447d27412ebb7637cd7eb109f4f
-pkg_deps=(core/bash core/jre8 core/jruby1)
-pkg_build_deps=(core/bash)
+pkg_deps=(
+  core/coreutils
+  core/jre8
+  core/jruby1
+)
+pkg_build_deps=()
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_dirname=logstash-${pkg_version}
@@ -21,5 +25,5 @@ do_install() {
   mkdir -p "$pkg_prefix"
   cp -r ./* "$pkg_prefix"
   rm -rf "$pkg_prefix/vendor/jruby"
-  fix_interpreter "${pkg_prefix}/bin/*" core/bash bin/sh
+  rm -rf "$pkg_prefix/bin"/*.bat
 }


### PR DESCRIPTION
These plans both use shell scripts in their bins that require things
like `dirname`, so that `hab pkg exec core/jruby1 jruby` or `hab pkg
exec core/logstash2 logstash` would not run.

This fixes those problems, and fixes a few things up in the plans.

![gif-keyboard-12408080495236673972](https://cloud.githubusercontent.com/assets/9912/22178857/b8abde50-e008-11e6-8950-7e8ba271b45b.gif)
