### PR TITLE
add foulkon (v0.4.0)

### DIFF
--- a/foulkon/config/environment.sh
+++ b/foulkon/config/environment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+{{#if bind.database}}
+{{~#eachAlive bind.database.members as |member|}}
+PGPORT="{{member.cfg.port}}"
+PGHOST="{{member.sys.ip}}"
+PG_SUPERUSER="{{member.cfg.superuser_name}}"
+PG_SUPERUSER_PASSWORD="{{member.cfg.superuser_password}}"
+PG_SUPERUSER_URI="postgres://{{member.cfg.superuser_name}}:{{member.cfg.superuser_password}}@{{member.sys.ip}}:{{member.cfg.port}}/postgres"
+{{~/eachAlive}}
+{{else}}
+{{#with cfg}}
+PGPORT="{{storage.port}}"
+PGHOST="{{storage.host}}"
+PG_SUPERUSER="{{storage.superuser_name}}"
+PG_SUPERUSER_PASSWORD="{{storage.superuser_password}}"
+PG_SUPERUSER_URI="postgres://{{storage.superuser_name}}:{{storage.superuser_password}}@{{storage.host}}:{{storage.port}}/postgres"
+{{/with}}
+{{/if}}

--- a/foulkon/config/proxy.toml
+++ b/foulkon/config/proxy.toml
@@ -1,0 +1,19 @@
+[server]
+host = "{{cfg.service.host}}"
+port = "{{cfg.service.port}}"
+worker-host = "{{cfg.worker-host}}"
+
+[logger]
+level = "{{cfg.log_level}}"
+
+[database]
+type = "postgres"
+
+[database.postgres]
+{{#if bind.database}}
+{{~#eachAlive bind.backend.members as |database|}}
+datasourcename = "postgres://{{cfg.storage.user}}:{{cfg.storage.password}}@{{database.sys.ip}}:{{database.cfg.port}}/{{cfg.storage.database}}?sslmode={{cfg.storage.ssl_mode}}"
+{{~/eachAlive}}
+{{else}}
+datasourcename = "postgres://{{cfg.storage.user}}:{{cfg.storage.password}}@{{cfg.storage.host}}:{{cfg.storage.port}}/{{cfg.storage.database}}?sslmode={{cfg.storage.ssl_mode}}"
+{{/if}}

--- a/foulkon/config/worker.toml
+++ b/foulkon/config/worker.toml
@@ -1,0 +1,27 @@
+[server]
+host = "{{cfg.service.host}}"
+port = "{{cfg.service.port}}"
+
+[logger]
+level = "{{cfg.log_level}}"
+
+[admin]
+username = "{{cfg.admin.username}}"
+password = "{{cfg.admin.password}}"
+
+[database]
+type = "postgres"
+
+[database.postgres]
+{{#if bind.database}}
+{{~#eachAlive bind.database.members as |member|}}
+datasourcename = "postgres://{{cfg.storage.user}}:{{cfg.storage.password}}@{{member.sys.ip}}:{{member.cfg.port}}/{{cfg.storage.database}}?sslmode={{cfg.storage.ssl_mode}}"
+{{~/eachAlive}}
+{{else}}
+{{#with cfg.storage}}
+datasourcename = "postgres://{{user}}:{{password}}@{{host}}:{{port}}/{{database}}?sslmode={{ssl_mode}}"
+{{/with}}
+{{~/if}}
+
+[authenticator]
+type = "{{cfg.authenticator.type}}"

--- a/foulkon/default.toml
+++ b/foulkon/default.toml
@@ -1,0 +1,22 @@
+log_level = "info"
+
+[service]
+host = "localhost"
+port = 8000
+
+[admin]
+username = "admin"
+password = "admin"
+
+[authenticator]
+type = "oidc"
+
+[storage]
+host = "postgres"
+port = 5432
+superuser_name = "superuser"
+superuser_password = "replaceme"
+database = "foulkon"
+user = "foulkon"
+password = "foulkon"
+ssl_mode = "disable"

--- a/foulkon/hooks/init
+++ b/foulkon/hooks/init
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+exec 2>&1
+
+source {{pkg.svc_config_path}}/environment.sh
+
+echo "Testing if pg is ready"
+pg_isready -d "${PG_SUPERUSER_URI}" || exit 1
+
+{{#with cfg.storage}}
+echo "Trying to create role '{{user}}'..."
+
+psql -d "${PG_SUPERUSER_URI}" \
+  -c "CREATE ROLE \"{{user}}\""
+
+echo "Setting password for role '{{user}}'..."
+psql -d "${PG_SUPERUSER_URI}" \
+  -c "ALTER ROLE \"{{user}}\" WITH LOGIN PASSWORD '{{password}}'"
+
+echo "Trying to create database '{{database}}'..."
+PGPASSWORD="${PG_SUPERUSER_PASSWORD}" createdb -U "${PG_SUPERUSER}" -h "${PGHOST}" -p "${PGPORT}" "{{database}}"
+{{/with}}
+
+# TODO this script is not beautiful -- if the init hook has been run before, this
+# will output errors. However, it's quicker to ignore the errors, and `exit 0`
+# here, than to first check if the user exists, and not create it if it does, etc
+exit 0

--- a/foulkon/hooks/run
+++ b/foulkon/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+exec worker -config-file {{pkg.svc_config_path}}/worker.toml
+
+# To use the proxy, exec this in your wrapper's run hook:
+# exec proxy -proxy-file {{pkg.svc_config_path}}/proxy.toml

--- a/foulkon/plan.sh
+++ b/foulkon/plan.sh
@@ -1,0 +1,67 @@
+go_pkg="github.com/Tecsisa/foulkon"
+
+pkg_name=foulkon
+pkg_description="Authorization server written in Go"
+pkg_origin=core
+pkg_version="v0.4.0"
+pkg_source="https://$go_pkg"
+pkg_upstream_url=$pkg_source
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_bin_dirs=(bin)
+pkg_build_deps=(
+  # core/which # let's just ignore those errors. works fine without.
+)
+pkg_deps=(
+  core/postgresql # for psql in hooks/init
+)
+pkg_scaffolding=core/scaffolding-go
+scaffolding_go_build_deps=()
+# note: foulkon uses github.com/Masterminds/glide; but we're using the version
+# foulkon uses instead of master (what scaffolding_go_build_deps would give us)
+
+pkg_exports=(
+  [port]=service.port
+  [host]=service.host
+)
+pkg_exposes=(port)
+pkg_binds_optional=(
+  [database]="port superuser_name superuser_password"
+)
+
+do_prepare() {
+  build_line "mkdir -p \$GOPATH/bin; export PATH=\$GOPATH/bin:\$PATH"
+  mkdir -p "$GOPATH/bin"
+  export PATH=$GOPATH/bin:$PATH
+}
+
+do_download() {
+  # `-d`: don't let go build it, we'll have to build this ourselves
+  # also, don't have `go get` bail when not finding a package in that directory
+  build_line "go get -d github.com/Tecsisa/foulkon"
+
+  go get -d github.com/Tecsisa/foulkon 2>&1 | grep -q "no Go files"
+
+  pushd "$scaffolding_go_pkg_path"
+    git reset --hard $pkg_version
+  popd
+}
+
+do_build() {
+  pushd "$scaffolding_go_pkg_path"
+    build_line "make deps generate"
+    make deps generate
+
+    # Note: We don't do 'make bin', because it's only these two we need
+    #       (It's not worth installing env, and fixing up paths etc...)
+    build_line "CGO_ENABLED=0 go install github.com/Tecsisa/foulkon/cmd/{worker,proxy}"
+    CGO_ENABLED=0 go install github.com/Tecsisa/foulkon/cmd/worker
+    CGO_ENABLED=0 go install github.com/Tecsisa/foulkon/cmd/proxy
+  popd
+}
+
+do_install() {
+  build_line "copying worker and proxy binary"
+  cp "${scaffolding_go_gopath:?}/bin/worker" "$pkg_prefix/bin"
+  cp "${scaffolding_go_gopath:?}/bin/proxy" "$pkg_prefix/bin"
+}


### PR DESCRIPTION
This adds a plan for [Foulkon](https://github.com/Tecsisa/foulkon/), an IAM-like authz service.

It contains _two services_: [Worker](https://github.com/Tecsisa/foulkon/blob/4e778b4a8f60c10067b61ab39a232397a0daeb49/doc/deploy/worker.md#deploy-foulkon-worker) and [Proxy](https://github.com/Tecsisa/foulkon/blob/4e778b4a8f60c10067b61ab39a232397a0daeb49/doc/deploy/proxy.md#deploy-foulkon-proxy). As added here, `core/foulkon` will [start the worker](https://github.com/habitat-sh/core-plans/compare/master...srenatus:sr/add-foulkon?expand=1#diff-bf5cdec83b952b2d52670605bb7a4e38R4). To start the proxy, wrap this plan and override [the run hook](https://github.com/habitat-sh/core-plans/compare/master...srenatus:sr/add-foulkon?expand=1#diff-bf5cdec83b952b2d52670605bb7a4e38).