### PR TITLE
composer: for installtions may need git

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -8,7 +8,7 @@ pkg_description="Dependency Manager for PHP"
 pkg_source=https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar
 pkg_filename=${pkg_name}.phar
 pkg_shasum=6a4f761aa34bb69fca86bc411a5e9836ca8246f0fcd29f3804b174fee9fb0569
-pkg_deps=(core/php5)
+pkg_deps=(core/php5 core/git)
 pkg_bin_dirs=(bin)
 
 do_unpack(){


### PR DESCRIPTION
for packages that are not pulled from [packagist](https://packagist.org/),
composer will most likely rely on git, so we should add that runtime dep.

Signed-off-by: Igor Galić <i.galic@brainsware.org>