### PR TITLE
[s-ruby] Support external database connection via optional bind.

### DIFF
--- a/scaffolding-ruby/doc/reference.md
+++ b/scaffolding-ruby/doc/reference.md
@@ -457,19 +457,21 @@ Your app's use of a [PostgreSQL][] database is detected by inspecting the `Gemfi
 
 ### Default App Environment Variables
 
-* `DATABASE_URL`: `postgres://{{cfg.db.user}}:{{cfg.db.password}}@{{bind.database.first.sys.ip}}:{{bind.database.first.cfg.port}}/{{cfg.db.name}}`
+* `DATABASE_URL`: `postgres://$user:$password@$host:$port/$name`
 
-**Note:** Currently PostgreSQL service groups running in the `leader` topology are not supported but future work will enable this more powerful mode.
+Where `$user`, `$password`, `$host`, `$port`, and `$name` will be determined at runtime.
 
 ### Default Config Settings
 
 * `db.name`: The database name on the database server for this app. Defaults to the value of `"${pkg_name}_production"`.
 * `db.user`: The connecting database user for this app. Defaults to the value of `"$pkg_name"`.
 * `db.password`: The connecting database password for this app. Defaults to the value of `"${pkg_name}"`. It is **strongly** recommended to use a different, randomly generated password when running your app in production.
+* `db.host`: (Only when bind is not used) The hostname/IP address of the database. There is no default.
+* `db.port`: (Only when bind is not used) The listen port of the database. The default will be `5432` if no value is provided.
 
 ### Default Service Bindings
 
-If a database requirement is detected, a **required** binding called `database` will be generated which requires the `port` configuration. This allows your app to [dynamically bind][12factor_backing_services] to the desired database service group at runtime.
+If a database requirement is detected, an **optional** binding called `database` will be generated which requires the `port` configuration. This allows your app to [dynamically bind][12factor_backing_services] to the desired database service group at runtime.
 
 * `pkg_binds[database]="port"`
 
@@ -483,6 +485,7 @@ Where `<SERVICE_GROUP>` is a service group running PostgreSQL exporting the `por
 hab start acmecorp/my_app --bind database:postgresql.default
 ```
 
+If your database is not currently running in a Habitat ring under a Supervisor, you may omit adding the `--bind database:...` option when loading and/or starting your app service. This means that you must provide at least one additional config setting: `db.host` (as explained above).
 
 [12factor_backing_services]: https://12factor.net/https://12factor.net/backing-services
 [12factor_build]: https://12factor.net/build-release-run


### PR DESCRIPTION
This change slightly alters the auto-generated service binding when
build a Ruby-based app when a PostgreSQL database requirement is
detected. Before this change a **required** binding was generated,
meaning that the PostgreSQL instance had to be running in joined Habitat
ring under a Supervisor.

Running the database under Habitat and allowing your app service to
detect and connect remains exactly the same (by adding the `--bind
database:<service_group>` option when loading and/or starting the app).

However, if your database is currently running external to a Habitat
ring, or if your database is being managed by a cloud provider (such as
RDS with Amazon Web Services), then you must provide 2 additional config
settings:

* `db.host`: The database hostname. There is no valid default.
* `db.port`: The database port. It defaults to `5432`.

It is hoped that allowing an optional database bind will provide an even
easier way to experiment with Habitat in a mixed or transitional
environment, or those where the database remains outside the control of
the application developers.

![gif-keyboard-16858093021929083979](https://cloud.githubusercontent.com/assets/261548/26225884/a139f7e0-3be6-11e7-8c56-09261f179df0.gif)
