### PR TITLE
Improvements to httpd

### DIFF
--- a/httpd/config/httpd.conf
+++ b/httpd/config/httpd.conf
@@ -193,7 +193,7 @@ DocumentRoot "{{pkg.svc_data_path}}/htdocs"
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "{{pkg.svc_var_path}}/logs/error_log"
+ErrorLog "|$cat"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -222,7 +222,7 @@ LogLevel warn
     # define per-<VirtualHost> access logfiles, transactions will be
     # logged therein and *not* in this file.
     #
-    CustomLog "{{pkg.svc_var_path}}/logs/access_log" common
+    CustomLog "|$cat" common
 
     #
     # If you prefer a logfile with access, agent, and referer information
@@ -503,7 +503,7 @@ LoadModule mpm_{{cfg.mpm.type}}_module modules/mod_mpm_{{cfg.mpm.type}}.so
 # Note that this is the default PidFile for most MPMs.
 #
 <IfModule !mpm_netware_module>
-    PidFile "logs/httpd.pid"
+    PidFile "{{pkg.svc_var_path}}/httpd.pid"
 </IfModule>
 
 # prefork MPM

--- a/httpd/hooks/init
+++ b/httpd/hooks/init
@@ -4,3 +4,6 @@
 mkdir -p {{pkg.svc_data_path}}/htdocs
 mkdir -p {{pkg.svc_data_path}}/cgi-bin
 mkdir -p {{pkg.svc_var_path}}/logs
+
+# We need to change permissions on reconfigure, but also on init.
+source "{{pkg.svc_path}}/hooks/reconfigure"

--- a/httpd/hooks/reconfigure
+++ b/httpd/hooks/reconfigure
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# httpd starts as root but then drops privileges to the "hab" user. This makes
+# it so the server doesn't have to run as root the whole time and is the
+# correct behavior. However, this means that all of the `pkg_svc_*` paths will
+# get changed to root:root mode 0700 after every reconfigure. This script will
+# make sure things get changed to being owned by hab:hab whenver that happens.
+chown -R hab:hab "{{pkg.svc_config_path}}" \
+  "{{pkg.svc_data_path}}" \
+  "{{pkg.svc_files_path}}" \
+  "{{pkg.svc_static_path}}" \
+  "{{pkg.svc_var_path}}"

--- a/httpd/hooks/reload
+++ b/httpd/hooks/reload
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Kill with a USR1 signal on reload rather than restarting
+kill -USR1 "$(cat "{{pkg.svc_var_path}}/httpd.pid")"


### PR DESCRIPTION
* Log access log and error log to stdout
* Fix location of pid file to be in svc_var_path
* Add a reconfigure hook to fix permissions back to hab on reconfigure
  and init
* Add a reload hook to kill with USR1 and gracefully reload rather than
  doing a full restart.

Note that doing a reconfigure (via `hab config apply` or otherwise) in a
studio will still cause you to log out. This does nothing to change that
but doesn't make it any worse. See habitat-sh/habitat#2153.

![tenor-132707241](https://cloud.githubusercontent.com/assets/9912/25647538/846717c0-2f88-11e7-8fd6-4ee29f580fd7.gif)
