### PR TITLE
improvements to mysql plan

### DIFF
--- a/mysql/config/init.sql
+++ b/mysql/config/init.sql
@@ -1,4 +1,4 @@
-UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N' WHERE user = 'root';
+UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N', host='127.0.0.1' WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 {{#if cfg.app_username}}

--- a/mysql/config/my.cnf
+++ b/mysql/config/my.cnf
@@ -35,7 +35,7 @@ port            = {{cfg.port}}
 basedir         = {{pkg.path}}
 datadir         = {{pkg.svc_data_path}}
 tmpdir          = /tmp
-lc-messages-dir = {{pkg.path}}/share/mysql
+lc-messages-dir = {{pkg.path}}/share/{{cfg.language}}
 explicit_defaults_for_timestamp
 
 # Instead of skip-networking the default is now to listen only on

--- a/mysql/default.toml
+++ b/mysql/default.toml
@@ -1,5 +1,6 @@
 port = 3306
 bind = "127.0.0.1"
+language = "english"
 root_password = ""
 app_username = false
 app_password = false

--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -45,6 +45,12 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+pkg_exports=(
+  [port]=port
+  [password]=app_password
+  [username]=app_username
+)
+
 do_build() {
   cmake . -DLOCAL_BOOST_DIR="$(pkg_path_for core/boost159)" \
           -DBOOST_INCLUDE_DIR="$(pkg_path_for core/boost159)/include" \


### PR DESCRIPTION
I recently needed to use the mysql plan in a docker environment with binding to other containers. Here are some changes I had to make to get that working:

* Makesure you can login as root on the container
* Error messages were not being translated and this makes language configurable defaulting to english
* Exports port and app creds

Signed-off-by: Matt Wrock <matt@mattwrock.com>