### PR TITLE
Fix local src build of scaffolding-go

### DIFF
--- a/scaffolding-go/lib/scaffolding.sh
+++ b/scaffolding-go/lib/scaffolding.sh
@@ -71,8 +71,9 @@ scaffolding_go_before() {
   # Initialize the Go Workspace package path if we are tryng to build the
   # package from local /src, that is when there is no $pkg_source set.
   if [[ ! $pkg_source ]]; then
-    mkdir -p "$scaffolding_go_pkg_path"
-    cp -r /src/* "$scaffolding_go_pkg_path"
+    mkdir -p "/tmp/srctmp/${scaffolding_go_base_path}"
+    cp -r /src "/tmp/srctmp/${scaffolding_go_base_path}/${pkg_name}"
+    mv /tmp/srctmp /src/src
   fi
 }
 

--- a/scaffolding-go/lib/scaffolding.sh
+++ b/scaffolding-go/lib/scaffolding.sh
@@ -71,9 +71,11 @@ scaffolding_go_before() {
   # Initialize the Go Workspace package path if we are tryng to build the
   # package from local /src, that is when there is no $pkg_source set.
   if [[ ! $pkg_source ]]; then
-    mkdir -p "/tmp/srctmp/${scaffolding_go_base_path}"
-    cp -r /src "/tmp/srctmp/${scaffolding_go_base_path}/${pkg_name}"
-    mv /tmp/srctmp /src/src
+    local tmp_src
+    tmp_src="${HAB_CACHE_SRC_PATH}/${pkg_name}_src"
+    mkdir -p "${tmp_src}/${scaffolding_go_base_path}"
+    cp -r "${scaffolding_go_gopath}" "${tmp_src}/${scaffolding_go_base_path}/${pkg_name}"
+    mv "${tmp_src}" "${scaffolding_go_workspace_src}"
   fi
 }
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This corrects an issue that was occurring for the use of *scaffolding-go* when opting to use local source instead of downloaded from external.

It was previously resulting in a directory copy error:

```
cp: cannot copy a directory, '/src/src', into itself, '/src/src/github.com/predominant/hello_string/src'
```

This fixes the issue, but might need some adjustments regarding temporary location, and exact commands.