### PR TITLE
Add wal-e to core plans

### DIFF
--- a/envdir/plan.sh
+++ b/envdir/plan.sh
@@ -1,0 +1,37 @@
+pkg_name=envdir
+pkg_version=0.7.0
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('MIT')
+pkg_description="Envdir runs another program with a modified environment according to files in a specified directory."
+pkg_upstream_url="https://github.com/jezdez/envdir"
+pkg_source=https://github.com/jezdez/envdir/archive/${pkg_version}.tar.gz
+pkg_deps=(core/python/3.5.2)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  pyvenv "$pkg_prefix"
+  source "$pkg_prefix/bin/activate"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  pip install "$pkg_name==$pkg_version"
+  # Write out versions of all pip packages to package
+  pip freeze > "$pkg_prefix/requirements.txt"
+}

--- a/wal-e/default.toml
+++ b/wal-e/default.toml
@@ -1,0 +1,11 @@
+backup_interval = 86400
+
+wale_s3_prefix = ''
+aws_access_key_id = ''
+aws_secret_access_key = ''
+aws_region = ''
+
+[pg]
+data_dir = ''
+superuser_name = 'admin'
+superuser_password = 'admin'

--- a/wal-e/hooks/run
+++ b/wal-e/hooks/run
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+exec 2>&1
+
+mkdir -p "{{pkg.svc_config_path}}/env"
+
+export PATH=$PATH:$(dirname $(find /hab/pkgs -name 'psql' | head -n 1))
+
+write_env_var() {
+  echo "$1" > "{{pkg.svc_config_path}}/env/$2"
+}
+
+write_env_var '{{cfg.wale_s3_prefix}}' 'WALE_S3_PREFIX'
+write_env_var '{{cfg.aws_access_key_id}}' 'AWS_ACCESS_KEY_ID'
+write_env_var '{{cfg.aws_secret_access_key}}' 'AWS_SECRET_ACCESS_KEY'
+write_env_var '{{cfg.aws_region}}' 'AWS_REGION'
+write_env_var '{{cfg.pg.superuser_name}}' 'PGUSER'
+write_env_var '{{cfg.pg.superuser_password}}' 'PGPASSWORD'
+write_env_var 'postgres' 'PGDATABASE'
+
+while true; do
+{{ #if cfg.pg.data_dir }}
+  envdir {{pkg.svc_config_path}}/env wal-e backup-push {{cfg.pg.data_dir}}
+{{/if}}
+  sleep {{cfg.backup_interval}}
+done

--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -1,0 +1,38 @@
+pkg_name=wal-e
+pkg_version=1.0.2
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('wal-e license')
+pkg_description="Continuous Archiving for Postgres"
+pkg_upstream_url="https://github.com/wal-e/wal-e"
+pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
+pkg_shasum=f3bd4171917656fef3829c9d993684d26c86eef0038ac3da7f12bae9122c6fc3
+pkg_deps=(core/envdir core/lzop core/pv core/postgresql core/python/3.5.2)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  pyvenv "$pkg_prefix"
+  source "$pkg_prefix/bin/activate"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  pip install "wal-e[aws]==$pkg_version"
+  # Write out versions of all pip packages to package
+  pip freeze > "$pkg_prefix/requirements.txt"
+}


### PR DESCRIPTION
wal-e is typically used in combination with postgresql to support backups and continuous archiving to various cloud object stores.

Signed-off-by: Justin Carter <justin@starkandwayne.com>