### PR TITLE
Adding aspcud as standard relsover to opam

### DIFF
--- a/aspcud/plan.sh
+++ b/aspcud/plan.sh
@@ -1,0 +1,27 @@
+pkg_name=aspcud
+pkg_origin=core
+pkg_version="1.9.1"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('gplv3+')
+pkg_source="https://sourceforge.net/projects/potassco/files/aspcud/${pkg_version}/aspcud-${pkg_version}-source.tar.gz"
+pkg_shasum="e0e917a9a6c5ff080a411ff25d1174e0d4118bb6759c3fe976e2e3cca15e5827"
+pkg_dirname="${pkg_name}-${pkg_version}-source"
+pkg_deps=(core/clingo core/gcc-libs core/re2c core/boost core/glibc)
+pkg_build_deps=(core/cmake core/make core/gcc)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  mkdir build
+  cmake -H./ \
+    -Bbuild \
+    -DBOOST_INCLUDEDIR="$(pkg_path_for boost)/include" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DGRINGO_LOC="$(pkg_path_for clingo)/bin/gringo" \
+    -DCLASP_LOC="$(pkg_path_for clingo)/bin/clasp"
+  make -C build
+}
+
+do_install() {
+  make -C build install
+}

--- a/clingo/plan.sh
+++ b/clingo/plan.sh
@@ -1,0 +1,29 @@
+pkg_name=clingo
+pkg_origin=core
+pkg_description="A grounder and solver for logic programs."
+pkg_upstream_url="https://potassco.org/"
+pkg_version="5.2.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('MIT')
+pkg_source="https://github.com/potassco/clingo/archive/v${pkg_version}.tar.gz"
+pkg_shasum="57d8979b0972a091e1921309ca9ba9c18dd0cf83afcfb1586a8c0bff54ed8b9b"
+pkg_deps=(core/gcc-libs core/glibc)
+pkg_build_deps=(core/doxygen core/cmake core/make core/gcc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  mkdir build
+  cmake -H./ \
+    -Bbuild \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCLINGO_MANAGE_RPATH=YES \
+    -DCLINGO_BUILD_APPS=YES
+  make -C build
+}
+
+do_install() {
+  make -C build install
+}

--- a/opam/plan.sh
+++ b/opam/plan.sh
@@ -9,6 +9,7 @@ pkg_source="https://github.com/ocaml/opam/releases/download/${pkg_version}/opam-
 pkg_shasum="15e617179251041f4bf3910257bbb8398db987d863dd3cfc288bdd958de58f00"
 pkg_dirname="opam-full-${pkg_version}"
 pkg_deps=(
+  core/aspcud
   core/camlp4
   core/diffutils
   core/gcc


### PR DESCRIPTION
aspcud is used by opam (when available) to resolve versions of dependencies. Without it it has a very naive and often faulty version resolution mechanism.

For opam build to succeed ocamlbuild and camlp4 will need to rebuilt first with the latest ocaml package (4.04.1)

Signed-off-by: Justin Carter <justin@starkandwayne.com>