### PR TITLE
[CONTRIBUTING] Add note about only using BusyBox sh in hooks.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ The supervisor dynamically invokes hooks at run-time, triggered by an applicatio
   - Redirect `stderr` to `stdout` (e.g. with `exec 2>&1` at the start of the hook)
   - Call the command to execute with `exec <command> <options>` rather than running the command directly. This ensures the command is executed in the same process and that the service will restart correctly on configuration changes.
   - If you are running something with a pipe `exec` won't work.
+  - Always assume a minimal BusyBox `sh` implementation, never GNU Bash unless `core/bash` is an explicit run dependency and the hook's shebang line calls this Bash interpreter directly.
 - Attempting to execute commands as a `root` user or trying to do `sudo hab install` are not good practice.
 - Don't edit any of the Supervisor rendered templates.
   - You can only write to: `/var/`, `/static/`, `/data/` directories. You should only access these with your `runtime configuration setting` variable.


### PR DESCRIPTION
Until the Supervisor is made more intelligent about which shell
interpreter to execute, all hooks written for core Plans must assume a
minmal bourne shell, such as BusyBox's `sh`, and never assume GNU
Bashims. This will cause breakages when running on systems which have
`/bin/sh` using a dash or non GNU Bash mode.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>