### PR TITLE
Updates to allow WAL-E and PostgreSQL to interact again

### DIFF
--- a/postgresql/default.toml
+++ b/postgresql/default.toml
@@ -18,7 +18,8 @@ lag_health_threshold = 1048576
 [wal-e]
 enable = false
 [wal-e.aws]
-prefix = ''
+bucket = ''
 access_key_id = ''
 secret_access_key = ''
 region = ''
+

--- a/postgresql/hooks/post-run
+++ b/postgresql/hooks/post-run
@@ -1,11 +1,2 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
-source {{pkg.svc_config_path}}/functions.sh
-
-stop_wale_service
-
-{{ #unless svc.me.follower }}
-{{ #if cfg.wal-e.enable }}
-start_wale_service
-{{ /if }}
-{{ /unless }}

--- a/postgresql/hooks/run
+++ b/postgresql/hooks/run
@@ -25,6 +25,14 @@ cp {{pkg.svc_config_path}}/recovery.conf {{pkg.svc_data_path}}/
 
 ensure_dir_ownership
 
+stop_wale_service
+
+{{ #unless svc.me.follower }}
+{{ #if cfg.wal-e.enable }}
+start_wale_service
+{{ /if }}
+{{ /unless }}
+
 echo "Starting PostgreSQL"
 export PGDATA={{pkg.svc_data_path}}
 exec chpst -U hab:hab -u hab:hab postgres \

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -9,14 +9,12 @@ pkg_source=https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_name}-${p
 pkg_shasum=1645b3736901f6d854e695a937389e68ff2066ce0cde9d73919d6ab7c995b9c6
 pkg_deps=(
   core/bash
-  core/envdir
   core/glibc
   core/openssl
   core/perl
   core/readline
   core/zlib
   core/libossp-uuid
-  core/wal-e
 )
 pkg_build_deps=(
   core/coreutils

--- a/wal-e/hooks/run
+++ b/wal-e/hooks/run
@@ -4,15 +4,8 @@ exec 2>&1
 
 mkdir -p "{{pkg.svc_config_path}}/env"
 
-psql_dir=$(dirname $(find /hab/pkgs -name 'psql' | head -n 1))
-if [[ "${psql_dir}" == "" ]]; then
-  echo "Postgres binaries not found! Please install core/postgresql"
-  exit 1
-fi
-
-export PATH=$PATH:${psql_dir}
-
 write_env_var() {
+  echo $1 = $2
   echo "$1" > "{{pkg.svc_config_path}}/env/$2"
 }
 
@@ -25,8 +18,13 @@ write_env_var '{{cfg.pg.superuser_password}}' 'PGPASSWORD'
 write_env_var 'postgres' 'PGDATABASE'
 
 while true; do
+  if pg_isready --dbname=postgres --quiet; then
 {{ #if cfg.pg.data_dir }}
-  envdir {{pkg.svc_config_path}}/env wal-e backup-push {{cfg.pg.data_dir}}
+    envdir {{pkg.svc_config_path}}/env wal-e backup-push {{cfg.pg.data_dir}}
 {{/if}}
-  sleep {{cfg.backup_interval}}
+    sleep {{cfg.backup_interval}}
+  else 
+    echo "WAL-E waiting for local database to be available"
+    sleep 10
+  fi
 done

--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -7,7 +7,7 @@ pkg_description="Continuous Archiving for Postgres"
 pkg_upstream_url="https://github.com/wal-e/wal-e"
 pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
 pkg_shasum=f3bd4171917656fef3829c9d993684d26c86eef0038ac3da7f12bae9122c6fc3
-pkg_deps=(core/envdir core/lzop core/pv core/python/3.5.2)
+pkg_deps=(core/envdir core/lzop core/pv core/python/3.5.2 core/postgresql)
 pkg_bin_dirs=(bin)
 
 do_download() {


### PR DESCRIPTION
- Removed postgresql dependency on wal-e
- Added wal-e dependency on postgresql
- Removed wal-e psql location tricks, fixed with dependency
- Changed postgresql to load core/wal-e in run hook (not post-run)
- Changed wal-e to enter a 10 second loop if no database is found

Resubmitted as I got some key data in there :(