### PR TITLE
adds in troubleshooting for bundler error to readme of ruby scaffolding

### DIFF
--- a/scaffolding-ruby/README.md
+++ b/scaffolding-ruby/README.md
@@ -25,6 +25,6 @@ You can bypass it by adding these lines to your plan.sh
 ```bash
 do_prepare() {
     do_default_prepare
-	  _bundler_version="1.15.1"
+    _bundler_version="1.15.1"
 }
 ```

--- a/scaffolding-ruby/README.md
+++ b/scaffolding-ruby/README.md
@@ -5,3 +5,26 @@ Ruby Scaffolding is a Habitat package which helps you build your Ruby-based **we
 * [Habitat Website](https://www.habitat.sh/)
 * [Ruby Scaffolding Quickstart Guide](doc/quickstart.md)
 * [Ruby Scaffolding Documentation](doc/reference.md)
+
+## Troubleshooting
+
+If you receive this error when running a build with this scaffolding:
+
+```bash
+The latest bundler is 1.15.4, but you are currently running 1.15.1.
+To update, run `gem install bundler`
+ERROR:  Could not find a valid gem '/hab/pkgs/core/bundler/1.15.1/20170621175238/cache/bundler-1.15.1
+1.15.1.
+bundler`.gem' (>= 0) in any repository
+   widget_world: Build time: 0m41s
+		widget_world: Exiting on error
+```
+
+You can bypass it by adding these lines to your plan.sh
+
+```bash
+do_prepare() {
+    do_default_prepare
+	  _bundler_version="1.15.1"
+}
+```


### PR DESCRIPTION
Adds in temporary work around steps for dealing with bundler versioning error when using the ruby scaffolding.  I have also opened #734 to explore a longer term solution.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>