### PR TITLE
Bump package version

### DIFF
--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-ruby
 pkg_origin=core
-pkg_version="0.8.3"
+pkg_version="0.8.5"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"


### PR DESCRIPTION
We have a version 0.8.4 that was built and up-loaded ad-hoc. That version is the latest, but no longer correct as it is dependent on a deprecated version of Ruby. So we need to bump up the package version.

Signed-off-by: Salim Alam <salam@chef.io>