### PR TITLE
OCaml toolchain

### DIFF
--- a/camlp4/plan.sh
+++ b/camlp4/plan.sh
@@ -1,0 +1,23 @@
+pkg_name=camlp4
+pkg_origin=core
+pkg_version="4.04"
+pkg_description="Camlp4 is a software system for writing extensible parsers for programming languages. It provides a set of OCaml libraries that are used to define grammars as well as loadable syntax extensions of such grammars."
+pkg_upstream_url="https://github.com/ocaml/camlp4"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL-2.0')
+pkg_source="https://github.com/ocaml/camlp4/archive/${pkg_version}+1.tar.gz"
+pkg_dirname="${pkg_name}-${pkg_version}-1"
+pkg_shasum="6044f24a44053684d1260f19387e59359f59b0605cdbf7295e1de42783e48ff1"
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/which core/ocamlbuild core/ocaml core/make core/gcc)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  ./configure --bindir="${pkg_prefix}/bin" --libdir="${pkg_prefix}/lib" --pkgdir="${pkg_prefix}"
+  make all
+}
+
+do_strip() {
+  return 0
+}

--- a/camlp4/plan.sh
+++ b/camlp4/plan.sh
@@ -8,8 +8,17 @@ pkg_license=('LGPL-2.0')
 pkg_source="https://github.com/ocaml/camlp4/archive/${pkg_version}+1.tar.gz"
 pkg_dirname="${pkg_name}-${pkg_version}-1"
 pkg_shasum="6044f24a44053684d1260f19387e59359f59b0605cdbf7295e1de42783e48ff1"
-pkg_deps=(core/glibc)
-pkg_build_deps=(core/which core/ocamlbuild core/ocaml core/make core/gcc)
+pkg_deps=(
+  core/coreutils
+  core/glibc
+  core/ocaml
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/ocamlbuild
+  core/which
+)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 

--- a/ocaml/plan.sh
+++ b/ocaml/plan.sh
@@ -1,0 +1,25 @@
+pkg_name=ocaml
+pkg_origin=core
+pkg_version="4.04.0"
+pkg_description="The OCAML compiler"
+pkg_upstream_url="https://ocaml.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL-2.0')
+pkg_source="https://github.com/ocaml/ocaml/archive/${pkg_version}.tar.gz"
+pkg_shasum="03e49d09d5a509216ca0cc8fccd10df3ad9dd441d7633e89974a74e149be3c51"
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/make core/gcc)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  ./configure --prefix "${pkg_prefix}" -no-graph && make world.opt
+}
+
+do_check() {
+  make bootstrap
+}
+
+do_strip() {
+  return 0
+}

--- a/ocamlbuild/plan.sh
+++ b/ocamlbuild/plan.sh
@@ -1,0 +1,16 @@
+pkg_name=ocamlbuild
+pkg_origin=core
+pkg_version="0.11.0"
+pkg_description="OCamlbuild is a generic build tool, that has built-in rules for building OCaml library and programs."
+pkg_upstream_url="https://github.com/ocaml/ocamlbuild"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL')
+pkg_source="https://github.com/ocaml/ocamlbuild/archive/${pkg_version}.tar.gz"
+pkg_shasum="1717edc841c9b98072e410f1b0bc8b84444b4b35ed3b4949ce2bec17c60103ee"
+pkg_deps=(core/glibc core/ocaml core/make core/gcc)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  make configure OCAMLBUILD_PREFIX="${pkg_prefix}" OCAMLBUILD_BINDIR="${pkg_prefix}/bin" OCAMLBUILD_LIBDIR="${pkg_prefix}/lib"
+  make
+}

--- a/ocamlbuild/plan.sh
+++ b/ocamlbuild/plan.sh
@@ -7,8 +7,16 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL')
 pkg_source="https://github.com/ocaml/ocamlbuild/archive/${pkg_version}.tar.gz"
 pkg_shasum="1717edc841c9b98072e410f1b0bc8b84444b4b35ed3b4949ce2bec17c60103ee"
-pkg_deps=(core/glibc core/ocaml core/make core/gcc)
-pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/glibc
+  core/ocaml
+  core/coreutils
+  core/ncurses
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
 
 do_build() {
   make configure OCAMLBUILD_PREFIX="${pkg_prefix}" OCAMLBUILD_BINDIR="${pkg_prefix}/bin" OCAMLBUILD_LIBDIR="${pkg_prefix}/lib"

--- a/opam/plan.sh
+++ b/opam/plan.sh
@@ -1,0 +1,37 @@
+pkg_name=opam
+pkg_origin=core
+pkg_description="opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow."
+pkg_upstream_url="https://opam.ocaml.org/"
+pkg_version="1.2.2"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('LGPL')
+pkg_source="https://github.com/ocaml/opam/releases/download/${pkg_version}/opam-full-${pkg_version}.tar.gz"
+pkg_shasum="15e617179251041f4bf3910257bbb8398db987d863dd3cfc288bdd958de58f00"
+pkg_dirname="opam-full-${pkg_version}"
+pkg_deps=(
+  core/camlp4
+  core/diffutils
+  core/gcc
+  core/git
+  core/glibc
+  core/m4
+  core/make
+  core/patch
+  core/pkg-config
+  core/rsync
+  core/ocaml
+  core/ocamlbuild
+  core/which
+)
+
+pkg_bin_dirs=(bin)
+
+do_build() {
+  ./configure --prefix "${pkg_prefix}"
+  make lib-ext
+  make
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
This PR adds the following packages:
- ocaml - the OCaml compiler and runtime
- ocamlbuild - build tool for OCaml projects (previously part of OCaml, now split out)
- camlp4 - language parser, sometimes used by deps in compilation step
- opam - package manager for installing deps

With these packages in place it is possible to build OCaml projects in the habitat world.

