### PR TITLE
Corrects broken sensu (accidentally already built and uploaded before PR)

### DIFF
--- a/sensu/Gemfile
+++ b/sensu/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sensu', '~> 0.26.5'
+gem 'sensu', '~> 0.29.0'
 gem 'sensu-plugin', '~> 1.4', '>= 1.4.3'

--- a/sensu/plan.sh
+++ b/sensu/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=sensu
 pkg_origin=core
-pkg_version=0.26.5
+pkg_version=0.29.0
 pkg_source=http://nothing.to.download.from.com
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A monitoring framework that aims to be simple, malleable, and scalable."


### PR DESCRIPTION
In testing the bundler update I rebuilt this and uploaded it with the appropriate version. Whoops!

https://bldr.habitat.sh/#/pkgs/core/sensu/0.29.0

Signed-off-by: eeyun <ihenry@chef.io>