### PR TITLE
[haproxy] Removes config servers and relies on binding

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -15,17 +15,9 @@ backend default
 {{#if cfg.httpchk}}
     option httpchk {{cfg.httpchk}}
 {{~/if}}
-{{#if bind.has_backend }}
-{{~#each bind.backend.members}}
-{{~#if alive }}
-    server {{sys.ip}} {{sys.ip}}:{{cfg.port}}
-{{~/if}}
-{{~/each}}
-{{else}}
-{{~#each cfg.server}}
-    server {{name}} {{host_or_ip}}:{{port}}
-{{~/each}}
-{{~/if}}
+{{~#eachAlive bind.backend.members as |member|}}
+    server {{member.sys.ip}} {{member.sys.ip}}:{{member.cfg.port}}
+{{~/eachAlive}}
 
 {{#if cfg.status.enabled}}
 listen  stats

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -13,13 +13,3 @@ port = 9000
 user = "admin"
 password = "password"
 uri = "/haproxy-stats"
-
-[[server]]
-name = "first"
-host_or_ip = "172.17.0.3"
-port = "8000"
-
-[[server]]
-name = "second"
-host_or_ip = "172.17.0.4"
-port = "8000"


### PR DESCRIPTION
I found that when launching `core/haproxy` that the binding
is required so I don't know a situation where the supervisor
would ever use the default values found in the configuration.

I found that `has_backend` to not work correctly and always
return a false value. Making it so the members found in the
backend binding to never appear in the configuration and
for haproxy to always fall back on the default values.

I replaced the loop for writing out the backends with an
`eachAlive` which is an equivalent of `each` with the check
to see if it is alive inside the loop.

Signed-off-by: Franklin Webber <franklin@chef.io>