### PR TITLE
Add Go Dependency Management Tool

### DIFF
--- a/dep/plan.sh
+++ b/dep/plan.sh
@@ -1,0 +1,11 @@
+pkg_name=dep
+pkg_origin=core
+pkg_version=0.3.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Go dependency management tool"
+pkg_license="BSD-3-Clause"
+# pkg_source set per the Setup instructions: https://git.io/v5LpG
+pkg_source="https://github.com/golang/dep/cmd/dep"
+pkg_upstream_url="https://github.com/golang/dep"
+pkg_scaffolding="core/scaffolding-go"
+pkg_bin_dirs=(bin)


### PR DESCRIPTION
This add the go dependency management tool to core-plans which help for making more complete scaffolding for go.