### PR TITLE
optional ldap and ssl support for grafana

### DIFF
--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -20,11 +20,11 @@
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
 #
-;data = /var/lib/grafana
+# data = {pkg.svc_var_path}/lib/grafana
 #
 # Directory where grafana can store logs
 #
-;logs = /var/log/grafana
+# logs = {pkg.svc_var_path}/log/grafana
 #
 # Directory where grafana will automatically scan and look for plugins
 #
@@ -34,7 +34,7 @@
 #################################### Server ####################################
 [server]
 # Protocol (http or https)
-;protocol = http
+protocol = {{cfg.protocol}}
 
 # The ip address to bind to, empty will bind to all interfaces
 ;http_addr =
@@ -63,8 +63,8 @@ http_port = {{cfg.listening_port}}
 ;enable_gzip = false
 
 # https certs & key file
-;cert_file =
-;cert_key =
+cert_file = {{cfg.cert_file}}
+cert_key = {{cfg.cert_key}}
 
 #################################### Database ####################################
 [database]
@@ -274,9 +274,9 @@ admin_password = {{ cfg.admin_pass }}
 
 #################################### Auth LDAP ##########################
 [auth.ldap]
-;enabled = false
-;config_file = /etc/grafana/ldap.toml
-;allow_sign_up = true
+enabled = {{cfg.ldap_enabled}}
+config_file = {{pkg.svc_config_path}}/ldap.toml
+allow_sign_up = true
 
 #################################### SMTP / Emailing ##########################
 [smtp]

--- a/grafana/config/ldap.toml
+++ b/grafana/config/ldap.toml
@@ -1,0 +1,62 @@
+# Set to true to log user information returned from LDAP
+verbose_logging = true
+
+[[servers]]
+# Ldap server host (specify multiple hosts space separated)
+host = "{{cfg.ldap_host}}"
+# Default port is 389 or 636 if use_ssl = true
+port = 389
+# Set to true if ldap server supports TLS
+use_ssl = false
+# Set to true if connect ldap server with STARTTLS pattern (create connection in insecure, then upgrade to secure connection with TLS)
+start_tls = false
+# set to true if you want to skip ssl cert validation
+ssl_skip_verify = false
+# set to the path to your root CA certificate or leave unset to use system defaults
+# root_ca_cert = "/path/to/certificate.crt"
+
+# Search user bind dn
+bind_dn = "{{cfg.ldap_bind_dn}}"
+# Search user bind password
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+bind_password = '{{cfg.ldap_bind_password}}'
+
+# User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"
+search_filter = "(cn=%s)"
+
+# An array of base dns to search through
+search_base_dns = ["{{cfg.ldap_search_base_dns}}"]
+
+# In POSIX LDAP schemas, without memberOf attribute a secondary query must be made for groups.
+# This is done by enabling group_search_filter below. You must also set member_of= "cn"
+# in [servers.attributes] below.
+
+## Group search filter, to retrieve the groups of which the user is a member (only set if memberOf attribute is not available)
+# group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+## An array of the base DNs to search through for groups. Typically uses ou=groups
+# group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
+
+# Specify names of the ldap attributes your ldap uses
+[servers.attributes]
+name = "givenName"
+surname = "sn"
+username = "sAMAccountName"
+member_of = "memberOf"
+email =  "email"
+
+# Map ldap groups to grafana org roles
+[[servers.group_mappings]]
+group_dn = "{{cfg.ldap_admin_group}}"
+org_role = "Admin"
+# The Grafana organization database id, optional, if left out the default org (id 1) will be used.  Setting this allows for multiple group_dn's to be assigned to the same org_role provided the org_id differs
+# org_id = 1
+
+[[servers.group_mappings]]
+group_dn = "{{cfg.ldap_editor_group}}"
+org_role = "Editor"
+
+[[servers.group_mappings]]
+# If you want to match all (or no ldap groups) then you can use wildcard
+group_dn = "{{cfg.ldap_viewer_group}}"
+org_role = "Viewer"
+

--- a/grafana/default.toml
+++ b/grafana/default.toml
@@ -1,4 +1,18 @@
-
-listening_port = 3000
+#Default config items
+listening_port = 80
 admin_user = "admin"
 admin_pass = "password"
+
+#LDAP config
+ldap_enabled = "false"
+ldap_host = ""
+ldap_bind_dn = ""
+ldap_bind_password = ""
+ldap_search_base_dns = ""
+ldap_admin_group = ""
+ldap_editor_group = ""
+ldap_viewer_group = "*"
+
+protocol = "http"
+cert_file = ""
+cert_key = ""

--- a/grafana/plan.sh
+++ b/grafana/plan.sh
@@ -11,7 +11,7 @@ pkg_deps=(core/glibc core/bash core/wget core/curl core/cacerts)
 pkg_build_deps=(core/patchelf)
 pkg_bin_dirs=(bin)
 pkg_description="Grafana graphing app, dynamically finds prometheus data sources"
-
+pkg_svc_user="root"
 pkg_exports=(
   [grafana_port]=listening_port
 )

--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="6.10.3"
+$pkg_version="6.11.2"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="3ab1286e8fdadc60f57a97f2222ad6b3d7a48847a52ef812cc8d5f354bf500ff"
+$pkg_shasum="ce57b050e11b3b8d46e18c85512384c8e2b1c0bd9f7832ba9786e175152a02a0"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=6.10.3
+pkg_version=6.11.2
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=a8f679f595fd921305c28d126935ad59b4419ac8474a99997a31e01ab50acd3d
+pkg_shasum=20146ed51b638404665737ed8a25cc06e96d7d7259eb90a4bdec4730a78002a6
 pkg_deps=(core/glibc core/gcc-libs core/coreutils)
 pkg_build_deps=(core/python2 core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.0"
+pkg_version="0.6.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
Allows Granfana to bind to different ports and support for Ldap and Ssl with config exposed in config.toml.