### PR TITLE
Fix RabbitMQ health check

### DIFF
--- a/rabbitmq/hooks/health_check
+++ b/rabbitmq/hooks/health_check
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-rabbitmqctl node_health_check > /dev/null
+export HOME="{{pkg.svc_var_path}}"
+rabbitmqctl node_health_check


### PR DESCRIPTION
It was giving
`rabbitmq.default hook[health_check]:(HK): erlexec: HOME must be set`

Set `HOME` the same way it's set in the run hook. Now that health checks return
stdout/stderr, don't need to redirect to /dev/null.

![gif-keyboard-15499788185742595728](https://cloud.githubusercontent.com/assets/9912/24986850/3e56b0fe-1fc2-11e7-8f89-cda5d27dbb39.gif)
