### PR TITLE
Update OpenSSH Plan

### DIFF
--- a/openssh/default.toml
+++ b/openssh/default.toml
@@ -1,3 +1,3 @@
 pubkey_authentication = 'yes'
 password_authentication = 'yes'
-port=22
+port=2222

--- a/openssh/default.toml
+++ b/openssh/default.toml
@@ -1,3 +1,3 @@
 pubkey_authentication = 'yes'
 password_authentication = 'yes'
-port=2222
+port=22

--- a/openssh/hooks/run
+++ b/openssh/hooks/run
@@ -2,4 +2,4 @@
 
 exec 2>&1
 
-exec sshd -D -f {{pkg.svc_config_path}}/sshd_config
+exec {{pkg.path}}/sbin/sshd -D -f {{pkg.svc_config_path}}/sshd_config

--- a/openssh/plan.sh
+++ b/openssh/plan.sh
@@ -1,17 +1,19 @@
 pkg_origin=core
 pkg_name=openssh
-pkg_version=7.2p2
+pkg_version=7.5p1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Provides OpenSSH client and server."
 pkg_license=('bsd')
 pkg_source=http://ftp3.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=a72781d1a043876a224ff1b0032daa4094d87565a68528759c1c2cab5482548c
+pkg_shasum=9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0
 pkg_upstream_url=https://www.openssh.com/
 pkg_bin_dirs=(bin sbin libexec)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_deps=(core/glibc core/openssl core/zlib)
 pkg_build_deps=(core/coreutils core/gcc core/make)
+pkg_svc_user="root"
+pkg_svc_group="root"
 
 do_build() {
   ./configure --prefix="${pkg_prefix}" \


### PR DESCRIPTION
* Update to OpenSSH 7.5p1
* Set hab_svc_user/group to root so it can bind to the default ssh port
* Use full path to sshd binary so that it can execute

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>