### PR TITLE
Remove cyclic dep of gdb in python plan.

### DIFF
--- a/python/plan.sh
+++ b/python/plan.sh
@@ -25,7 +25,6 @@ pkg_build_deps=(
   core/coreutils
   core/diffutils
   core/gcc
-  core/gdb
   core/linux-headers
   core/make
   core/util-linux


### PR DESCRIPTION
I found this when calculating dependant package rebuilding today. The
Python plan had a build dependency on GDB, but GDB requires Python at
runtime for its repl integration. Removing `core/gdb` as a *build* dep
doesn't appear to adversely affect the Python package.
