### PR TITLE
Application to be a core-plans maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ To become a maintainer, open a pull request to this list.
 ## Maintainers
 
 * [Seth Chisamore](https://github.com/schisamo)
+* [Steven Danna](https://github.com/stevendanna)
 * [Elliott Davis](https://github.com/elliott-davis)
 * [Mike Fiedler](https://github.com/miketheman)
 * [Scott Macfarlane](https://github.com/smacfarlane)


### PR DESCRIPTION
I've added or contributed to 40 core-plans:

 autogen, bdwgc, curl, dejagnu, ed, erlang, expect, freetype
 gcc, git, gsl, guile, haproxy, httpd, icu, imagemagick, jbigkit
 libatomic_ops, libpcap, libscrypt, libseccomp, libtiff, libunistring
 libunwind, libxslt, lsof, lua, lzip, mercurial, openssl, pixman, python
 rsync, socat, strace, tcl, tcpdump, tmux, tor, valgrind

In addition I've made a couple of minor contributions to Habitat and
try to stay up-to-date on the state of the code base.  Currently, I'm
working on packaging X client libraries.

I've also served as an omnibus-software maintainer and have experience
solving a variety of software build problems across a number of
language ecosystems and on a number of platforms.

My personal goals as a maintainer would be to (1) work on policies and
tooling to keep core-plans up-to-date with its many upstreams, (2)
improve habitat's support for the language runtimes and userspace
tooling necessary to make habitat a good basis for development
environments. I am also willing to help across the core-plans
repository.

Signed-off-by: Steven Danna <steve@chef.io>