### PR TITLE
Change logging level and dir

### DIFF
--- a/sumologic/config/wrapper.conf
+++ b/sumologic/config/wrapper.conf
@@ -86,10 +86,10 @@ wrapper.app.parameter.1=com.sumologic.scala.collector.Collector
 wrapper.console.format=PM
 
 # Log Level for console output.  (See docs for log levels)
-wrapper.console.loglevel=INFO
+wrapper.console.loglevel=ERROR
 
 # Log file to use for wrapper output logging.
-wrapper.logfile={{pkg.svc_var_path}}/logs/collector.out.log
+wrapper.logfile={{pkg.svc_var_path}}/collector.out.log
 
 # Format of output for the log file.  (See docs for formats)
 wrapper.logfile.format=LPTM


### PR DESCRIPTION
Couple of minor tweaks to the sumologic wrapper configuration - change the default console logging level to Error in order to not have a ton of spew in the hab syslog, and also fix the collector logging directory location.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-244893104](https://user-images.githubusercontent.com/13542112/31570570-f65df07e-b039-11e7-97c8-5334045b149b.gif)
