### PR TITLE
[curl] Add HTTP2 protocol support to curl

### DIFF
--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -13,12 +13,14 @@ pkg_deps=(
   core/glibc
   core/openssl
   core/zlib
+  core/nghttp2
 )
 pkg_build_deps=(
   core/coreutils
   core/gcc
   core/make
   core/perl
+  core/pkg-config
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -34,6 +36,7 @@ do_build() {
               --with-ca-bundle="$(pkg_path_for cacerts)/ssl/certs/cacert.pem" \
               --with-ssl="$(pkg_path_for openssl)" \
               --with-zlib="$(pkg_path_for zlib)" \
+              --with-nghttp2="$(pkg_path_for nghttp2)" \
               --disable-manual \
               --disable-ldap \
               --disable-ldaps \


### PR DESCRIPTION
This depends on https://github.com/habitat-sh/core-plans/pull/676 to be accepted.

Signed-off-by: John Jelinek <jjelinek@containerstore.com>