### PR TITLE
composer: create a wrapper that resolves php's path

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -20,9 +20,19 @@ do_build() {
 }
 
 do_check() {
-  "$(pkg_path_for core/php5)/bin/php" composer --version | grep -q $pkg_version
+  return 0 # makes no sense here…
 }
 
 do_install() {
   install -vDm755 "../$pkg_filename" "$pkg_prefix/bin/$pkg_filename"
+
+  cat<<EOF > "$pkg_prefix/bin/composer"
+#!/bin/sh
+$(pkg_path_for core/php5)/bin/php "$pkg_prefix/bin/$pkg_filename" "\$@"
+EOF
+  chmod +x "$pkg_prefix/bin/composer"
+
+  # here's our custom do_check()
+  set -eo pipefail
+  "$pkg_prefix/bin/composer" --version 2>/dev/null | grep -q $pkg_version
 }


### PR DESCRIPTION
rather than leaving this job to people who use our package, we create a
simple (build-time) wrapper that will resolve the correct path to php.
Since core/composer has a run-time dependency on core/php5, it will
always rebuild when core/php5 changes.


We also "move" do_check() at the end of do_install(). We cannot check
what we didn't do (build), so we check the end result.
n.b.: The 2>/dev/null hides the following error message from composer:

    Do not run Composer as root/super user! See https://getcomposer.org/root for details

I think it's safe for us to ignore… given that we run practically
everything as root.

Signed-off-by: Igor Galić <i.galic@brainsware.org>