### PR TITLE
[libidn] Update to v1.33

### DIFF
--- a/libidn/plan.sh
+++ b/libidn/plan.sh
@@ -1,20 +1,41 @@
 pkg_name=libidn
 pkg_origin=core
-pkg_version=1.32
-pkg_license=('lgplv2+')
+pkg_version=1.33
+pkg_description="Library for internationalized domain names"
+pkg_upstream_url=https://www.gnu.org/software/libidn/
+pkg_license=('LGPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=ba5d5afee2beff703a34ee094668da5c6ea5afa38784cebba8924105e185c4f5
+pkg_shasum=44a7aab635bb721ceef6beecc4d49dfd19478325e1b47f3196f7d2acc4930e19
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/file
+  core/gcc
+  core/make
+  core/patch
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
 
 do_check() {
   make check
 }
 
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}
 
 # ----------------------------------------------------------------------------
 # **NOTICE:** What follows are implementation details required for building a


### PR DESCRIPTION
Address open CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2015-8948
https://nvd.nist.gov/vuln/detail/CVE-2016-6261
https://nvd.nist.gov/vuln/detail/CVE-2016-6262
https://nvd.nist.gov/vuln/detail/CVE-2016-6263

Update plan to include required metadata and improve readability

Signed-off-by: Mike Fiedler <miketheman@gmail.com>