### PR TITLE
Update pg_hba.conf default template.

### DIFF
--- a/postgresql/config/pg_hba.conf
+++ b/postgresql/config/pg_hba.conf
@@ -12,14 +12,14 @@
 # Other authentication configurations taken from chef node defaults:
 ###########
 
-local   all             postgres                                ident
+local   all             {{cfg.initdb_superuser_name}}                                     ident
 local   all             all                                     ident
-host    all             all             127.0.0.1/32            md5
+host    all             all             127.0.0.1/8             md5
 host    all             all             ::1/128                 md5
 host    all             all             0.0.0.0/0               md5
-local   replication     postgres                                ident
-host    replication     postgres        127.0.0.1/32            md5
-host    replication     postgres        ::1/128                 md5
+local   replication     {{cfg.initdb_superuser_name}}                                     ident
+host    replication     {{cfg.initdb_superuser_name}}             127.0.0.1/8             md5
+host    replication     {{cfg.initdb_superuser_name}}             ::1/128                 md5
 host    replication     replication     0.0.0.0/0               md5
 host    repmgr_db       replication     0.0.0.0/0               md5
 # "local" is for Unix domain socket connections only


### PR DESCRIPTION
This updates the pg_hba.conf to use the default superuser rather than `postgres` to ensure the permissions work as expected.