### PR TITLE
Bump haproxy to 1.6.11, add status page support

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -26,3 +26,17 @@ backend default
     server {{name}} {{host_or_ip}}:{{port}}
 {{~/each}}
 {{~/if}}
+
+{{#if cfg.status_page}}
+listen  stats   
+    bind {{cfg.status_bind}}
+    mode            http
+    log             global
+    maxconn 10
+    stats enable
+    stats hide-version
+    stats refresh 30s
+    stats show-node
+    stats auth {{cfg.status_user}}:{{cfg.status_password}}
+    stats uri  {{cfg.status_uri}}
+{{~/if}}

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -3,6 +3,12 @@ mode = "http"
 bind = "*:80"
 httpchk = "GET /"
 
+status_page = false
+status_bind = "*:9000"
+status_user = "admin"
+status_password = "password"
+status_uri = "/haproxy-stats"
+
 [[server]]
 name = "first"
 host_or_ip = "172.17.0.3"

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,14 +1,14 @@
 pkg_origin=core
 pkg_name=haproxy
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=1.6.5
+pkg_version=1.6.11
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source=http://www.haproxy.org/download/1.6/src/haproxy-${pkg_version}.tar.gz
 pkg_upstream_url="http://git.haproxy.org/git/haproxy-1.6.git/"
-pkg_shasum=c4b3fb938874abbbbd52782087117cc2590263af78fdce86d64e4a11acfe85de
+pkg_shasum=62fe982edb102a9f55205792bc14b0d05745cc7993cd6bee5d73cd3c5ae16ace
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
-pkg_expose=(8080)
+pkg_expose=(80 9000)
 pkg_deps=(core/zlib core/pcre core/openssl)
 pkg_build_deps=(
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Michael Ducy <michael@chef.io>

Added in the ability to turn on the HAProxy Status page. This is useful for demos, and merging these in will allow us (Habitat people and Chefs) to demo using the core/haproxy plan and not a forked plan. 

I also bumped the version to the latest stable version of HAProxy 1.6.x.