### PR TITLE
add redis detection to scaffolding-ruby

### DIFF
--- a/scaffolding-ruby/libexec/is_redis_connected.rb
+++ b/scaffolding-ruby/libexec/is_redis_connected.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# -*- encoding: utf-8 -*-
+
+require "#{Dir.pwd}/config/environment.rb"
+
+begin
+  Redis.new(url: ENV['REDIS_URL']).keys
+rescue => e
+  abort "Redis connection failed: #{e}"
+end


### PR DESCRIPTION
Modeled after the PostgreSQL detection.

+ detects the presence of redisy gems; there are no hab dependencies for C-bindings to add for the gems
+ configures an optional binding to a redis hab service to look up its port
+ configures a `REDIS_URL` env var via the scaffolding and based on config provided by API or through the binding

TODO:
- [ ] test more!
- [ ] provide a default value (say, `0`) for the Redis DB number?
