### PR TITLE
Create symlinks to kmod alternative names

### DIFF
--- a/kmod/plan.sh
+++ b/kmod/plan.sh
@@ -26,6 +26,16 @@ do_build() {
   make
 }
 
+do_install() {
+  do_default_install
+
+  pushd "${pkg_prefix}/bin" >/dev/null
+  for bin in {depmod,insmod,lsmod,modinfo,modprobe,rmmod}; do
+    ln -s kmod "$bin"
+  done
+  popd >/dev/null
+}
+
 do_end() {
   if [[ -n "${_clean_file}" ]]; then
     rm -f /usr/bin/file


### PR DESCRIPTION
This updates the kmod package to create symlinks to its alternative names (insmod, depmod, modprobe, etc.)

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>