### PR TITLE
Setup CA Certs in app_env.sh

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -165,6 +165,7 @@ EOT
 
   env_sh="$pkg_prefix/config/app_env.sh"
   mkdir -p "$(dirname "$env_sh")"
+  echo "export SSL_CERT_FILE='$(pkg_path_for core/cacerts)/ssl/cert.pem'" >> "$env_sh"
   for key in "${!scaffolding_env[@]}"; do
     echo "export $key='${scaffolding_env[$key]}'" >> "$env_sh"
   done

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"
 pkg_upstream_url="https://github.com/habitat-sh/core-plans/tree/master/scaffolding-ruby"
-pkg_deps=(core/bundler core/ruby core/tar core/busybox-static core/rq core/gcc core/make core/pkg-config)
+pkg_deps=(core/bundler core/ruby core/tar core/busybox-static core/rq core/gcc core/make core/pkg-config core/cacerts)
 pkg_build_deps=(core/coreutils core/sed)
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
This installs core/cacerts and sets up the app_env.sh to use the cacerts
file. The motivation for this is that an average user would expect
outbound ssl connections to just work and they do not without adding
the cacerts and setting the environment variable.

Signed-off-by: Christopher Webber <cwebber@chef.io>