### PR TITLE
[sensu] Add openssl to LD_LIBRARY_PATH

### DIFF
--- a/sensu/hooks/run
+++ b/sensu/hooks/run
@@ -4,7 +4,7 @@ exec 2>&1
 
 export GEM_HOME="{{pkg.path}}/vendor/bundle/ruby/2.3.0"
 export GEM_PATH="{{pkgPathFor "core/ruby"}}/lib/ruby/gems/2.3.0:{{pkgPathFor "core/bundler"}}:$GEM_HOME"
-export LD_LIBRARY_PATH="{{pkgPathFor "core/gcc-libs"}}/lib:{{pkgPathFor "core/libffi"}}/lib"
+export LD_LIBRARY_PATH="{{pkgPathFor "core/gcc-libs"}}/lib:{{pkgPathFor "core/libffi"}}/lib:{{pkgPathFor "core/openssl"}}/lib"
 export CONFIG_DIR="{{pkg.svc_config_path}}"
 
 if [ "{{cfg.mode}}" == "client" ]


### PR DESCRIPTION
The current Sensu package fails to start:
```
sensu.default(O):
/hab/pkgs/nsdavidson/sensu/0.29.0/20171009174405/vendor/bundle/ruby/2.4.0/gems/eventmachine-1.2.2/lib/eventmachine.rb:8:in
`require': libssl.so.1.0.0: cannot open shared object file: No such file
or directory -
/hab/pkgs/nsdavidson/sensu/0.29.0/20171009174405/vendor/bundle/ruby/2.4.0/gems/eventmachine-1.2.2/lib/rubyeventmachine.so
(LoadError)`
```

Adding `core/openssl` to `LD_LIBRARY_PATH` resolves this and allows
sensu to start.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>