### PR TITLE
Updated dotnet-core plans for newer versions.

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,15 +1,15 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="1.0.1"
+$pkg_version="1.0.4"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/F/D/5/FD52A2F7-65B6-4912-AEDD-4015DF6D8D22/dotnet-1.1.1-sdk-win-x64.zip"
-$pkg_shasum="e729afcf3cc69f17ec7968468b399c843b8b8327523e62c03450e4653115cf76"
-$pkg_filename="dotnet-1.1.1-sdk-win-x64.zip"
+$pkg_source="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$pkg_version/dotnet-dev-win-x64.$pkg_version.zip"
+$pkg_shasum="82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
+$pkg_filename="dotnet-dev-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=1.0.1
+pkg_version=1.0.4
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.microsoft.com/download/F/D/5/FD52A2F7-65B6-4912-AEDD-4015DF6D8D22/dotnet-1.1.1-sdk-debian-x64.tar.gz"
-pkg_shasum=84601397f83adaf2028653b73f27093f66d4c763dae5c770743351975477ee1e
-pkg_filename="dotnet-1.1.1-sdk-debian-x64.tar.gz"
+pkg_source="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${pkg_version}/dotnet-dev-debian-x64.${pkg_version}.tar.gz"
+pkg_shasum=eeb1baff3999e48e725ad22d7fac800363acec56b122369c37979f87730961a5
+pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils
   core/curl
@@ -39,7 +39,7 @@ do_prepare() {
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
   find -type f -name '*.so*' \
     -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
-  fix_interpreter "$HAB_CACHE_SRC_PATH/$pkg_dirname/sdk/1.0.1/Roslyn/RunCsc.sh" core/coreutils bin/env
+  fix_interpreter "$HAB_CACHE_SRC_PATH/$pkg_dirname/sdk/${pkg_version}/Roslyn/RunCsc.sh" core/coreutils bin/env
 }
 
 do_build() {

--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core"
 $pkg_origin="core"
-$pkg_version="1.1.1"
+$pkg_version="1.1.2"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-win-x64.$pkg_version.zip"
-$pkg_shasum="b0f7fc902308b98fa8e202081884d310a94a93264a1f5beeb4632acccf2c0bb2"
+$pkg_source="https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$pkg_version/dotnet-win-x64.$pkg_version.zip"
+$pkg_shasum="a4ccb23a6cf2ddf9894cb178ce8e69b5788880a1e3d9d659f26fb914a4bc2988"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 
@@ -18,12 +18,4 @@ function Invoke-Unpack {
 
 function Invoke-Install {
   Copy-Item * "$pkg_prefix/bin" -Recurse -Force
-}
-
-function Invoke-Check() {
-  mkdir dotnet-new
-  pushd dotnet-new
-  ../dotnet.exe new
-  popd
-  Remove-Item -Recurse -Force dotnet-new
 }

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=1.1.1
+pkg_version=1.1.2
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.microsoft.com/download/9/5/6/9568826C-E3F6-44A7-9F75-DD8E6AB29543/dotnet-debian-x64.$pkg_version.tar.gz"
-pkg_shasum=6359fcd443c686476c6b55bfcd5fdc214a64f8f399bfc1801e4d841c4ca163de
-pkg_filename="dotnet-debian-x64.$pkg_version.tar.gz"
+pkg_source="https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${pkg_version}/dotnet-debian-x64.${pkg_version}.tar.gz"
+pkg_shasum=26f6a2e247dd0b9ac4003d12cf1bd8647985255fdd7659b60e36a7a26fce15de
+pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl
   core/gcc-libs
@@ -47,14 +47,6 @@ do_build() {
 do_install() {
   cp -a . "$pkg_prefix/bin"
   chmod o+r -R "$pkg_prefix/bin"
-}
-
-do_check() {
-  mkdir dotnet-new
-  pushd dotnet-new
-  ../dotnet new
-  popd
-  rm -rf dotnet-new
 }
 
 do_strip() {


### PR DESCRIPTION
Removed checks from dotnet-core runtime that won't execute, as they apply to sdk.
Made source paths use variablized URL so it doesn't need to be changed for each version (same url that the dotnet core install script uses)
Made fix_interpreter in sdk plan use a variabled path based on version

Signed-off-by: W. Duncan Fraser <duncan@wduncanfraser.com>