### PR TITLE
[tcpdump] Upgrade to 4.9.2

### DIFF
--- a/tcpdump/plan.sh
+++ b/tcpdump/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=tcpdump
 pkg_origin=core
-pkg_version=4.9.0
+pkg_version=4.9.2
 pkg_description="A powerful command-line packet analyzer."
 pkg_upstream_url="http://www.tcpdump.org/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://www.tcpdump.org/release/tcpdump-${pkg_version}.tar.gz
-pkg_shasum=eae98121cbb1c9adbedd9a777bf2eae9fa1c1c676424a54740311c8abcee5a5e
+pkg_shasum=798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79
 # core/coreutils isn't /really/ needed at runtime, but fix_interpreter
 # only works if the dep is listed in pkg_deps
 pkg_deps=(core/glibc core/libpcap core/openssl core/coreutils)


### PR DESCRIPTION
Version 4.9.2 primarily addresses a number of vulnerabilities.  See
the change log for the (long) list:

http://www.tcpdump.org/tcpdump-changes.txt

Signed-off-by: Steven Danna <steve@chef.io>