### PR TITLE
Make nginx more externally configurable

### DIFF
--- a/nginx/config/http.include
+++ b/nginx/config/http.include
@@ -1,0 +1,15 @@
+include        mime.types;
+default_type   application/octet-stream;
+
+sendfile       {{cfg.http.sendfile}};
+tcp_nopush     {{cfg.http.tcp_nopush}};
+tcp_nodelay    {{cfg.http.tcp_nodelay}};
+
+keepalive_timeout  {{cfg.http.keepalive_timeout}};
+
+gzip  on;
+gzip_vary on;
+gzip_min_length 10240;
+gzip_proxied expired no-cache no-store private auth;
+gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
+gzip_disable "MSIE [1-6]\.";

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -1,12 +1,7 @@
 pid {{pkg.svc_var_path}}/nginx.pid;
 lock_file {{pkg.svc_var_path}}/nginx.lock;
 
-worker_processes  {{cfg.worker_processes}};
-daemon off;
-
-events {
-    worker_connections  {{cfg.events.worker_connections}};
-}
+include worker.include;
 
 http {
     client_body_temp_path {{pkg.svc_var_path}}/client-body;
@@ -15,21 +10,7 @@ http {
     scgi_temp_path {{pkg.svc_var_path}}/scgi;
     uwsgi_temp_path {{pkg.svc_var_path}}/uwsgi;
 
-    include        mime.types;
-    default_type   application/octet-stream;
-
-    sendfile       {{cfg.http.sendfile}};
-    tcp_nopush     {{cfg.http.tcp_nopush}};
-    tcp_nodelay    {{cfg.http.tcp_nodelay}};
-
-    keepalive_timeout  {{cfg.http.keepalive_timeout}};
-
-    gzip  on;
-    gzip_vary on;
-    gzip_min_length 10240;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
-    gzip_disable "MSIE [1-6]\.";
+    include http.include;
 
     server {
         listen       {{cfg.http.listen.port}};

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -1,3 +1,6 @@
+pid {{pkg.svc_var_path}}/nginx.pid;
+lock_file {{pkg.svc_var_path}}/nginx.lock;
+
 worker_processes  {{cfg.worker_processes}};
 daemon off;
 
@@ -6,6 +9,12 @@ events {
 }
 
 http {
+    client_body_temp_path {{pkg.svc_var_path}}/client-body;
+    proxy_temp_path {{pkg.svc_var_path}}/proxy;
+    fastcgi_temp_path {{pkg.svc_var_path}}/fastcgi;
+    scgi_temp_path {{pkg.svc_var_path}}/scgi;
+    uwsgi_temp_path {{pkg.svc_var_path}}/uwsgi;
+
     include        mime.types;
     default_type   application/octet-stream;
 

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -1,15 +1,6 @@
-pid {{pkg.svc_var_path}}/nginx.pid;
-lock_file {{pkg.svc_var_path}}/nginx.lock;
-
 include worker.include;
 
 http {
-    client_body_temp_path {{pkg.svc_var_path}}/client-body;
-    proxy_temp_path {{pkg.svc_var_path}}/proxy;
-    fastcgi_temp_path {{pkg.svc_var_path}}/fastcgi;
-    scgi_temp_path {{pkg.svc_var_path}}/scgi;
-    uwsgi_temp_path {{pkg.svc_var_path}}/uwsgi;
-
     include http.include;
 
     server {

--- a/nginx/config/worker.include
+++ b/nginx/config/worker.include
@@ -1,0 +1,6 @@
+worker_processes  {{cfg.worker_processes}};
+daemon off;
+
+events {
+    worker_connections  {{cfg.events.worker_connections}};
+}

--- a/nginx/default.toml
+++ b/nginx/default.toml
@@ -9,6 +9,9 @@
 
 
 #### General Configuration
+# a config file to entirely replace the built-in nginx.conf template
+config_path = false
+
 # worker_processes: Number of NGINX processes. Default = 1
 worker_processes = 4
 

--- a/nginx/hooks/run
+++ b/nginx/hooks/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+exec 2>&1
+
+exec nginx -c {{pkg.svc_config_path}}/nginx.conf

--- a/nginx/hooks/run
+++ b/nginx/hooks/run
@@ -2,4 +2,8 @@
 
 exec 2>&1
 
-exec nginx -c {{pkg.svc_config_path}}/nginx.conf
+{{#if cfg.config_path~}}
+    exec nginx -c {{cfg.config_path}}
+{{~else~}}
+    exec nginx -c {{pkg.svc_config_path}}/nginx.conf
+{{~/if}}

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -12,7 +12,6 @@ pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(sbin)
 pkg_include_dirs=(include)
-pkg_svc_run="nginx"
 pkg_svc_user="root"
 pkg_exports=(
   [port]=http.listen.port
@@ -21,19 +20,11 @@ pkg_exposes=(port)
 
 do_build() {
   ./configure --prefix="$pkg_prefix" \
-    --conf-path="$pkg_svc_config_path/nginx.conf" \
     --sbin-path="$pkg_prefix/bin/nginx" \
-    --pid-path="$pkg_svc_var_path/nginx.pid" \
-    --lock-path="$pkg_svc_var_path/nginx.lock" \
     --user=hab \
     --group=hab \
     --http-log-path=/dev/stdout \
     --error-log-path=stderr \
-    --http-client-body-temp-path="$pkg_svc_var_path/client-body" \
-    --http-proxy-temp-path="$pkg_svc_var_path/proxy" \
-    --http-fastcgi-temp-path="$pkg_svc_var_path/fastcgi" \
-    --http-scgi-temp-path="$pkg_svc_var_path/scgi" \
-    --http-uwsgi-temp-path="$pkg_svc_var_path/uwsgi" \
     --with-ipv6 \
     --with-pcre \
     --with-pcre-jit \

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -20,11 +20,19 @@ pkg_exposes=(port)
 
 do_build() {
   ./configure --prefix="$pkg_prefix" \
+    --conf-path="$pkg_svc_config_path/nginx.conf" \
     --sbin-path="$pkg_prefix/bin/nginx" \
+    --pid-path="$pkg_svc_var_path/nginx.pid" \
+    --lock-path="$pkg_svc_var_path/nginx.lock" \
     --user=hab \
     --group=hab \
     --http-log-path=/dev/stdout \
     --error-log-path=stderr \
+    --http-client-body-temp-path="$pkg_svc_var_path/client-body" \
+    --http-proxy-temp-path="$pkg_svc_var_path/proxy" \
+    --http-fastcgi-temp-path="$pkg_svc_var_path/fastcgi" \
+    --http-scgi-temp-path="$pkg_svc_var_path/scgi" \
+    --http-uwsgi-temp-path="$pkg_svc_var_path/uwsgi" \
     --with-ipv6 \
     --with-pcre \
     --with-pcre-jit \


### PR DESCRIPTION
This pull request does two things to make nginx friendly to external use:
- All service configuration is removed from compilation directives and instead set in the default generated config file and run hook that gets used when the package is run as a service. This prevents any attempts by the nginx binary to touch the `/hab/svc/nginx` tree when the binary is used directly and that doesn't exist
- Adds `config_path` config option that can be used to have the run hook start nginx with an arbitrary configuration file, entirely bypassing the rigid default internal `nginx.conf`. All the interesting parts of the default `nginx.conf` that implement other top-level configs are moved to include files that external top-level configurations could still make use of

This can address #583 by allowing the drupal `init` hook to do this instead:
```
export HAB_NGINX='config_path="{{pkg.svc_config_path}}/nginx.conf"'
hab svc load core/nginx --group {{svc.group}} --force
```