### PR TITLE
reverting long path change

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -18,10 +18,7 @@ function Invoke-Unpack {
 }
 
 function Invoke-Install {
-  # the node directory tree can lead to filepaths longer than 260 characters
-  # depending on the file system base which can cause copy errors. Prefixing with 
-  # \\?\ avoids those errors
-  Copy-Item "\\?\$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/*" "\\?\$pkg_prefix/bin" -Recurse
+  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/*" "$pkg_prefix/bin" -Recurse
 }
 
 function Invoke-Check() {


### PR DESCRIPTION
I think the change has the potential to cause more problems than it fixes and should be unnecessary on powershell core.

Signed-off-by: Matt Wrock <matt@mattwrock.com>