### PR TITLE
Updated Artifactory Pro to version 5.3.1

### DIFF
--- a/artifactory-pro/default.toml
+++ b/artifactory-pro/default.toml
@@ -7,6 +7,7 @@
 #                                                    __/ |
 #                                                   |___/
 
+#A valid license key is needed for this application to start correctly
 license = ""
 port = 8081
 

--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=4.14.3
+pkg_version=5.3.1
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=470f7cafcc94ffd181b75aac70e033f2414d69ca3cd66fc03cf621c9b8a3368e
+pkg_shasum=96f7f3d4eb4dc781f946ce55a6da623782c9f074de416f6f2c43f7cc2a625a6a
 pkg_deps=(core/bash core/jre8)
 pkg_build_deps=(core/unzip)
 pkg_exports=(


### PR DESCRIPTION
Signed-off-by: Christopher Maher <defilan@gmail.com>

This is a pretty simple update. This is to bring the Artifactory Pro plan to version 5.3.1 with an updated hash. I also added a note to the default toml file indicating the need for a valid license key in order to successfully start this application (requirement added to Artifactory v5). 