### PR TITLE
m4 is a run-time requirement for bison

### DIFF
--- a/bison2/plan.sh
+++ b/bison2/plan.sh
@@ -10,8 +10,8 @@ pkg_source=http://ftp.gnu.org/gnu/$pkg_distname/${pkg_distname}-${pkg_version}.t
 pkg_filename=${pkg_distname}-${pkg_version}.tar.xz
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_shasum=b409adcbf245baadb68d2f66accf6fdca5e282cafec1b865f4b5e963ba8ea7fb
-pkg_deps=(core/glibc)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/m4 core/perl)
+pkg_deps=(core/glibc core/m4)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/perl)
 pkg_bin_dirs=(bin)
 
 do_check() {


### PR DESCRIPTION
while working on #437, I've discovered that bison needs m4 to execute its
subscripts. Unfortunately, it's very hard to tell from the outside:

```
[36][default:/hab/cache/src/php-7.1.2:141]# make
bison -y -p ini_ -v -d /hab/cache/src/php-7.1.2/Zend/zend_ini_parser.y -o /hab/cache/src/php-7.1.2/Zend/zend_ini_parser.c
make: *** [Makefile:581: /hab/cache/src/php-7.1.2/Zend/zend_ini_parser.c] Broken pipe
```

`strace(1)` reveals, that bison is trying to `execve(2)` `m4` here.

In all other distros I checked, bison has m4 as run-time dependence:

* https://pkgs.alpinelinux.org/package/v3.5/main/x86_64/bison
* https://www.archlinux.org/packages/core/x86_64/bison/
* http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/wily/bison/wily/view/head:/debian/control#L13

Signed-off-by: Igor Galić <i.galic@brainsware.org>