### PR TITLE
[lsof] IPv6 support

### DIFF
--- a/lsof/plan.sh
+++ b/lsof/plan.sh
@@ -20,6 +20,8 @@ do_unpack() {
 do_build() {
   export DESTDIR="$PREFIX"
   export LSOF_CFLAGS_OVERRIDE=1
+  LSOF_INCLUDE="$(pkg_path_for glibc)/include/"
+  export LSOF_INCLUDE
   pushd "$SRC_PATH" > /dev/null
   chmod +x ./Configure
   ./Configure linux -n


### PR DESCRIPTION
The lsof Makefile uses grep to search for constants in standard header
files to determine whether to enable IPv6. LSOF_INCLUDE sets where it
should look for those header files. Setting this variable correctly
results in IPv6 support being enabled.

Signed-off-by: Steven Danna <steve@chef.io>