### PR TITLE
Improvements to Kibana plan

### DIFF
--- a/kibana/plan.sh
+++ b/kibana/plan.sh
@@ -3,44 +3,48 @@ pkg_version=4.6.1
 pkg_origin=core
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_description="Kibana is an open source (Apache Licensed), browser based analytics and search dashboard for Elasticsearch. Kibana is a snap to setup and start using. Kibana strives to be easy to get started with, while also being flexible and powerful, just like Elasticsearch."
+pkg_description="Kibana is a browser based analytics and search dashboard for Elasticsearch."
 pkg_upstream_url=https://www.elastic.co/products/kibana
 pkg_source=https://github.com/elastic/${pkg_name}/archive/v${pkg_version}.tar.gz
 pkg_shasum=58dc3f82cdd62708034169db64c342a48674065673e2115d410509f83fe59c9e
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_deps=(core/node)
-pkg_build_deps=(core/node core/coreutils core/python2 core/make core/gcc core/git)
+pkg_build_deps=(
+  core/cacerts
+  core/coreutils
+  core/gcc
+  core/git
+  core/make
+  core/node
+  core/python2
+)
 pkg_exports=(
   [port]=server.port
 )
 pkg_exposes=(port)
-pkg_binds=(
+pkg_binds_optional=(
   [elasticsearch]="http-port"
 )
+pkg_bin_dirs=(bin)
 
 do_prepare() {
-  # The `/usr/bin/env` path is hardcoded, so we'll add a symlink if needed.
-  if [[ ! -r /usr/bin/env ]]; then
-    ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
-    _clean_env=true
-  fi
+  # Make sure git has CA certs when downloading
+  git config --global http.sslCAInfo "$(pkg_path_for cacerts)/ssl/certs/cacert.pem"
+
+  npm config set progress=false
 }
 
 do_build () {
-  git config --global http.sslVerify false
   npm install
 }
 
 do_install() {
-  cp -rv ./* "$pkg_prefix/"
-  mkdir -p "${pkg_prefix}/bin"
-# Delete the /config directory created by Kibana installer; habitat lays down /config/kibana.yml
+  cp -r ./* "$pkg_prefix/"
+  # Delete the /config directory created by Kibana installer; habitat lays down
+  # /config/kibana.yml
   rm -rv "$pkg_prefix/config/"
 }
 
-do_end() {
-  # Clean up the `env` link, if we set it up.
-  if [[ -n "$_clean_env" ]]; then
-    rm -fv /usr/bin/env
-  fi
+do_strip() {
+  return 0
 }


### PR DESCRIPTION
* Make description shorter
* Use CA certs setting for git downloads instead of verify none
* Use `pkg_binds_optional` instead of `pkg_binds` so non-habitat-hosted
  Elasticsearch works
* Remove unnecessary symlinking of /usr/bin/env
* Disable npm progress bars
* Make copying to the prefix quieter
* Disable `do_strip` because it's slow and gives no benefit

Signed-off-by: Nathan L Smith <smith@chef.io>