### PR TITLE
Remove python version specification

### DIFF
--- a/envdir/plan.sh
+++ b/envdir/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('MIT')
 pkg_description="Envdir runs another program with a modified environment according to files in a specified directory."
 pkg_upstream_url="https://github.com/jezdez/envdir"
 pkg_source=https://github.com/jezdez/envdir/archive/${pkg_version}.tar.gz
-pkg_deps=(core/python/3.5.2)
+pkg_deps=(core/python)
 pkg_bin_dirs=(bin)
 
 do_download() {

--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -7,7 +7,7 @@ pkg_description="Continuous Archiving for Postgres"
 pkg_upstream_url="https://github.com/wal-e/wal-e"
 pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
 pkg_shasum=f3bd4171917656fef3829c9d993684d26c86eef0038ac3da7f12bae9122c6fc3
-pkg_deps=(core/envdir core/lzop core/pv core/python/3.5.2)
+pkg_deps=(core/envdir core/lzop core/pv core/python)
 pkg_bin_dirs=(bin)
 
 do_download() {


### PR DESCRIPTION
The `envdir` and `wal-e` plans contain `core/python/3.5.2` as a dependency, wrecking having if they're in your dep tree with anything that isn't similarly locked to 3.5.2. This overspecification was part of the original commit of the two plans and I can't find any indication they were included for any particular reason. They build fine and the upstream projects don't indicate any python3 version restrictions.