### PR TITLE
Add `pkg_bin_dirs` to ocamlbuild

### DIFF
--- a/ocamlbuild/plan.sh
+++ b/ocamlbuild/plan.sh
@@ -17,6 +17,7 @@ pkg_build_deps=(
   core/gcc
   core/make
 )
+pkg_bin_dirs=(bin)
 
 do_build() {
   make configure OCAMLBUILD_PREFIX="${pkg_prefix}" OCAMLBUILD_BINDIR="${pkg_prefix}/bin" OCAMLBUILD_LIBDIR="${pkg_prefix}/lib"


### PR DESCRIPTION
This was missing.

![tenor-91654935](https://cloud.githubusercontent.com/assets/9912/26018138/bd88bfd4-3732-11e7-9deb-5261307ee768.gif)

When this is uploaded, the camlp4 and opam packages from #502 can be uploaded.