### PR TITLE
Enhance run time configuration possibilities for nginx

### DIFF
--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -15,6 +15,8 @@ http {
 
     keepalive_timeout  {{cfg.http.keepalive_timeout}};
 
+    server_names_hash_bucket_size {{cfg.http.server_names_hash_bucket_size}};
+
     gzip  on;
     gzip_vary on;
     gzip_min_length 10240;
@@ -22,13 +24,20 @@ http {
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
     gzip_disable "MSIE [1-6]\.";
 
+    {{cfg.http.global_ssl_password_file}}
+
     server {
         listen       {{cfg.http.listen.port}};
         server_name  localhost;
 
         location / {
-            root   {{pkg.svc_data_path}};
+            root   {{cfg.http.www-data}};
             index  index.html index.htm;
         }
     }
+
+    {{cfg.http.include.additional_servers}}
+
 }
+
+{{cfg.include.additional_configuration_files}}

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -6,7 +6,11 @@ events {
 }
 
 http {
-    include        mime.types;
+
+    {{~#each cfg.include.additional_configuration_file}}
+    include {{config_file}};
+    {{~/each}}
+
     default_type   application/octet-stream;
 
     sendfile       {{cfg.http.sendfile}};
@@ -36,8 +40,8 @@ http {
         }
     }
 
-    {{cfg.http.include.additional_servers}}
+    {{~#if cfg.http.vhosts.additional_servers}}
+    include {{cfg.http.vhosts.enabled}}/*;
+    {{~/if}}
 
 }
-
-{{cfg.include.additional_configuration_files}}

--- a/nginx/default.toml
+++ b/nginx/default.toml
@@ -34,5 +34,17 @@ tcp_nodelay = "on"
 # http.keepalive_timeout: Timeout on client connection keepalive, in seconds. Default = 75
 keepalive_timeout = 60
 
-[http.listen]
-port = 80
+# http.server_names_hash_bucket_size: Sets the bucket size for the server names hash tables.
+# The default value depends on the size of the processor’s cache line. Default = 32
+server_names_hash_bucket_size = 64
+
+www-data = "/hab/svc/nginx/data"
+global_ssl_password_file = "# ssl_password_file /home/hab/.ssh/tls/global.pass;"
+
+
+#### Extended Configuration
+[include]
+additional_configuration_files = ""
+
+[http.include]
+additional_servers = ""

--- a/nginx/default.toml
+++ b/nginx/default.toml
@@ -19,6 +19,12 @@ worker_processes = 4
 # worker_connections: Connections per Worker Process.  Default = 1024
 worker_connections = 1024
 
+[[include.additional_configuration_file]]
+config_file = "mime.types"
+
+[[include.additional_configuration_file]]
+config_file = "win-utf"
+
 
 #### HTTP Context Configuration
 [http]
@@ -42,9 +48,10 @@ www-data = "/hab/svc/nginx/data"
 global_ssl_password_file = "# ssl_password_file /home/hab/.ssh/tls/global.pass;"
 
 
-#### Extended Configuration
-[include]
-additional_configuration_files = ""
+[http.vhosts]
+additional_servers = true
+available = "/etc/nginx/sites-available"
+enabled = "/etc/nginx/sites-enabled"
 
-[http.include]
-additional_servers = ""
+[http.listen]
+port = 80


### PR DESCRIPTION
#### Meta : 
@elliott-davis @eeyun 
This is a resubmission of PR #277.
(Unaware of the DCO rules and not having much ego in the changes, I submitted from, `yourse1f-yourorg`, an experimental account I mainly use for making tutorials.)

So, here it is again, with a few little improvements

#### Proposed changes : 

Makes root path `cfg` configurable rather than `pkg` configurable.

Adds empty template variables for :

sites-enabled
ssl_password_file
server_names_hash_bucket_size
include other configurations files

#### To do :

@miketheman, I see what you mean about the `include` list as a array table of filenames.  I'll commit that a bit later.

#### Ego :
Signed-off-by: Martin H. Bramwell <martinhbramwell@gmail.com>