### PR TITLE
Fix syntax error in slapd.ldif

### DIFF
--- a/openldap/config/slapd.ldif
+++ b/openldap/config/slapd.ldif
@@ -1,7 +1,6 @@
 dn: cn=config
 objectClass: olcGlobal
 cn: config
-
 olcArgsFile: {{pkg.svc_var_path}}/run/slapd.args
 olcPidFile: {{pkg.svc_var_path}}/run/slapd.pid
 


### PR DESCRIPTION
Bumped version to the latest OpenLDAP stable. 

The server failed to start correctly because of an extra newline in the slapd.ldif. I've removed that line which fixes that issue.