### PR TITLE
[glibc] Fix regression due to linting in #475.

### DIFF
--- a/glibc/plan.sh
+++ b/glibc/plan.sh
@@ -254,8 +254,8 @@ do_install() {
     #
     # Thanks to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L25-L32
     pushd "$pkg_prefix/include" > /dev/null
-      # shellcheck disable=SC2010
-      ln -sv "$(ls -d "$(pkg_path_for linux-headers)/include"/* | grep -v 'scsi$')" .
+      # shellcheck disable=SC2010,SC2046
+      ln -sv $(ls -d $(pkg_path_for linux-headers)/include/* | grep -v 'scsi$') .
     popd > /dev/null
 
     mkdir -pv "$pkg_prefix/lib/locale"


### PR DESCRIPTION
(Editor's note) sometimes I really dislike fixing Plan code because
shellcheck has an issue with it--the Plans are guarenteed to run under
GNU Bash 4.x and thus Plans don't fall prey to common shell coding
issues. This was another example of a carefully made lint fix that
resulted in a broken package which took many downstream dependencies to
find. Thankfully, this is only the frustration of someone who needs to
build **all** Plans which include the most complex cases. My hope is
that almost everyone else never has to worry about these details--we do
this in service of the greater good.(/Editor's note)

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>