### PR TITLE
[node-scaffolding] Modify node scaffold so it runs out of the service var directory 

### DIFF
--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -488,7 +488,7 @@ else
   exit 1
 fi
 
-cd $scaffolding_app_prefix
+cd $pkg_svc_var_path
 
 exec $cmd \$@
 EOF


### PR DESCRIPTION
Currently it runs out of the package build directory.

Signed-off-by: Scott Hain <shain@chef.io>