### PR TITLE
[scaffolding-ruby] provide a default database config for asset compilation

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -390,6 +390,7 @@ scaffolding_run_assets_precompile() {
     pushd "$scaffolding_app_prefix" > /dev/null
     if _rake -P --trace | grep -q '^rake assets:precompile$'; then
       build_line "Detected and running Rake 'assets:precompile'"
+      export DATABASE_URL=${DATABASE_URL:-"postgresql://nobody@nowhere/fake_db_to_appease_rails_env"}
       _rake assets:precompile
     fi
     popd > /dev/null


### PR DESCRIPTION
## Issue

Reported in [HabiChat](http://slack.habitat.sh/):

> Following [these instructions](https://www.habitat.sh/blog/2017/08/habitat-rails-postgres-3-different-ways/) to convert an existing rails 5 app to habitat.  Everything works fine, until the build.  The scaffolding detects and runs Rake 'assets:precompile', but then crashes because it can't find config/database.yml.  This confuses me on two fronts:  1) This is the build phase, and I haven't deployed a database for it to talk to; b) I do have a config/database.yml, albeit configured with dummy data.

> If the database isn't available during build phase, but the scaffolding ultimately provides the database configuration during runtime, shouldn't the scaffolding provide a dummy-but-connectable database configuration so that the rake commands that have nothing to do with the database run correctly?  Or is there something else I can do to make this work?

> The offending error:

 ```
myapp: Detected and running Rake 'assets:precompile'
rake aborted!
Cannot load `Rails.application.database_configuration`:
Could not load database configuration. No such file - ["config/database.yml"]
```

## Hacky Fix

The following in the Rails app's plan resolved the error:

```
do_install() {
  export DATABASE_URL="postgresql://nobody@nowhere/fake_db_to_appease_rails_env"
  do_default_install
}
```

## Proposed Solution

While Rails core no longer requires a database configuration by default during asset compilation, some gems assume a database is available on load and some Rails applications have ActiveRecord calls in routes. Either will trigger a database config validation during assets:precompile. Setting `DATABASE_URL` to a connection string that parses cleanly will appease these applications.

Opted to check for and use an existing `DATABASE_URL` in case a plan for an app actually does need a connection string to a running database. The logistics for setting all that up is outside the scope of scaffolding–and really is a path fraught with suffering that should be avoided–but it is easy enough to not clobber something that may have been set by the plan author already.