### PR TITLE
Update Varnish Download URL

### DIFF
--- a/varnish/plan.sh
+++ b/varnish/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="http://varnish-cache.org/"
 pkg_license=('bsd')
 pkg_version="5.1.2"
-pkg_source="https://repo.varnish-cache.org/source/${pkg_name}-${pkg_version}.tar.gz"
+pkg_source="https://varnish-cache.org/_downloads/${pkg_name}-${pkg_version}.tgz"
 
 pkg_shasum="39d858137e26948a7c85f07363f13f0778da61d234126e03a160a0cb9ba4fce3"
 pkg_deps=(core/glibc core/ncurses core/docutils core/pcre core/gcc core/bash )


### PR DESCRIPTION
Varnish has updated their download URL. The previous one no longer works