### PR TITLE
add plan for php 7.1.x and make it the default php

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -8,7 +8,7 @@ pkg_description="Dependency Manager for PHP"
 pkg_source=https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar
 pkg_filename=${pkg_name}.phar
 pkg_shasum=6a4f761aa34bb69fca86bc411a5e9836ca8246f0fcd29f3804b174fee9fb0569
-pkg_deps=(core/php5 core/git)
+pkg_deps=(core/php core/git)
 pkg_bin_dirs=(bin)
 
 do_unpack(){
@@ -28,7 +28,7 @@ do_install() {
 
   cat<<EOF > "$pkg_prefix/bin/composer"
 #!/bin/sh
-$(pkg_path_for core/php5)/bin/php "$pkg_prefix/bin/$pkg_filename" "\$@"
+$(pkg_path_for core/php)/bin/php "$pkg_prefix/bin/$pkg_filename" "\$@"
 EOF
   chmod +x "$pkg_prefix/bin/composer"
 

--- a/php/plan.sh
+++ b/php/plan.sh
@@ -1,0 +1,67 @@
+pkg_name=php
+pkg_distname=php
+pkg_origin=core
+pkg_version=7.1.2
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('PHP-3.01')
+pkg_upstream_url=http://php.net/
+pkg_description="PHP is a popular general-purpose scripting language that is especially suited to web development."
+pkg_source=https://php.net/get/${pkg_distname}-${pkg_version}.tar.bz2/from/this/mirror
+pkg_filename=${pkg_distname}-${pkg_version}.tar.bz2
+pkg_dirname=${pkg_distname}-${pkg_version}
+pkg_shasum=e0f2214e2366434ee231156ba70cfefd0c59790f050d8727a3f1dc2affa67004
+pkg_deps=(
+  core/coreutils
+  core/curl
+  core/glibc
+  core/libxml2
+  core/libjpeg-turbo
+  core/libpng
+  core/openssl
+  core/zlib
+)
+pkg_build_deps=(
+  core/bison2
+  core/gcc
+  core/make
+  core/re2c
+)
+pkg_bin_dirs=(bin sbin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/php)
+
+do_build() {
+  ./configure --prefix="$pkg_prefix" \
+    --enable-exif \
+    --enable-fpm \
+    --with-fpm-user=hab \
+    --with-fpm-group=hab \
+    --enable-mbstring \
+    --enable-opcache \
+    --with-mysql=mysqlnd \
+    --with-mysqli=mysqlnd \
+    --with-pdo-mysql=mysqlnd \
+    --with-curl="$(pkg_path_for curl)" \
+    --with-gd \
+    --with-jpeg-dir="$(pkg_path_for libjpeg-turbo)" \
+    --with-libxml-dir="$(pkg_path_for libxml2)" \
+    --with-openssl="$(pkg_path_for openssl)" \
+    --with-png-dir="$(pkg_path_for libpng)" \
+    --with-xmlrpc \
+    --with-zlib="$(pkg_path_for zlib)"
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # Modify PHP-FPM config so it will be able to run out of the box. To run a real
+  # PHP-FPM application you would want to supply your own config with
+  # --fpm-config <file>.
+  mv "$pkg_prefix/etc/php-fpm.conf.default" "$pkg_prefix/etc/php-fpm.conf"
+}
+
+do_check() {
+  make test
+}


### PR DESCRIPTION
This adds a plan for the current PHP 7.1.2, and promotes it to be the
default PHP by naming it `core/php` and using it in `core/composer`

Signed-off-by: Igor Galić <i.galic@brainsware.org>