### PR TITLE
move setting scaffolding prefix until after pkg_version is computed

### DIFF
--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -18,6 +18,8 @@ scaffolding_load() {
 
 do_default_prepare() {
   export NODE_ENV=production
+  # The install prefix path for the app
+  scaffolding_app_prefix="$pkg_prefix/$app_prefix"
   build_line "Setting NODE_ENV=$NODE_ENV"
 }
 
@@ -230,7 +232,7 @@ _setup_vars() {
   # `$scaffolding_node_pkg` is empty by default
   : "${scaffolding_node_pkg:=}"
   # The install prefix path for the app
-  scaffolding_app_prefix="$pkg_prefix/app"
+  app_prefix="app"
   #
   : "${scaffolding_app_port:=8000}"
   # If `${scaffolding_env[@]` is not yet set, setup the hash
@@ -390,7 +392,7 @@ _update_bin_dirs() {
   pkg_bin_dirs=(
     ${pkg_bin_dir[@]}
     bin
-    $(basename "$scaffolding_app_prefix")/node_modules/.bin
+    $app_prefix/node_modules/.bin
   )
 }
 

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.1"
+pkg_version="0.6.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -26,6 +26,8 @@ fi
 
 do_default_prepare() {
   local gem_dir gem_path
+  # The install prefix path for the app
+  scaffolding_app_prefix="$pkg_prefix/$app_prefix"
 
   # Determine Ruby engine, ABI version, and Gem path by running `ruby` itself.
   eval "$(ruby -rubygems -rrbconfig - <<-'EOF'
@@ -447,7 +449,7 @@ _setup_vars() {
   _bundler_version="$("$(pkg_path_for bundler)/bin/bundle" --version \
     | awk '{print $NF}')"
   # The install prefix path for the app
-  scaffolding_app_prefix="$pkg_prefix/app"
+  app_prefix="app"
   #
   : "${scaffolding_app_port:=8000}"
   # If `${scaffolding_env[@]` is not yet set, setup the hash
@@ -620,13 +622,13 @@ _update_bin_dirs() {
   pkg_bin_dirs=(
     ${pkg_bin_dir[@]}
     bin
-    $(basename "$scaffolding_app_prefix")/binstubs
+    $app_prefix/binstubs
   )
 }
 
 _update_svc_run() {
   if [[ -z "$pkg_svc_run" ]]; then
-    pkg_svc_run="$pkg_prefix/bin/${pkg_name}-web"
+    pkg_svc_run="${pkg_name}-web"
     build_line "Setting pkg_svc_run='$pkg_svc_run'"
   fi
 }

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-ruby
 pkg_origin=core
-pkg_version="0.8.5"
+pkg_version="0.8.6"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"


### PR DESCRIPTION
`scaffolding_app_prefix` isn't truly needed until `do_prepare()` or later. Moved setting it into scaffold's `do_default_prepare()`.

Before it was being set suuuuper early in the scaffolding build. Because it uses `$pkg_prefix`, when set so early, it did not benefit from `$pkg_prefix` getting updated by `update_pkg_version()` which would leave some paths to things with a version of `__pkg__version__unset__`.

Instead, at the early point where `scaffolding_app_prefix` used to be set, `$app_prefix` is set to denote the directory inside the package into which the application will be copied.

For setting `pkg_bin_dirs`, `$app_prefix` ("app") is used instead of computing the basename of `$scaffolding_app_prefix` (also just "app").

For `pkg_svc_run`, because the `bin/` directory has already been added to `pkg_bin_dirs` and is therefore on the runtime PATH, only the executable needs to be named there, not the full path to it.