### PR TITLE
Use /bin/bash for rabbitmq hook shebangs

### DIFF
--- a/rabbitmq/config/env
+++ b/rabbitmq/config/env
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export RABBITMQ_MNESIA_BASE="{{pkg.svc_var_path}}/db"
 export RABBITMQ_CONFIG_FILE="{{pkg.svc_config_path}}/rabbitmq"

--- a/rabbitmq/hooks/health_check
+++ b/rabbitmq/hooks/health_check
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 rabbitmqctl node_health_check > /dev/null

--- a/rabbitmq/hooks/init
+++ b/rabbitmq/hooks/init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo 2>&1
 


### PR DESCRIPTION
Some operating systems that have versions like "16.04" that I'm very
angry with today happen to, by default, symlink /bin/sh to dash, which
is not bash, which makes some of these hooks fail.

Update the hooks to use /bin/bash because that's what we mean.

![gif-keyboard-9059047796215507659](https://cloud.githubusercontent.com/assets/9912/22495660/2dad36d4-e808-11e6-8154-bf4d432e36e0.gif)

