### PR TITLE
add plan for node 8

### DIFF
--- a/node8/plan.sh
+++ b/node8/plan.sh
@@ -1,0 +1,10 @@
+source "../node/plan.sh"
+
+pkg_name=node8
+pkg_version=8.3.0
+pkg_shasum=33fa7a02f265636c240be9ebd0f93942f77856a9c2c751592da1a0962b6ed010
+pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
+
+# the archive contains a 'v' version # prefix, but the default value of
+# pkg_dirname is node-${pkg_version} (without the v). This tweak makes build happy
+pkg_dirname=node-v$pkg_version

--- a/node8/plan.sh
+++ b/node8/plan.sh
@@ -1,9 +1,14 @@
 source "../node/plan.sh"
 
 pkg_name=node8
+pkg_origin=core
 pkg_version=8.3.0
-pkg_shasum=33fa7a02f265636c240be9ebd0f93942f77856a9c2c751592da1a0962b6ed010
+pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
+pkg_license=('MIT')
+pkg_upstream_url=https://nodejs.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
+pkg_shasum=33fa7a02f265636c240be9ebd0f93942f77856a9c2c751592da1a0962b6ed010
 
 # the archive contains a 'v' version # prefix, but the default value of
 # pkg_dirname is node-${pkg_version} (without the v). This tweak makes build happy


### PR DESCRIPTION
Adds a plan for node version 8.3.0.

Signed-off-by: Matthew Peck <mpeck@chef.io>