### PR TITLE
Correct the broken linking of `libpython2.7.so.1.0`

### DIFF
--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -32,7 +32,7 @@ pkg_build_deps=(
 )
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)
-pkg_include_dirs=(include)
+pkg_include_dirs=(include Include)
 pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 
 do_prepare() {


### PR DESCRIPTION
Package merged this afternoon broke linking to `libpython2.7.so.1.0`.
Local tests show this corrects the issue.


Signed-off-by: Ian Henry <ihenry@chef.io>