### PR TITLE
Add config option for db.adapter in scaffold-ruby

### DIFF
--- a/scaffolding-ruby/doc/reference.md
+++ b/scaffolding-ruby/doc/reference.md
@@ -455,14 +455,17 @@ Your app's use of a [PostgreSQL][] database is detected by inspecting the `Gemfi
 * `rjack-jdbc-postgres`
 * `tgbyte-activerecord-jdbcpostgresql-adapter`
 
+**NOTE:** If you are using `activerecord-postgis-adapter` you will need to set the `db.adapter` config option to `postgis` in order to access the `postgis` functions in `PostgreSQL`.
+
 ### Default App Environment Variables
 
-* `DATABASE_URL`: `postgres://$user:$password@$host:$port/$name`
+* `DATABASE_URL`: `$adapter://$user:$password@$host:$port/$name`
 
-Where `$user`, `$password`, `$host`, `$port`, and `$name` will be determined at runtime.
+Where `$adapter`, `$user`, `$password`, `$host`, `$port`, and `$name` will be determined at runtime.
 
 ### Default Config Settings
 
+* `db.adapter`: The connecting database adapter for this app.  Defaults to the value of `postgres` if no value is provided.
 * `db.name`: The database name on the database server for this app. Defaults to the value of `"${pkg_name}_production"`.
 * `db.user`: The connecting database user for this app. Defaults to the value of `"$pkg_name"`.
 * `db.password`: The connecting database password for this app. Defaults to the value of `"${pkg_name}"`. It is **strongly** recommended to use a different, randomly generated password when running your app in production.

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -144,6 +144,7 @@ if ! $pkg_prefix/libexec/is_db_connected; then
   >&2 echo " * db.host      - The database hostname or IP address (Current: {{#if cfg.db.host}}{{cfg.db.host}}{{else}}<unset>{{/if}})"
   >&2 echo " * db.port      - The database listen port number (Current: {{#if cfg.db.port}}{{cfg.db.port}}{{else}}5432{{/if}})"
 {{~/unless}}
+  >&2 echo " * db.adapter   - The database adapter (Current: {{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgres{{/if}})"
   >&2 echo " * db.user      - The database username (Current: {{#if cfg.db.user}}{{cfg.db.user}}{{else}}<unset>{{/if}})"
   >&2 echo " * db.password  - The database password (Current: {{#if cfg.db.password}}<set>{{else}}<unset>{{/if}})"
   >&2 echo " * db.name      - The database name (Current: {{#if cfg.db.name}}{{cfg.db.name}}{{else}}<unset>{{/if}})"
@@ -261,7 +262,7 @@ scaffolding_setup_app_config() {
 scaffolding_setup_database_config() {
   if [[ "${_uses_pg:-}" == "true" ]]; then
     local db t
-    db="postgres://{{cfg.db.user}}:{{cfg.db.password}}"
+    db="{{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgres{{/if}}://{{cfg.db.user}}:{{cfg.db.password}}"
     db="${db}@{{#if bind.database}}{{bind.database.first.sys.ip}}{{else}}{{#if cfg.db.host}}{{cfg.db.host}}{{else}}db.host.not.set{{/if}}{{/if}}"
     db="${db}:{{#if bind.database}}{{bind.database.first.cfg.port}}{{else}}{{#if cfg.db.port}}{{cfg.db.port}}{{else}}5432{{/if}}{{/if}}"
     db="${db}/{{cfg.db.name}}"
@@ -276,6 +277,9 @@ scaffolding_setup_database_config() {
       { echo ""
         echo "[db]"
       } >> "$t"
+      if _default_toml_has_no db.adapter; then
+        echo "adapter = \"postgres\"" >> "$t"
+      fi
       if _default_toml_has_no db.name; then
         echo "name = \"${pkg_name}_production\"" >> "$t"
       fi


### PR DESCRIPTION
This is needed to support using the https://github.com/rgeo/activerecord-postgis-adapter which expects the database adapter to be `postgis` even though it is talking to a postgresql database.

Signed-off-by: Will Fisher <will@alaska.edu>