### PR TITLE
Telegraf

### DIFF
--- a/telegraf/.gitignore
+++ b/telegraf/.gitignore
@@ -1,0 +1,1 @@
+results/*

--- a/telegraf/.gitignore
+++ b/telegraf/.gitignore
@@ -1,1 +1,2 @@
 results/*
+telegraf/*

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,0 +1,26 @@
+pkg_name=telegraf
+pkg_origin=core
+pkg_version="1.3.1"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('The MIT License (MIT)')
+pkg_description="telegraf - client for InfluxDB"
+pkg_upstream_url="https://github.com/influxdata/telegraf/"
+pkg_scaffolding="core/scaffolding-go"
+pkg_svc_run="bin/telegraf"
+
+do_download() {
+    git clone --branch "${pkg_version}" https://github.com/influxdata/telegraf || true
+    cd telegraf && \
+        git pull origin $pkg_version
+}
+
+do_build() {
+    go get github.com/influxdata/telegraf
+    cd $GOPATH/src/github.com/influxdata/telegraf
+    make
+}
+
+do_install() {
+    mkdir -p $pkg_prefix/bin
+    cp /bin/telegraf $pkg_prefix/bin
+}

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -10,6 +10,7 @@ pkg_svc_run="bin/telegraf"
 pkg_bin_dirs=(bin)
 
 do_begin() {
+    set -x
     export GOBIN="${GOPATH}/bin"
 }
 
@@ -19,30 +20,10 @@ do_download() {
         git pull origin $pkg_version
 }
 
-do_verify() {
-    do_default_verify
-}
-
-do_clean() {
-    return 0
-}
-
-do_unpack() {
-    do_default_unpack
-}
-
-do_prepare() {
-    return 0
-}
-
 do_build() {
     go get github.com/influxdata/telegraf
     cd "$GOPATH"/src/github.com/influxdata/telegraf || exit
     make
-}
-
-do_check() {
-    return 0
 }
 
 do_install() {
@@ -50,10 +31,6 @@ do_install() {
     cp /bin/telegraf "${pkg_prefix}"/bin
 }
 
-do_strip() {
-    do_default_strip
-}
-
-do_end() {
+do_clean() {
     return 0
 }

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -7,11 +7,32 @@ pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_scaffolding="core/scaffolding-go"
 pkg_svc_run="bin/telegraf"
+pkg_bin_dirs=(bin)
+
+do_begin() {
+    export GOBIN="${GOPATH}/bin"
+}
 
 do_download() {
     git clone --branch "${pkg_version}" https://github.com/influxdata/telegraf || true
     cd telegraf && \
         git pull origin $pkg_version
+}
+
+do_verify() {
+    do_default_verify
+}
+
+do_clean() {
+    return 0
+}
+
+do_unpack() {
+    do_default_unpack
+}
+
+do_prepare() {
+    return 0
 }
 
 do_build() {
@@ -20,7 +41,19 @@ do_build() {
     make
 }
 
+do_check() {
+    return 0
+}
+
 do_install() {
-    mkdir -p $pkg_prefix/bin
-    cp /bin/telegraf $pkg_prefix/bin
+    mkdir -p ${pkg_prefix}/bin
+    cp /bin/telegraf ${pkg_prefix}/bin
+}
+
+do_strip() {
+    do_default_strip
+}
+
+do_end() {
+    return 0
 }

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -37,7 +37,7 @@ do_prepare() {
 
 do_build() {
     go get github.com/influxdata/telegraf
-    cd $GOPATH/src/github.com/influxdata/telegraf
+    cd "$GOPATH"/src/github.com/influxdata/telegraf || exit
     make
 }
 
@@ -46,8 +46,8 @@ do_check() {
 }
 
 do_install() {
-    mkdir -p ${pkg_prefix}/bin
-    cp /bin/telegraf ${pkg_prefix}/bin
+    mkdir -p "${pkg_prefix}"/bin
+    cp /bin/telegraf "${pkg_prefix}"/bin
 }
 
 do_strip() {


### PR DESCRIPTION
* adding a plan for `telegraf`, the client for InfluxDB

binary only, doesnt include any configs, those should get laid down by whatever is consuming this artifact.