### PR TITLE
[JRE7] Stop relying on Oracle's unreliable download links

### DIFF
--- a/jre7/plan.sh
+++ b/jre7/plan.sh
@@ -2,7 +2,7 @@ pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_name=jre7
 pkg_version=7u80
-pkg_source=http://download.oracle.com/otn-pub/java/jdk/${pkg_version}-b15/jre-${pkg_version}-linux-x64.tar.gz
+pkg_source=https://www.dropbox.com/s/77b7n7wkjzpzhfd/jre-${pkg_version}-linux-x64.tar.gz
 pkg_shasum=4c01efd0d8e80bb6e2f324ec3408ce64f066d4506c7ec93a491f615a4523f4f3
 pkg_filename=jre-${pkg_version}-linux-x64.tar.gz
 pkg_license=('Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX')
@@ -15,35 +15,6 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 source_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
-
-## Refer to habitat/components/plan-build/bin/hab-plan-build.sh for help
-
-# Customomized download_file() to work around the Oracle EULA Cookie-wall
-#  See: http://stackoverflow.com/questions/10268583/downloading-java-jdk-on-linux-via-wget-is-shown-license-page-instead
-download_file() {
-  local url="$1"
-  local dst="$2"
-  local sha="$3"
-
-  build_line "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
-
-  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
-  if [[ -f $dst && -n "$sha" ]]; then
-    build_line "Found previous file '$dst', attempting to re-use"
-    if verify_file "$dst" "$sha"; then
-      build_line "Using cached and verified '$dst'"
-      return 0
-    else
-      build_line "Clearing previous '$dst' file and re-attempting download"
-      rm -fv "$dst"
-    fi
-  fi
-
-  build_line "Downloading '$url' to '$dst'"
-  $_wget_cmd --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" "$url" -O "$dst"
-  build_line "Downloaded '$dst'";
-  popd > /dev/null
-}
 
 do_unpack() {
   local unpack_file="$HAB_CACHE_SRC_PATH/$pkg_filename"


### PR DESCRIPTION
This change sets the JRE7 package source to point to the Arch Linux Project's hosted package.
Signed-off-by: eeyun <ihenry@chef.io>