### PR TITLE
Add back symlinks to env

### DIFF
--- a/kibana/plan.sh
+++ b/kibana/plan.sh
@@ -28,6 +28,13 @@ pkg_binds_optional=(
 pkg_bin_dirs=(bin)
 
 do_prepare() {
+  # The `/usr/bin/env` path is hardcoded in some node modules, so we'll add a
+  # symlink if needed.
+  if [[ ! -r /usr/bin/env ]]; then
+    ln -svf "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+    _clean_env=true
+  fi
+
   # Make sure git has CA certs when downloading
   git config --global http.sslCAInfo "$(pkg_path_for cacerts)/ssl/certs/cacert.pem"
 
@@ -47,4 +54,11 @@ do_install() {
 
 do_strip() {
   return 0
+}
+
+do_end() {
+  # Clean up the `env` link, if we set it up.
+  if [[ -n "$_clean_env" ]]; then
+    rm -fv /usr/bin/env
+  fi
 }


### PR DESCRIPTION
In #445 the build didn't actually work right because turns out it really
did need /usr/bin/env. Add it back here.

Signed-off-by: Nathan L Smith <smith@chef.io>