### PR TITLE
[JDK7] Stop depending on Oracle's unreliable download links

### DIFF
--- a/jdk7/plan.sh
+++ b/jdk7/plan.sh
@@ -2,7 +2,7 @@ pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_name=jdk7
 pkg_version=7u80
-pkg_source=http://download.oracle.com/otn-pub/java/jdk/${pkg_version}-b15/jdk-${pkg_version}-linux-x64.tar.gz
+pkg_source=https://www.dropbox.com/s/lni4xcu2eqhqjq9/jdk-${pkg_version}-linux-x64.tar.gz
 pkg_shasum=bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623
 pkg_filename=jdk-${pkg_version}-linux-x64.tar.gz
 pkg_license=('Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX')
@@ -16,36 +16,8 @@ pkg_include_dirs=(include)
 
 source_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
 
-## Refer to habitat/components/plan-build/bin/hab-plan-build.sh for help
-
-# Customomized download_file() to work around the Oracle EULA Cookie-wall
-#  See: http://stackoverflow.com/questions/10268583/downloading-java-jdk-on-linux-via-wget-is-shown-license-page-instead
-download_file() {
-  local url="$1"
-  local dst="$2"
-  local sha="$3"
-
-  build_line "By including the JDK you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
-
-  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
-  if [[ -f $dst && -n "$sha" ]]; then
-    build_line "Found previous file '$dst', attempting to re-use"
-    if verify_file "$dst" "$sha"; then
-      build_line "Using cached and verified '$dst'"
-      return 0
-    else
-      build_line "Clearing previous '$dst' file and re-attempting download"
-      rm -fv "$dst"
-    fi
-  fi
-
-  build_line "Downloading '$url' to '$dst'"
-  $_wget_cmd --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie"  "$url" -O "$dst"
-  build_line "Downloaded '$dst'";
-  popd > /dev/null
-}
-
 do_unpack() {
+  build_line "By including the JDK you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
   local unpack_file="$HAB_CACHE_SRC_PATH/$pkg_filename"
   mkdir "$source_dir"
   pushd "$source_dir" >/dev/null


### PR DESCRIPTION
Around 2-3 months ago Oracle changed how users can access older versions of the JDK. JDK7 was affected. You can no longer download jdk7 without authenticating with an Oracle SSO.

This change points the pkg source to Arch Linux hosted download location. Oracle JDK7u80  is hosted there in its entirety. I've tested this build and the sha is exactly the same.

Signed-off-by: eeyun <ihenry@chef.io>