### PR TITLE
[socat] Upgrade to latest, add openssl and readline support

### DIFF
--- a/socat/plan.sh
+++ b/socat/plan.sh
@@ -1,12 +1,56 @@
 pkg_name=socat
 pkg_origin=core
-pkg_version=1.7.3.0
+pkg_version=1.7.3.2
 pkg_source=http://www.dest-unreach.org/${pkg_name}/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=f8de4a2aaadb406a2e475d18cf3b9f29e322d4e5803d8106716a01fd4e64b186
+pkg_shasum=ce3efc17e3e544876ebce7cd6c85b3c279fda057b2857fcaaf67b9ab8bdaf034
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Multipurpose relay for bidirectional data transfer between two independent data channels"
 pkg_upstream_url=http://www.dest-unreach.org/socat/
 pkg_license=('GPL-2.0')
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc)
-pkg_deps=(core/glibc)
+pkg_deps=(core/glibc core/readline core/openssl)
+
+#
+# TODO(ssd) 2017-06-11: The following is a summary of my attempt to
+# get the test suit passing. Most tests pass; however it requires
+# substantial setup and there are number of failing tests so I've left
+# them disabled.
+#
+# The tests depend on the underlying kernel supporting the features it
+# has been built with. Notably, your kernel must support SCTP for the
+# SCTP tests to pass.
+#
+# The test suite has at least the following dependencies
+#
+#   core/diffutils
+#   core/iproute2
+#   core/net-tools (for ifconfig)
+#   core/which
+#   core/grep (to ensure we don't get grep from busybox)
+#   core/coreutils (to ensure we don't get stat from busybox)
+#   core/busybox (for ping)
+#
+# The tests currently hang at the following test:
+#
+#   test 320 UDP4MAXCHILDREN: max-children option...
+#
+# If you comment that test out, there are still 4-5 failing tests that
+# would need to be addressed.
+#
+# do_prepare() {
+#     if [[ ! -r /sbin/ifconfig ]]; then
+#         ln -sv "$(pkg_path_for net-tools)/sbin/ifconfig" /sbin/ifconfig
+#         _clean_ifconfig=true
+#     fi
+# }
+#
+# do_end() {
+#     if [[ -n "$_clean_ifconfig" ]]; then
+#         rm -fv /sbin/ifconfig
+#     fi
+# }
+#
+# do_check() {
+#     make test
+# }


### PR DESCRIPTION
With the addition of openssl and readlines the only socat features we
don't support are libwrap and openssl-fips. We've stayed away from
libwrap so far and I think that is a good idea.  FIPS is a can of
worms I don't want to open right now.

I've also chronicled my attempt and getting the test suite passing.
It appears that our build of socat is fine and most of the issues are
environmental; however, after solving a half dozen small problems I
decided it was OK to not have the tests for now.

Signed-off-by: Steven Danna <steve@chef.io>