### PR TITLE
Add max_locks_per_transaction to the postgresql plan

### DIFF
--- a/postgresql/config/postgresql.conf
+++ b/postgresql/config/postgresql.conf
@@ -5,6 +5,7 @@ external_pid_file = '{{pkg.svc_var_path}}/postgresql.pid'
 authentication_timeout = 1min
 
 max_files_per_process = 1000
+max_locks_per_transaction = {{cfg.max_locks_per_transaction}}
 
 logging_collector = on
 log_directory = '{{pkg.svc_var_path}}/pg_log'

--- a/postgresql/default.toml
+++ b/postgresql/default.toml
@@ -1,6 +1,7 @@
 port = '5432'
 
 max_connections = 100
+max_locks_per_transaction = 64
 log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d,client=%h %r (%x:%e)'
 log_level = 'ERROR'
 


### PR DESCRIPTION
This adds an additional config item,  `max_locks_per_transaction`, and sets the default value (64) based on the PostgreSQL 9.6 documentation:

https://www.postgresql.org/docs/9.6/static/runtime-config-locks.html

Signed-off-by: Christian Nunciato <cnunciato@chef.io>