### PR TITLE
Add kubectl plan

### DIFF
--- a/kubectl/default.toml
+++ b/kubectl/default.toml
@@ -1,0 +1,3 @@
+# Use this file to templatize your application's native configuration files.
+# See the docs at https://www.habitat.sh/docs/create-packages-configure/.
+# You can safely delete this file if you don't need it.

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -1,0 +1,60 @@
+pkg_name=kubectl
+pkg_origin=core
+pkg_license=('Apache 2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="1.6.3"
+pkg_source="https://storage.googleapis.com/kubernetes-release/release/v${pkg_version}/bin/linux/amd64/kubectl"
+pkg_shasum="2e9872fe2409deee257434a8c45976a4e1cc3f2e4e2a972fd85e86127a1f7cbd"
+pkg_build_deps=(core/curl)
+pkg_bin_dirs=(bin)
+
+do_begin() {
+  return 0
+}
+
+do_download() {
+    mkdir -p $HAB_CACHE_SRC_PATH/${pkg_dirname}
+
+    cd $HAB_CACHE_SRC_PATH/${pkg_dirname}
+    
+    curl -o ${pkg_dirname} -s ${pkg_source}
+}
+
+do_verify(){
+  return 0
+}
+
+do_clean(){
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_check() {
+  return 0
+}
+
+do_install() {
+  mkdir -p ${pkg_prefix}/bin
+  cp ${HAB_CACHE_SRC_PATH}/${pkg_dirname}/${pkg_dirname} ${pkg_prefix}/bin/${pkg_name}
+  chmod 0755 ${pkg_prefix}/bin/${pkg_name}
+}
+
+do_strip() {
+  return 0
+}
+
+do_end() {
+  return 0
+}
+

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -7,17 +7,18 @@ pkg_source="https://storage.googleapis.com/kubernetes-release/release/v${pkg_ver
 pkg_shasum="2e9872fe2409deee257434a8c45976a4e1cc3f2e4e2a972fd85e86127a1f7cbd"
 pkg_build_deps=(core/curl)
 pkg_bin_dirs=(bin)
+pkg_upstream="https://kubernetes.io/docs/tasks/tools/install-kubectl/"
 
 do_begin() {
   return 0
 }
 
 do_download() {
-    mkdir -p $HAB_CACHE_SRC_PATH/${pkg_dirname}
+    mkdir -p "$HAB_CACHE_SRC_PATH/${pkg_dirname}"
 
-    cd $HAB_CACHE_SRC_PATH/${pkg_dirname}
+    cd "$HAB_CACHE_SRC_PATH/${pkg_dirname}"
     
-    curl -o ${pkg_dirname} -s ${pkg_source}
+    curl -o "${pkg_dirname}" -s "${pkg_source}"
 }
 
 do_verify(){
@@ -45,9 +46,9 @@ do_check() {
 }
 
 do_install() {
-  mkdir -p ${pkg_prefix}/bin
-  cp ${HAB_CACHE_SRC_PATH}/${pkg_dirname}/${pkg_dirname} ${pkg_prefix}/bin/${pkg_name}
-  chmod 0755 ${pkg_prefix}/bin/${pkg_name}
+  mkdir -p "${pkg_prefix}/bin"
+  cp "${HAB_CACHE_SRC_PATH}/${pkg_dirname}/${pkg_dirname}" "${pkg_prefix}/bin/${pkg_name}"
+  chmod 0755 "${pkg_prefix}/bin/${pkg_name}"
 }
 
 do_strip() {
@@ -57,4 +58,3 @@ do_strip() {
 do_end() {
   return 0
 }
-


### PR DESCRIPTION
Add kubectl plan. This is the main tool to interact with Kubernetes from the CLI. The source is in the main repo for all of Kubernetes so it is easier to use the precompiled static binary Kubernetes provides.

Signed-off-by: Michael Ducy <michael@chef.io>