### PR TITLE
remove -verb arg which breaks powershel core and is unnecessary on powershell full

### DIFF
--- a/7zip/plan.ps1
+++ b/7zip/plan.ps1
@@ -11,7 +11,7 @@ $pkg_filename="7z$($pkg_version.Replace('.',''))-x64.exe"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {
-  Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -Verb runas -ArgumentList "/S /D=`"$(Resolve-Path $HAB_CACHE_SRC_PATH)/$pkg_dirname`""
+  Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/S /D=`"$(Resolve-Path $HAB_CACHE_SRC_PATH)/$pkg_dirname`""
 }
 
 function Invoke-Install {


### PR DESCRIPTION


Signed-off-by: Matt Wrock <matt@mattwrock.com>