### PR TITLE
Add HTTP2 support to httpd

### DIFF
--- a/httpd/config/httpd.conf
+++ b/httpd/config/httpd.conf
@@ -516,14 +516,16 @@ LoadModule mpm_{{cfg.mpm.type}}_module modules/mod_mpm_{{cfg.mpm.type}}.so
 <IfModule mpm_{{cfg.mpm.type}}_module>
     StartServers             {{cfg.mpm.startservers}}
     ServerLimit              {{cfg.mpm.serverlimit}}
+    {{~#unless cfg.mpm.threaded}}
     MinSpareServers          {{cfg.mpm.minspareservers}}
     MaxSpareServers          {{cfg.mpm.maxspareservers}}
+    {{~/unless}}
     MaxRequestWorkers        {{cfg.mpm.maxrequestworkers}}
     MaxConnectionsPerChild   {{cfg.mpm.maxconnectionsperchild}}
-    {{#if cfg.mpm.threaded}}
+    {{~#if cfg.mpm.threaded}}
     ThreadLimit         {{cfg.mpm.threadlimit}}
     ThreadsPerChild      {{cfg.mpm.threadsperchild}}
-    {{/if}}
+    {{~/if}}
 </IfModule>
 
 #mod_status information
@@ -544,3 +546,5 @@ LoadModule mpm_{{cfg.mpm.type}}_module modules/mod_mpm_{{cfg.mpm.type}}.so
     Deny from {{cfg.mod_proxy.deny}}
     Allow from {{cfg.mod_proxy.allow}}
 </IfModule>
+
+Protocols {{ cfg.protocols }}

--- a/httpd/default.toml
+++ b/httpd/default.toml
@@ -5,9 +5,10 @@ serverport = "80"
 listen = ["80"]
 user = "hab"
 group = "hab"
-default_modules = [	"access_compat", "alias", "auth_basic", "authn_file", "authn_core", "authz_host",
-                    "authz_groupfile", "authz_user", "autoindex", "dir", "env", "filter",
-                    "headers", "log_config", "mime", "reqtimeout", "setenvif", "ssl", "status", "version" ]
+default_modules = [ "access_compat", "alias", "auth_basic", "authn_file", "authn_core", "authz_host",
+                    "authz_groupfile", "authz_user", "autoindex", "dir", "env", "filter", "headers",
+                    "http2", "log_config", "mime", "reqtimeout", "setenvif", "ssl", "status", "version" ]
+protocols = "http/1.1"
 
 #httpd-default settings
 timeout = 60

--- a/httpd/hooks/init
+++ b/httpd/hooks/init
@@ -4,3 +4,6 @@
 mkdir -p {{pkg.svc_data_path}}/htdocs
 mkdir -p {{pkg.svc_data_path}}/cgi-bin
 mkdir -p {{pkg.svc_var_path}}/logs
+
+find {{pkg.svc_data_path}} -type d -exec chmod 0755 {} \;
+find {{pkg.svc_data_path}} -type f -exec chmod 0644 {} \;

--- a/httpd/plan.sh
+++ b/httpd/plan.sh
@@ -7,7 +7,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://archive.apache.org/dist/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_shasum=b71a13f56b8061c6b4086fdcc9ffdddd904449735eadec0f0e2947e33eec91d7
-pkg_deps=(core/glibc core/expat core/libiconv core/apr core/apr-util core/pcre core/zlib core/openssl core/gcc-libs)
+pkg_deps=(core/glibc core/expat core/libiconv core/apr core/apr-util core/pcre core/zlib core/openssl core/gcc-libs core/nghttp2)
 pkg_build_deps=(core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -29,6 +29,7 @@ do_build() {
                 --with-apr-util="$(pkg_path_for core/apr-util)" \
                 --with-z="$(pkg_path_for core/zlib)" \
                 --with-ssl="$(pkg_path_for core/openssl)" \
+                --with-nghttp2="$(pkg_path_for core/nghttp2)" \
                 --enable-modules="none" \
                 --enable-mods-static="none" \
                 --enable-mods-shared="reallyall" \


### PR DESCRIPTION
This depends on #676 to be merged. To take advantage of HTTP2, update these config values:
```
protocols = "h2 h2c http/1.1"

[mpm]
type = "event"
threaded = true
```

Once #677 is merged, you should be able to test this with curl via `hab pkg exec core/curl curl -I localhost --http2` and you'll see output like this:
```
HTTP/1.1 101 Switching Protocols
Upgrade: h2c
Connection: Upgrade

HTTP/2 200
date: Sun, 00 Jan 1900 00:00:00 GMT
server: Apache/2.4.27 (Unix) OpenSSL/1.0.2j
content-type: text/html;charset=ISO-8859-1
```