### PR TITLE
[ci] Drop required variable check for pkg_source & pkg_version.

### DIFF
--- a/bin/check-default-variables.sh
+++ b/bin/check-default-variables.sh
@@ -12,9 +12,7 @@ required_variables=(
   pkg_maintainer
   pkg_name
   pkg_origin
-  pkg_source
   pkg_upstream_url
-  pkg_version
 )
 
 for var in "${required_variables[@]}"


### PR DESCRIPTION
* A required `$pkg_source` was dropped in habitat-sh/habitat#2074 which
affects Scaffolding package Plans where the code is located with the
Plan.
* A require `$pkg_version` was dropped in habitat-sh/habitat#2235 which
will affect the cacerts and cargo-nightly Plans once updated to use the
new `pkg_version()` helper.

![gif-keyboard-11946055264264368072](https://cloud.githubusercontent.com/assets/261548/25763642/53f5cbd4-31a1-11e7-9631-ef39bd6ce967.gif)
