### PR TITLE
Fix doxygen build

### DIFF
--- a/doxygen/plan.sh
+++ b/doxygen/plan.sh
@@ -31,7 +31,9 @@ do_build() {
   build_line "Setting libiconv flags..."
   export CXXFLAGS="-liconv $CXXFLAGS"
   build_line "CXXFLAGS are now: $CXXFLAGS"
-  cmake -DCMAKE_INSTALL_PREFIX:PATH="$pkg_prefix" -G "Unix Makefiles" ../
+  cmake -DCMAKE_INSTALL_PREFIX:PATH="$pkg_prefix" \
+    -DICONV_INCLUDE_DIR="$(hab pkg path core/libiconv)/include" \
+    -G "Unix Makefiles" ../
   make
 }
 


### PR DESCRIPTION
Add `ICONV_INCLUDE_DIR`. Fixes #198.

![gif-keyboard-13024694539917549943](https://cloud.githubusercontent.com/assets/9912/22553453/5bbecfe0-e922-11e6-9453-6033b2b0420a.gif)