### PR TITLE
Add missing readline dependency for php plans

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -25,6 +25,7 @@ pkg_build_deps=(
   core/gcc
   core/make
   core/re2c
+  core/readline
 )
 pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(lib)
@@ -42,6 +43,7 @@ do_build() {
     --with-mysql=mysqlnd \
     --with-mysqli=mysqlnd \
     --with-pdo-mysql=mysqlnd \
+    --with-readline="$(pkg_path_for readline)" \
     --with-curl="$(pkg_path_for curl)" \
     --with-gd \
     --with-jpeg-dir="$(pkg_path_for libjpeg-turbo)" \

--- a/php5/plan.sh
+++ b/php5/plan.sh
@@ -23,6 +23,7 @@ pkg_build_deps=(
   core/gcc
   core/make
   core/re2c
+  core/readline
 )
 pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(lib)
@@ -35,6 +36,7 @@ do_build() {
     --enable-fpm \
     --enable-mbstring \
     --enable-opcache \
+    --with-readline="$(pkg_path_for readline)" \
     --with-curl="$(pkg_path_for curl)" \
     --with-libxml-dir="$(pkg_path_for libxml2)" \
     --with-openssl="$(pkg_path_for openssl)" \


### PR DESCRIPTION
The PHP CLI binaries were failing to read input without readline