### PR TITLE
Add dockerd to docker plan

### DIFF
--- a/docker/plan.sh
+++ b/docker/plan.sh
@@ -17,7 +17,7 @@ do_build() {
 }
 
 do_install() {
-  for bin in docker $(ls -1 docker-*); do
+  for bin in docker dockerd $(ls -1 docker-*); do
     install -v -D "$bin" "$pkg_prefix/bin/$bin"
   done
 }


### PR DESCRIPTION
dockerd is the actual daemon. If we want to run docker containers we need that binary.

Signed-off-by: Justin Carter <justin@starkandwayne.com>