### PR TITLE
Add PostGIS extension to postgresql

### DIFF
--- a/gdal/plan.sh
+++ b/gdal/plan.sh
@@ -11,10 +11,23 @@ pkg_build_deps=(
   core/gcc
   core/make
   core/pkg-config
+  core/patchelf
 )
 pkg_deps=(
   core/glibc
+  core/gcc-libs
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+
+
+do_install() {
+  do_default_install
+
+  build_line "Patching ELF binaries:"
+  find "${pkg_prefix}/lib" -type f -executable \
+    -exec sh -c 'file -i "$1" | grep -q "x-sharedlib; charset=binary"' _ {} \; \
+    -print \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+}

--- a/gdal/plan.sh
+++ b/gdal/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=gdal
+pkg_origin=core
+pkg_version=2.2.1
+pkg_description="GDAL is a translator library for raster and vector geospatial data formats"
+pkg_upstream_url=http://www.gdal.org/
+pkg_license=('MIT')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=http://download.osgeo.org/gdal/${pkg_version}/gdal-${pkg_version}.tar.gz
+pkg_shasum=61837706abfa3e493f3550236efc2c14bd6b24650232f9107db50a944abf8b2f
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_deps=(
+  core/glibc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/gdal/plan.sh
+++ b/gdal/plan.sh
@@ -10,6 +10,7 @@ pkg_shasum=61837706abfa3e493f3550236efc2c14bd6b24650232f9107db50a944abf8b2f
 pkg_build_deps=(
   core/gcc
   core/make
+  core/pkg-config
 )
 pkg_deps=(
   core/glibc

--- a/geos/plan.sh
+++ b/geos/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=geos
+pkg_origin=core
+pkg_version=3.6.2
+pkg_description="GEOS (Geometry Engine - Open Source) is a C++ port of the ​Java Topology Suite (JTS)."
+pkg_upstream_url=http://trac.osgeo.org/geos
+pkg_license=('LGPL')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=http://download.osgeo.org/geos/geos-${pkg_version}.tar.bz2
+pkg_shasum=045a13df84d605a866602f6020fc6cbf8bf4c42fb50de237a08926e1d7d7652a
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_deps=(
+  core/glibc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/geos/plan.sh
+++ b/geos/plan.sh
@@ -10,10 +10,23 @@ pkg_shasum=045a13df84d605a866602f6020fc6cbf8bf4c42fb50de237a08926e1d7d7652a
 pkg_build_deps=(
   core/gcc
   core/make
+  core/patchelf
 )
 pkg_deps=(
   core/glibc
+  core/gcc-libs
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+
+
+do_install() {
+  do_default_install
+
+  build_line "Patching ELF binaries:"
+  find "$pkg_prefix/lib" -type f -executable \
+    -exec sh -c 'file -i "$1" | grep -q "x-sharedlib; charset=binary"' _ {} \; \
+    -print \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+}

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -16,12 +16,22 @@ pkg_deps=(
   core/readline
   core/zlib
   core/libossp-uuid
+
+  # for postgis
+  core/gcc # postgis-*.so really only need gcc-libs in runtime, but since gcc is needed during build the libraries end up using the gcc paths
+  core/libxml2
+  jarvus/geos
+  jarvus/proj
+  jarvus/gdal
 )
 
 pkg_build_deps=(
   core/coreutils
-  core/gcc
   core/make
+
+  # for postgis
+  core/perl
+  core/diffutils
 )
 
 pkg_bin_dirs=(bin)
@@ -37,6 +47,36 @@ pkg_exposes=(port)
 pkg_svc_user=root
 pkg_svc_group=$pkg_svc_user
 
+ext_postgis_version=2.3.2
+ext_postgis_source=http://download.osgeo.org/postgis/source/postgis-${ext_postgis_version}.tar.gz
+ext_postgis_filename=postgis-${ext_postgis_version}.tar.gz
+ext_postgis_shasum=e92e34c18f078a3d1a2503cd870efdc4fa9e134f0bcedbbbdb8b46b0e6af09e4
+
+do_before() {
+  ext_postgis_dirname="postgis-${ext_postgis_version}"
+  ext_postgis_cache_path="$HAB_CACHE_SRC_PATH/${ext_postgis_dirname}"
+}
+
+do_download() {
+  do_default_download
+  download_file $ext_postgis_source $ext_postgis_filename $ext_postgis_shasum
+}
+
+do_verify() {
+  do_default_verify
+  verify_file $ext_postgis_filename $ext_postgis_shasum
+}
+
+do_clean() {
+  do_default_clean
+  rm -rf "$ext_postgis_cache_path"
+}
+
+do_unpack() {
+  do_default_unpack
+  unpack_file $ext_postgis_filename
+}
+
 do_build() {
     # ld manpage: "If -rpath is not used when linking an ELF
     # executable, the contents of the environment variable LD_RUN_PATH
@@ -50,8 +90,29 @@ do_build() {
               --sysconfdir="$pkg_svc_config_path" \
               --localstatedir="$pkg_svc_var_path"
     make world
+
+    # PostGIS can't be built until after postgresql is installed to $pkg_prefix
 }
 
 do_install() {
   make install-world
+
+  # make and install PostGIS extension
+  HAB_LIBRARY_PATH="$(pkg_path_for proj)/lib:${pkg_prefix}/lib"
+  export LIBRARY_PATH="${LIBRARY_PATH}:${HAB_LIBRARY_PATH}"
+  build_line "Added habitat libraries to LIBRARY_PATH: ${HAB_LIBRARY_PATH}"
+
+  export PATH="${PATH}:${pkg_prefix}/bin"
+  build_line "Added postgresql binaries to PATH: ${pkg_prefix}/bin"
+
+  pushd "$ext_postgis_cache_path" > /dev/null
+
+  build_line "Building ${ext_postgis_dirname}"
+  ./configure --prefix="$pkg_prefix"
+  make
+
+  build_line "Installing ${ext_postgis_dirname}"
+  make install
+
+  popd > /dev/null
 }

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -18,7 +18,6 @@ pkg_deps=(
   core/libossp-uuid
 
   # for postgis
-  core/gcc # postgis-*.so really only need gcc-libs in runtime, but since gcc is needed during build the libraries end up using the gcc paths
   core/libxml2
   core/geos
   core/proj
@@ -27,6 +26,7 @@ pkg_deps=(
 
 pkg_build_deps=(
   core/coreutils
+  core/gcc
   core/make
 
   # for postgis

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -20,9 +20,9 @@ pkg_deps=(
   # for postgis
   core/gcc # postgis-*.so really only need gcc-libs in runtime, but since gcc is needed during build the libraries end up using the gcc paths
   core/libxml2
-  jarvus/geos
-  jarvus/proj
-  jarvus/gdal
+  core/geos
+  core/proj
+  core/gdal
 )
 
 pkg_build_deps=(

--- a/proj/plan.sh
+++ b/proj/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=proj
+pkg_origin=core
+pkg_version=4.9.3
+pkg_description="Cartographic Projections Library"
+pkg_upstream_url=https://github.com/OSGeo/proj.4
+pkg_license=('MIT')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=http://download.osgeo.org/proj/proj-${pkg_version}.tar.gz
+pkg_shasum=6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_deps=(
+  core/glibc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)


### PR DESCRIPTION
This PR adds the popular PostGIS extension to the main postgresql build. This seems to be the best way to make PostGIS available to habitat users because:

- Postgresql developers are of the opinion that because users can load extensions, it would be a security vulnerability to allow extensions to be loaded from anywhere other than the official extensions path within the postgresql tree. There is no path without patching postgresql to load extensions from somewhere else in the filesystem: http://www.postgresql-archive.org/Configurable-location-for-extension-control-files-td5757897.html
- Because of this, the PostGIS build tools mostly ignore `--prefix` and just add files to the postgresql tree wherever it detects it: https://trac.osgeo.org/postgis/ticket/635
- So to use Postgresql and PostGIS together unpatched as immutable builds, they have to be distributed together as one package
- Extensions must be loaded by database users at runtime to be activated, so there is no runtime overhead to merely including the PostGIS extension in the Postgresql build artifact. Including it in the build only makes it available for loading and only costs disk space.

The PostGIS build process requires that postgresql binaries and libraries be available in the environment, so this plan adds them dynamically in the install phase and executes both the build and install phases for PostGIS after Postgresql is installed to `$pkg_prefix`

Two things that feel kind of dirty here that I want to flag for discussion/review:

- [ ] Needing to add the lib path for proj manually to `LIBRARY_PATH`
- [X] Needing to move `core/gcc` to a runtime dependency
   - The built `lib/postgis-2.3.so` has runtime dependencies on `libstdc++.so.6` and `libgcc_s.so.1` that can be met by `core/gcc-libs` at runtime. Because `core/gcc` is present at build time though, the rpaths for this and some other `.so`s end up looking like `/hab/pkgs/core/gcc/5.2.0/20170513202244/lib/../lib/libgcc_s.so.1` and that can end up resolving to not found after installation if only `gcc-libs` is around at runtime.
  - **UPDATE**: resolved by `patchelf`ing `gdal` and `geos`