### PR TITLE
Make mysql compile

### DIFF
--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -5,7 +5,6 @@ pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0')
 pkg_source=http://dev.mysql.com/get/Downloads/MySQL-5.7/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=f7415bdac2ca8bbccd77d4f22d8a0bdd7280b065bd646a71a506b77c7a8bd169
-
 pkg_upstream_url=https://www.mysql.com/
 pkg_description=$(cat << EOF
 Starts MySQL with a basic configuration. Configurable at run time:
@@ -18,32 +17,29 @@ Starts MySQL with a basic configuration. Configurable at run time:
 Set the app_username and app_password at runtime to have that user created, it will not be otherwise.
 EOF
 )
-
 pkg_deps=(
-  core/glibc
-  core/gcc-libs
   core/coreutils
-  core/sed
   core/gawk
+  core/gcc-libs
+  core/glibc
   core/grep
-  core/pcre
-  core/procps-ng
   core/inetutils
   core/ncurses
   core/openssl
+  core/pcre
+  core/perl
+  core/procps-ng
+  core/sed
 )
-
 pkg_build_deps=(
-  core/cmake
-  core/coreutils
-  core/diffutils
-  core/patch
-  core/make
-  core/gcc
-  # -- MySQL currently requires boost_1_59_0
+  core/bison
   core/boost159
+  core/cmake
+  core/diffutils
+  core/gcc
+  core/make
+  core/patch
 )
-
 pkg_svc_user="hab"
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -51,11 +47,29 @@ pkg_lib_dirs=(lib)
 
 do_build() {
   cmake . -DLOCAL_BOOST_DIR="$(pkg_path_for core/boost159)" \
-          -DBOOST_INCLUDE_DIR="$(pkg_path_for core/boost159)"/include \
+          -DBOOST_INCLUDE_DIR="$(pkg_path_for core/boost159)/include" \
           -DWITH_BOOST="$(pkg_path_for core/boost159)" \
+          -DCURSES_INCLUDE_PATH="$(pkg_path_for core/ncurses)/include" \
+          -DCURSES_LIBRARY="$(pkg_path_for core/ncurses)/lib/libcurses.so" \
           -DWITH_SSL=yes \
-          -DCMAKE_INSTALL_PREFIX="$pkg_prefix"
+          -DOPENSSL_INCLUDE_DIR="$(hab pkg path core/openssl)/include" \
+          -DOPENSSL_LIBRARY="$(pkg_path_for core/openssl)/lib/libssl.so" \
+          -DCRYPTO_LIBRARY="$(pkg_path_for core/openssl)/lib/libcrypto.so" \
+          -DCMAKE_INSTALL_PREFIX="$pkg_prefix" \
+          -DWITH_EMBEDDED_SERVER=no \
+          -DWITH_EMBEDDED_SHARED_LIBRARY=no
   make
+}
+
+do_install() {
+  do_default_install
+
+  # Remove static libraries, tests, and other things we don't need
+  rm -rf "$pkg_prefix/docs" "$pkg_prefix/man" "$pkg_prefix/mysql-test" \
+    "$pkg_prefix"/lib/*.a
+
+  fix_interpreter "$pkg_prefix/bin/mysqld_multi" core/perl bin/perl
+  fix_interpreter "$pkg_prefix/bin/mysqldumpslow" core/perl bin/perl
 }
 
 do_check() {


### PR DESCRIPTION
Add some missing lib flags, clean up and sort dependencies, fix
interpreters, and remove a bunch of files that make the package 10x
smaller.

`hab start` will start mysql, but I haven't done much else more with it
than that, but it does indeed compile.

Fixes #197.

![gif-keyboard-14820210478140584641](https://cloud.githubusercontent.com/assets/9912/22538071/55ba9e6e-e8d5-11e6-86e4-c22e5dd3f529.gif)
