### PR TITLE
[pixman] Correctly set pkg_pconfig_dir

### DIFF
--- a/pixman/plan.sh
+++ b/pixman/plan.sh
@@ -1,6 +1,7 @@
 pkg_origin=core
 pkg_name=pixman
 pkg_description="A low-level software library for pixel manipulation"
+pkg_upstream_url="http://pixman.org/"
 pkg_version=0.34.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
@@ -10,6 +11,7 @@ pkg_deps=(core/glibc core/gcc-libs core/libpng core/zlib)
 pkg_build_deps=(core/gcc core/make core/pkg-config core/diffutils core/file)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
+pkg_pconfig_dirs=(lib/pkgconfig)
 
 do_prepare() {
     if [[ ! -r /usr/bin/file ]]; then


### PR DESCRIPTION
pixman puts its pkg-config data in `lib` rather than `include`.

Signed-off-by: Steven Danna <steve@chef.io>