### PR TITLE
Improvements to rabbitmq plan

### DIFF
--- a/rabbitmq/config/env
+++ b/rabbitmq/config/env
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export RABBITMQ_MNESIA_BASE="{{pkg.svc_var_path}}/db"
+export RABBITMQ_CONFIG_FILE="{{pkg.svc_config_path}}/rabbitmq"
+export RABBITMQ_SCRIPTS_DIR="{{pkg.path}}/sbin"
+export RABBITMQ_ENABLED_PLUGINS_FILE="{{pkg.svc_var_path}}/enabled_plugins"
+export HOME="{{pkg.svc_var_path}}"
+export RABBITMQ_LOGS=-
+export RABBITMQ_SASL_LOGS=-

--- a/rabbitmq/default.toml
+++ b/rabbitmq/default.toml
@@ -1,9 +1,22 @@
 [rabbitmq]
+
+# Host on which to listen. An empty string means "listen on all interfaces."
 listen_host=""
+
+# Port to bind to.
 listen_port=5672
+
+# Virtual host to create when RabbitMQ creates a new database from scratch. The
+# exchange amq.rabbitmq.log will exist in this virtual host.
 default_vhost="/"
+
+# User name to create when RabbitMQ creates a new database from scratch.
 default_user="guest"
+
+# Password for the default user.
 default_pass="guest"
 
 [rabbitmq.management]
+
+# Whether to enable the rabbitmq management plugin.
 enabled=false

--- a/rabbitmq/hooks/health_check
+++ b/rabbitmq/hooks/health_check
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rabbitmqctl node_health_check > /dev/null

--- a/rabbitmq/hooks/init
+++ b/rabbitmq/hooks/init
@@ -2,18 +2,12 @@
 
 echo 2>&1
 
-export RABBITMQ_MNESIA_BASE={{pkg.svc_var_path}}/db
-export RABBITMQ_CONFIG_FILE={{pkg.svc_config_path}}/rabbitmq
-export RABBITMQ_SCRIPTS_DIR=$(hab pkg path core/rabbitmq)/sbin
-export RABBITMQ_ENABLED_PLUGINS_FILE={{pkg.svc_var_path}}/enabled_plugins
-export HOME={{pkg.svc_var_path}}
-export RABBITMQ_LOGS=-
-export RABBITMQ_SASL_LOGS=-
+source "{{pkg.svc_config_path}}/env"
 
 {{#if cfg.rabbitmq.management.enabled}}
 echo "Enabling management console"
-$(hab pkg path core/rabbitmq)/sbin/rabbitmq-plugins --offline enable rabbitmq_management
+rabbitmq-plugins --offline enable rabbitmq_management
 {{else}}
 echo "Disabling management console"
-$(hab pkg path core/rabbitmq)/sbin/rabbitmq-plugins --offline disable rabbitmq_management
+rabbitmq-plugins --offline disable rabbitmq_management
 {{/if}}

--- a/rabbitmq/hooks/run
+++ b/rabbitmq/hooks/run
@@ -1,18 +1,14 @@
 #!/bin/bash
 
+source "{{pkg.svc_config_path}}/env"
+
+# https://www.youtube.com/watch?v=wGhQ2BDt4VE
 kill_rabbit() {
-  $(hab pkg path core/rabbitmq)/sbin/rabbitmqctl stop
+  rabbitmqctl stop
   exit
 }
 
 trap "kill_rabbit" INT TERM HUP ABRT QUIT
 
-export HOME={{pkg.svc_var_path}}
-export RABBITMQ_MNESIA_BASE={{pkg.svc_var_path}}/db
-export RABBITMQ_CONFIG_FILE={{pkg.svc_config_path}}/rabbitmq
-export RABBITMQ_ENABLED_PLUGINS_FILE={{pkg.svc_var_path}}/enabled_plugins
-export RABBITMQ_LOGS=-
-export RABBITMQ_SASL_LOGS=-
-
 # We do NOT call exec here, as we trap signals and kill rabbit in this script
-{{pkg.path}}/sbin/rabbitmq-server 2>&1
+rabbitmq-server 2>&1

--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -9,12 +9,43 @@ pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source=http://www.rabbitmq.com/releases/rabbitmq-server/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz
 pkg_shasum=395689bcf57fd48aed452fcd43ff9a992de40067d3ea5c44e14680d69db7b78e
 pkg_dirname=${pkg_distname}-${pkg_version}
-pkg_deps=(core/glibc core/erlang)
-pkg_build_deps=(core/bash core/python2 core/zip core/unzip core/git core/coreutils core/make core/gcc core/erlang core/libxslt core/libxml2 core/gawk core/diffutils core/perl core/grep core/rsync)
-pkg_lib_dirs=(lib)
+pkg_deps=(
+  core/coreutils
+  core/glibc
+  core/erlang
+)
+pkg_build_deps=(
+  core/bash
+  core/diffutils
+  core/gawk
+  core/gcc
+  core/git
+  core/grep
+  core/libxml2
+  core/libxslt
+  core/make
+  core/perl
+  core/python2
+  core/rsync
+  core/unzip
+  core/zip
+)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(sbin)
 pkg_exposes=(5672)
+
+do_prepare() {
+  export PREFIX="${pkg_prefix}"
+  build_line "Setting PREFIX=$PREFIX"
+  export DESTDIR="${PREFIX}"
+  build_line "Setting DESTDIR=$DESTDIR"
+  export RMQ_ROOTDIR=""
+  build_line "Setting RMQ_ROOTDIR=$RMQ_ROOTDIR"
+  export RMQ_LIBDIR=""
+  build_line "Setting RMQ_LIBDIR=$RMQ_LIBDIR"
+  export RMQ_ERLAPP_DIR=""
+  build_line "Setting RMQ_ERLAPP_DIR=$RMQ_ERLAPP_DIR"
+}
 
 do_build() {
   make
@@ -22,13 +53,4 @@ do_build() {
 
 do_check() {
   make tests
-}
-
-do_install() {
-  export PREFIX="${pkg_prefix}"
-  export DESTDIR="${PREFIX}"
-  export RMQ_ROOTDIR=""
-  export RMQ_LIBDIR=""
-  export RMQ_ERLAPP_DIR=""
-  make install
 }


### PR DESCRIPTION
* Extract env vars set in both init and run hooks into a config/env file
* Annotate default.toml
* Add a health check
* Replace some `$(hab pkg path)`s with `{{pkg.path}}`s
* Don't reference the full path in hooks because we already have it in
  `$PATH`
* Multi-line and alphabatize the deps
* Add coreutils dep so scripts in sbin can find `dirname`
* Move env var setting to `do_prepare` so we can use the default
  `do_install`
* Remove redundant build deps that are already in deps

![gif-keyboard-6088529903160348732](https://cloud.githubusercontent.com/assets/9912/22413538/6a258a5c-e67e-11e6-8063-c3973e8ada45.gif)

