### PR TITLE
Elasticsearch plan improvements

### DIFF
--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -56,11 +56,8 @@ http.port: {{cfg.network.port}}
 transport.tcp.port: {{cfg.transport.port}}
 discovery.zen.fd.ping_timeout: {{cfg.discovery.zen_fd_ping_timeout}}
 discovery.zen.ping.multicast.enabled: {{cfg.discovery.ping_multicast_enabled}}
-{{#if bind.has_elasticsearch ~}}
-discovery.zen.ping.unicast.hosts: [{{#each bind.elasticsearch.members ~}} "{{sys.ip}}", {{/each ~}}]
-{{else ~}}
-discovery.zen.ping.unicast.hosts: {{cfg.discovery.ping_unicast_hosts}}
-{{/if ~}}
+discovery.zen.ping.unicast.hosts: [{{#each svc.members ~}} "{{sys.ip}}", {{/each ~}}]
+
 discovery.zen.minimum_master_nodes: {{cfg.discovery.minimum_master_nodes}}
 
 gateway.recover_after_nodes: {{cfg.gateway.recover_after_nodes}}

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -111,7 +111,7 @@ transport:
 
 discovery.zen.fd.ping_timeout: {{cfg.discovery.zen_fd_ping_timeout}}
 discovery.zen.ping.multicast.enabled: {{cfg.discovery.ping_multicast_enabled}}
-discovery.zen.ping.unicast.hosts: [{{#each svc.members ~}} "{{sys.ip}}", {{/each ~}}]
+discovery.zen.ping.unicast.hosts: [{{#each bind.elasticsearch.members ~}} "{{sys.ip}}", {{/each ~}}]
 
 discovery.zen.minimum_master_nodes: {{cfg.discovery.minimum_master_nodes}}
 

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -1,29 +1,57 @@
 
 cluster.name: {{cfg.cluster.name}}
 
-cluster.routing.allocation.node_concurrent_recoveries: {{cfg.cluster.routing.allocation.node_concurrent_recoveries}}
-cluster.routing.allocation.node_initial_primaries_recoveries: {{cfg.cluster.routing.allocation.node_initial_primaries_recoveries}}
-cluster.routing.allocation.same_shard.host: {{cfg.cluster.routing.allocation.same_shard-host}}
+cluster.routing.rebalance.enable: {{cfg.cluster.routing.rebalance.enable}}
 
-{{~#if cfg.cluster.routing.allocation.awareness-attributes}}
-cluster.routing.allocation.awareness.attributes: {{cfg.cluster.routing.allocation.awareness-attributes}}
+cluster.info.update.interval: {{cfg.cluster.info.update.interval}}
+
+{{~#with cfg.cluster.routing.allocation}}
+cluster.routing.allocation.node_concurrent_recoveries: {{node_concurrent_recoveries}}
+cluster.routing.allocation.node_initial_primaries_recoveries: {{node_initial_primaries_recoveries}}
+cluster.routing.allocation.same_shard.host: {{same_shard-host}}
+
+{{~#if awareness.attributes}}
+cluster.routing.allocation.awareness.attributes: {{awareness.attributes}}
+{{~/if}}
+{{~#if awareness.force.zone.values}}
+cluster.routing.allocation.awareness.force.zone.values: {{awareness.force.zone.values}}
 {{~/if}}
 
-node.name: {{cfg.node.name}}
-node.max_local_storage_nodes: {{cfg.node.max_local_storage_nodes}}
+cluster.routing.allocation.allow_rebalance: {{allow_rebalance}}
+cluster.routing.allocation.cluster_concurrent_rebalance: {{cluster_concurrent_rebalance}}
 
-{{~#if cfg.node.rack_id}}
-node.rack_id: {{cfg.node.rack_id}}
+cluster.routing.allocation.balance.shard: {{balance.shard}}
+cluster.routing.allocation.balance.index: {{balance.index}}
+cluster.routing.allocation.balance.threshold: {{balance.threshold}}
+
+cluster.routing.allocation.disk.threshold_enabled: {{disk.threshold_enabled}}
+cluster.routing.allocation.disk.include_relocations: {{disk.include_relocations}}
+
+cluster.routing.allocation.disk.watermark.low: {{disk.watermark.low}}
+cluster.routing.allocation.disk.watermark.high: {{disk.watermark.high}}
+{{~/with}}
+
+
+{{~#with cfg.node}}
+node.name: {{name}}
+node.max_local_storage_nodes: {{max_local_storage_nodes}}
+
+{{~#if rack_id}}
+node.rack_id: {{rack_id}}
 {{~/if}}
-{{~#if cfg.node.zone}}
-node.zone: {{cfg.node.zone}}
+{{~#if zone}}
+node.zone: {{zone}}
 {{~/if}}
-{{~#if cfg.node.master}}
-node.master: {{cfg.node.master}}
+{{~#if master}}
+node.master: {{master}}
 {{~/if}}
-{{~#if cfg.node.data}}
-node.data: {{cfg.node.data}}
+{{~#if data}}
+node.data: {{data}}
 {{~/if}}
+{{~#if client}}
+node.client: {{client}}
+{{~/if}}
+{{~/with}}
 
 
 path.data: {{pkg.svc_data_path}}/{{cfg.path.data}}
@@ -31,13 +59,32 @@ path.logs: {{pkg.svc_var_path}}/{{cfg.path.logs}}
 path.plugins: {{pkg.svc_var_path}}/{{cfg.path.plugins}}
 path.scripts: {{pkg.svc_config_path}}/{{cfg.path.scripts}}
 
-indices.recovery.concurrent_streams: {{cfg.indices.recovery.concurrent_streams}}
-indices.recovery.concurrent_small_file_streams: {{cfg.indices.recovery.concurrent_small_file_streams}}
-indices.recovery.file_chunk_size: {{cfg.indices.recovery.file_chunk_size}}
-indices.recovery.translog_ops: {{cfg.indices.recovery.translog_ops}}
-indices.recovery.translog_size: {{cfg.indices.recovery.translog_size}}
-indices.recovery.compress: {{cfg.indices.recovery.compress}}
-indices.recovery.max_bytes_per_sec: {{cfg.indices.recovery.max_bytes_per_sec}}
+{{~#with cfg.indices}}
+indices:
+  queries.cache.size : {{queries-cache-size}}
+  {{~#with recovery}}
+  recovery:
+    concurrent_streams: {{concurrent_streams}}
+    concurrent_small_file_streams: {{concurrent_small_file_streams}}
+    file_chunk_size: {{file_chunk_size}}
+    translog_ops: {{translog_ops}}
+    translog_size: {{translog_size}}
+    compress: {{compress}}
+    max_bytes_per_sec: {{max_bytes_per_sec}}
+  {{~/with}}
+  {{~#with memory}}
+  memory:
+    index_buffer_size: {{index_buffer_size}}
+    min_index_buffer_size: {{min_index_buffer_size}}
+    max_index_buffer_size: {{max_index_buffer_size}}
+    min_shard_index_buffer_size: {{min_shard_index_buffer_size}}
+  {{~/with}}
+  {{~#with ttl}}
+  ttl:
+    interval: {{interval}}
+    bulk_size: {{bulk_size}}
+  {{~/with}}
+{{~/with}}
 
 {{~#if cfg.indices.fielddata.cache-size}}
 indices.fielddata.cache.size: {{cfg.indices.fielddata.cache-size}}
@@ -51,8 +98,71 @@ indices.breaker.request.overhead: {{cfg.indices.breaker.request-overhead}}
 
 bootstrap.mlockall: {{cfg.bootstrap.mlockall}}
 
-network.host: {{cfg.network.host}}
-http.port: {{cfg.network.port}}
+{{~#with cfg.network}}
+network:
+  host: {{host}}
+  {{~#if publish_port}}
+  publish_port: {{publish_port}}
+  {{~/if}}
+  {{~#if bind_host}}
+  bind_host: {{bind_host}}
+  {{~/if}}
+  {{~#with breaker}}
+  breaker:
+    inflight_requests.limit: {{inflight_requests-limit}}
+    inflight_requests.overhead: {{inflight_requests-overhead}}
+  {{~/with}}
+
+  {{~#with tcp}}
+  tcp:
+    no_delay: {{no_delay}}
+    keep_alive: {{keep_alive}}
+    reuse_address: {{reuse_address}}
+    {{~#if send_buffer_size}}
+    send_buffer_size: {{send_buffer_size}}
+    {{~/if}}
+    {{~#if receive_buffer_size}}
+    receive_buffer_size: {{receive_buffer_size}}
+    {{~/if}}
+  {{~/with}}
+
+{{~/with}}
+
+{{~#with cfg.http}}
+http:
+  enabled: {{enabled}}
+  port: {{port}}
+  {{~#if publish_port}}
+  publish_port: {{publish_port}}
+  {{~/if}}
+  {{~#if bind_host}}
+  bind_host: {{bind_host}}
+  {{~/if}}
+  {{~#if publish_host}}
+  publish_host: {{publish_host}}
+  {{~/if}}
+  {{~#if host}}
+  host: {{host}}
+  {{~/if}}
+  max_content_length: {{max_content_length}}
+  max_initial_line_length: {{max_initial_line_length}}
+  max_header_size: {{max_header_size}}
+  compression: {{compression}}
+  compression_level: {{compression_level}}
+  detailed_errors-enabled: {{detailed_errors-enabled}}
+  pipelining: {{pipelining}}
+  max_events: {{max_events}}
+  {{~#with cors}}
+  cors:
+    enabled: {{enabled}}
+    allow-origin: {{allow-origin}}
+    max-age: {{max-age}}
+    allow-methods: {{allow-methods}}
+    allow-headers: {{allow-headers}}
+    allow-credentials: {{allow-credentials}}
+  {{~/with}}
+
+{{~/with}}
 
 {{~#with cfg.transport}}
 transport:
@@ -109,16 +219,41 @@ transport:
   {{~/with}}
 {{~/with}}
 
-discovery.zen.fd.ping_timeout: {{cfg.discovery.zen_fd_ping_timeout}}
+
+{{~#with cfg.discovery.zen.fd}}
+discovery.zen.fd.ping_timeout: {{ping_timeout}}
+discovery.zen.fd.ping_interval: {{ping_interval}}
+discovery.zen.fd.ping_retries: {{ping_retries}}
+{{~/with}}
+
+
 discovery.zen.ping.multicast.enabled: {{cfg.discovery.ping_multicast_enabled}}
 discovery.zen.ping.unicast.hosts: [{{#each bind.elasticsearch.members ~}} "{{sys.ip}}", {{/each ~}}]
+
+{{~#with cfg.discovery.zen}}
+discovery.zen.ping_timeout: {{ping_timeout}}
+discovery.zen.join_timeout: {{join_timeout}}
+discovery.zen.publish_timeout: {{publish_timeout}}
+discovery.zen.no_master_block: {{no_master_block}}
+{{~/with}}
+
+discovery.zen.master_election.filter_client: {{cfg.discovery.zen.master_election.filter_client}}
+discovery.zen.master_election.filter_data: {{cfg.discovery.zen.master_election.filter_data}}
 
 discovery.zen.minimum_master_nodes: {{cfg.discovery.minimum_master_nodes}}
 
 gateway.recover_after_nodes: {{cfg.gateway.recover_after_nodes}}
+{{~#if cfg.gateway.recover_after_master_nodes}}
+gateway.recover_after_master_nodes: {{cfg.gateway.recover_after_master_nodes}}
+{{~/if}}
+{{~#if cfg.gateway.recover_after_data_nodes}}
+gateway.recover_after_data_nodes: {{cfg.gateway.recover_after_data_nodes}}
+{{~/if}}
+
 gateway.expected_nodes: {{cfg.gateway.expected_nodes}}
 gateway.expected_master_nodes: {{cfg.gateway.expected_master_nodes}}
 gateway.expected_data_nodes: {{cfg.gateway.expected_data_nodes}}
+
 {{~#if cfg.gateway.recover_after_time}}
 gateway.recover_after_time: {{cfg.gateway.recover_after_time}}
 {{~/if}}

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -53,7 +53,62 @@ bootstrap.mlockall: {{cfg.bootstrap.mlockall}}
 
 network.host: {{cfg.network.host}}
 http.port: {{cfg.network.port}}
-transport.tcp.port: {{cfg.transport.port}}
+
+{{~#with cfg.transport}}
+transport:
+  {{~#if host}}
+  host: {{host}}
+  {{~/if}}
+  {{~#if bind_host}}
+  bind_host: {{bind_host}}
+  {{~/if}}
+  {{~#if publish_host}}
+  publish_host: {{publish_host}}
+  {{~/if}}
+  {{~#if ping_schedule}}
+  ping_schedule: {{ping_schedule}}
+  {{~/if}}
+
+  {{~#with tcp}}
+  tcp:
+    port: {{port}}
+    {{~#if connect_timeout}}
+    connect_timeout: {{connect_timeout}}
+    {{~/if}}
+    {{~#if compress}}
+    compress: {{compress}}
+    {{~/if}}
+  {{~/with}}
+  {{~#with profiles}}
+  profiles:
+    {{~#each this }}
+    {{@key}}:
+      port: {{port}}
+      {{~#if bind_host}}
+      bind_host: {{bind_host}}
+      {{~/if}}
+      {{~#if publish_host }}
+      publish_host: {{publish_host}}
+      {{~/if}}
+      {{~#if tcp_no_delay}}
+      tcp_no_delay: {{tcp_no_delay}}
+      {{~/if}}
+      {{~#if tcp_keep_alive }}
+      tcp_keep_alive: {{tcp_keep_alive}}
+      {{~/if}}
+      {{~#if reuse_address }}
+      reuse_address: {{reuse_address}}
+      {{~/if}}
+      {{~#if tcp_send_buffer_size }}
+      tcp_send_buffer_size: {{tcp_send_buffer_size}}
+      {{~/if}}
+      {{~#if tcp_receive_buffer_size }}
+      tcp_receive_buffer_size: {{tcp_receive_buffer_size}}
+      {{~/if}}
+    {{~/each }}
+  {{~/with}}
+{{~/with}}
+
 discovery.zen.fd.ping_timeout: {{cfg.discovery.zen_fd_ping_timeout}}
 discovery.zen.ping.multicast.enabled: {{cfg.discovery.ping_multicast_enabled}}
 discovery.zen.ping.unicast.hosts: [{{#each svc.members ~}} "{{sys.ip}}", {{/each ~}}]

--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -165,7 +165,21 @@
   # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
 
 [transport]
-  port = 9300
+# host =
+# bind_host =
+# publish_host =
+# ping_schedule =
+
+[transport.tcp]
+port = "9300-9400"
+# connect_timeout = "30s"
+# compress = false
+
+#[transport.profiles]
+#[transport.profiles.default]
+#port = "9300-9400"
+#bind_host = "10.0.0.1"
+
 
 #
 # --------------------------------- Discovery ----------------------------------

--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -48,7 +48,7 @@
 [node]
   # Use a descriptive name for the node:
   #
-  name = ""
+  name = "${HOSTNAME}"
   #
   # Add custom attributes to the node:
   #
@@ -175,7 +175,6 @@
   # The default list of hosts is ["127.0.0.1", "[::1]"]
   #
   ping_multicast_enabled = "false"
-  ping_unicast_hosts = "[]"
   #
   # Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
   #

--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -38,10 +38,34 @@
     # setting only applies if multiple nodes are started on the same machine.
     #
     same_shard-host = "false"
+
+    allow_rebalance = "indices_all_active"
+    cluster_concurrent_rebalance = 2
+
+  [cluster.routing.allocation.awareness]
     #
     # https://www.elastic.co/guide/en/elasticsearch/reference/2.3/allocation-awareness.html
     #
-    awareness-attributes = ""
+    attributes = ""
+  [cluster.routing.allocation.awareness.force.zone]
+    # values = ""
+
+  [cluster.routing.allocation.balance]
+    shard = "0.45f"
+    index = "0.55f"
+    threshold = "1.0f"
+  [cluster.routing.allocation.disk]
+    threshold_enabled = true
+    include_relocations = true
+  [cluster.routing.allocation.disk.watermark]
+    low = "85%"
+    high = "90%"
+  [cluster.routing.rebalance]
+    enable = "all"
+  [cluster.info.update]
+    interval = "30s"
+
+
 #
 # ------------------------------------ Node ------------------------------------
 #
@@ -67,6 +91,7 @@
   #
   master = "true"
   data   = "true"
+  #client = "true"
 
 #
 # ----------------------------------- Paths ------------------------------------
@@ -93,6 +118,7 @@
 # ----------------------------------- Indices ----------------------------------
 #
 [indices]
+  queries-cache-size = "10%"
   [indices.recovery]
     concurrent_streams =            "3"
     concurrent_small_file_streams = "2"
@@ -132,6 +158,14 @@
     # final estimation. Defaults to 1.
     #
     request-overhead =               "1"
+  [indices.memory]
+    index_buffer_size = "10%"
+    min_index_buffer_size = "48mb"
+    max_index_buffer_size = ""
+    min_shard_index_buffer_size = "4mb"
+  [indices.ttl]
+    interval = "60s"
+		bulk_size = 10000
 
 #
 # ----------------------------------- Memory -----------------------------------
@@ -156,11 +190,46 @@
   # Set the bind address to a specific IP (IPv4 or IPv6):
   #
   host =  "_site_"
-  #
+  # bind_host =
+  # publish_host =
+  [network.breaker]
+  inflight_requests-limit = "100%"
+  inflight_requests-overhead = 1
+
+	[network.tcp]
+ 	no_delay = true
+	keep_alive = true
+	reuse_address = true
+	# send_buffer_size =
+	# receive_buffer_size =
+
+[http]
   # Set a custom port for HTTP:
   #
+  enabled = true
   port = 9200
-  #
+  # publish_port =
+  # bind_host =
+  # publish_host =
+  # host =
+  max_content_length = "100mb"
+  max_initial_line_length = "4kb"
+  max_header_size = "8kB"
+  compression = false
+  compression_level = 6
+  detailed_errors-enabled = true
+  pipelining = true
+  max_events = 10000
+  [http.cors]
+  enabled = false
+  allow-origin = ""
+  max-age = 1728000
+  allow-methods = "OPTIONS, HEAD, GET, POST, PUT, DELETE"
+  allow-headers = "X-Requested-With, Content-Type, Content-Length"
+  allow-credentials = false
+
+
+
   # For more information, see the documentation at:
   # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
 
@@ -197,7 +266,20 @@ port = "9300-9400"
   # For more information, see the documentation at:
   # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
   #
-  zen_fd_ping_timeout = "30s"
+  [discovery.zen]
+    ping_timeout = "3s"
+    join_timeout = "60s"
+    publish_timeout = "30s"
+    no_master_block = "write"
+  [discovery.zen.fd]
+    ping_timeout = "30s"
+    ping_interval = "1s"
+    ping_retries = 3
+
+  [discovery.zen.master_election]
+    filter_client = true
+    filter_data = false
+
 
 #
 # ---------------------------------- Gateway -----------------------------------
@@ -207,6 +289,9 @@ port = "9300-9400"
   # Block initial recovery after a full cluster restart until N nodes are started:
   #
   recover_after_nodes   = ""
+  #recover_after_master_nodes = ""
+  #recover_after_data_nodes = ""
+
   #
   # The number of (data or master) nodes that are expected to be in the cluster.
   # Recovery of local shards will start as soon as the expected number of nodes

--- a/elasticsearch/hooks/health_check
+++ b/elasticsearch/hooks/health_check
@@ -2,7 +2,7 @@
 #
 # Elasticsearch Health Check for Habitat
 
-status="$(wget -qO - "{{svc.me.sys.ip}}:{{svc.me.cfg.http-port}}/_cat/health")"
+status="$(wget -qO - "{{svc.me.sys.ip}}:{{svc.me.cfg.http.port}}/_cat/health")"
 color="$(echo "$status" | awk '{print $4}')"
 
 case $color in

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -18,7 +18,10 @@ pkg_exports=(
   [http-port]=network.port
   [transport-port]=transport.port
 )
-pkg_exposes=(http-port transport-port)
+
+pkg_binds=(
+  [elasticsearch]=""
+)
 
 do_build() {
   return 0


### PR DESCRIPTION
Use the svc object to configure multi-nodes config setup for elasticsearch.
Use the default value for node name for elasticsearch (nodes take the name of
the host).
