### PR TITLE
[scaffolding-ruby] Allow Plan hash values & default.toml data to win.

### DIFF
--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"
 pkg_upstream_url="https://github.com/habitat-sh/core-plans"
-pkg_deps=(core/bundler core/ruby core/tar core/busybox-static core/gcc core/make core/pkg-config)
+pkg_deps=(core/bundler core/ruby core/tar core/busybox-static core/rq core/gcc core/make core/pkg-config)
 pkg_build_deps=(core/coreutils core/sed)
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
This is PR in 2 parts:

## [scaffolding-ruby] Only set hash entries if not already set.

This change changes how some Scaffolding data is set when it is in an
associative array. For `scaffolding_env`, `scaffolding_process_bins`,
`pkg_binds`, and `pkg_exports` a key is first checked to see if there is
already a value (which would have been set in a Plan) and a value will
be set only if there is no current value set.

## [scaffolding-ruby] Attempt to only add default.toml data if not set in Plan.

This change attempts to allow a Plan author to write configuration in
their `default.toml` file which will not be overridden by the
Scaffolding code. Before a Scaffolding default entry is added, the
Plan's `default.toml` is checked first to see if a key exists there. If
no key exists, the Scaffolding default is added and otherwise it is not.
This should allow a Plan to always win with their configuration data.
