### PR TITLE
[go] bump 1.9.1

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.9
+pkg_version=1.9.1
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=a4ab229028ed167ba1986825751463605264e44868362ca8e7accc8be057e993
+pkg_shasum=a84afc9dc7d64fe0fa84d4d735e2ece23831a22117b50dafc75c1484f1cb550e
 pkg_dirname=go
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)


### PR DESCRIPTION
> Two security-related issues were recently reported.
> To address this issue, we have just released Go 1.8.4 and Go 1.9.1.
>
> We recommend that all users update to one of these releases (if you're not sure which, choose Go 1.9.1).

https://groups.google.com/forum/#!topic/golang-nuts/sHfMg4gZNps