### PR TITLE
Changing default adapter value to postgresql

### DIFF
--- a/scaffolding-ruby/doc/reference.md
+++ b/scaffolding-ruby/doc/reference.md
@@ -465,7 +465,7 @@ Where `$adapter`, `$user`, `$password`, `$host`, `$port`, and `$name` will be de
 
 ### Default Config Settings
 
-* `db.adapter`: The connecting database adapter for this app.  Defaults to the value of `postgres` if no value is provided.
+* `db.adapter`: The connecting database adapter for this app.  Defaults to the value of `postgresql` if no value is provided.
 * `db.name`: The database name on the database server for this app. Defaults to the value of `"${pkg_name}_production"`.
 * `db.user`: The connecting database user for this app. Defaults to the value of `"$pkg_name"`.
 * `db.password`: The connecting database password for this app. Defaults to the value of `"${pkg_name}"`. It is **strongly** recommended to use a different, randomly generated password when running your app in production.

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -144,7 +144,7 @@ if ! $pkg_prefix/libexec/is_db_connected; then
   >&2 echo " * db.host      - The database hostname or IP address (Current: {{#if cfg.db.host}}{{cfg.db.host}}{{else}}<unset>{{/if}})"
   >&2 echo " * db.port      - The database listen port number (Current: {{#if cfg.db.port}}{{cfg.db.port}}{{else}}5432{{/if}})"
 {{~/unless}}
-  >&2 echo " * db.adapter   - The database adapter (Current: {{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgres{{/if}})"
+  >&2 echo " * db.adapter   - The database adapter (Current: {{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgresql{{/if}})"
   >&2 echo " * db.user      - The database username (Current: {{#if cfg.db.user}}{{cfg.db.user}}{{else}}<unset>{{/if}})"
   >&2 echo " * db.password  - The database password (Current: {{#if cfg.db.password}}<set>{{else}}<unset>{{/if}})"
   >&2 echo " * db.name      - The database name (Current: {{#if cfg.db.name}}{{cfg.db.name}}{{else}}<unset>{{/if}})"
@@ -262,7 +262,7 @@ scaffolding_setup_app_config() {
 scaffolding_setup_database_config() {
   if [[ "${_uses_pg:-}" == "true" ]]; then
     local db t
-    db="{{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgres{{/if}}://{{cfg.db.user}}:{{cfg.db.password}}"
+    db="{{#if cfg.db.adapter}}{{cfg.db.adapter}}{{else}}postgresql{{/if}}://{{cfg.db.user}}:{{cfg.db.password}}"
     db="${db}@{{#if bind.database}}{{bind.database.first.sys.ip}}{{else}}{{#if cfg.db.host}}{{cfg.db.host}}{{else}}db.host.not.set{{/if}}{{/if}}"
     db="${db}:{{#if bind.database}}{{bind.database.first.cfg.port}}{{else}}{{#if cfg.db.port}}{{cfg.db.port}}{{else}}5432{{/if}}{{/if}}"
     db="${db}/{{cfg.db.name}}"
@@ -278,7 +278,7 @@ scaffolding_setup_database_config() {
         echo "[db]"
       } >> "$t"
       if _default_toml_has_no db.adapter; then
-        echo "adapter = \"postgres\"" >> "$t"
+        echo "adapter = \"postgresql\"" >> "$t"
       fi
       if _default_toml_has_no db.name; then
         echo "name = \"${pkg_name}_production\"" >> "$t"


### PR DESCRIPTION
The correct name for the PostgreSQL adapter is `postgresql`.

Signed-off-by: David Wrede <dwrede@chef.io>