### PR TITLE
add a plan for composer: php package manager

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=composer
+pkg_origin=core
+pkg_version=1.3.2
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('MIT')
+pkg_upstream_url=https://getcomposer.org/
+pkg_description="Dependency Manager for PHP"
+pkg_source=https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar
+pkg_filename=${pkg_name}.phar
+pkg_shasum=6a4f761aa34bb69fca86bc411a5e9836ca8246f0fcd29f3804b174fee9fb0569
+pkg_deps=(core/php5)
+pkg_bin_dirs=(bin)
+
+do_unpack(){
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_check() {
+  "$(pkg_path_for core/php5)/bin/php" composer --version | grep -q $pkg_version
+}
+
+do_install() {
+  install -vDm755 "../$pkg_filename" "$pkg_prefix/bin/$pkg_filename"
+}


### PR DESCRIPTION
This adds a plan.sh for the PHP package manager, composer.