### PR TITLE
Adds in support for prebuild and postbuild scripts defined in package…

### DIFF
--- a/scaffolding-node/CHANGELOG.md
+++ b/scaffolding-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-node)
 
+## 0.6.6 (10-18-2017)
+
+- support prebuild and postbuild scripts
+
 ## 0.6.5 (10-11-2017)
 
 - Exclude the results/ directory from inclusion in a package [#854]

--- a/scaffolding-node/README.md
+++ b/scaffolding-node/README.md
@@ -6,4 +6,12 @@ Node Scaffolding is a Habitat package which helps you build your  [Node.js][node
 * [Node Scaffolding Quickstart Guide](doc/quickstart.md)
 * [Node Scaffolding Documentation](doc/reference.md)
 
+# Pre-build, build, and post-build steps}
+
+This scaffolding does support running build scripts, etc. that are defined in package.json. However, due to a [known issue](https://github.com/habitat-sh/habitat/issues/1547), you will need to run the Habitat services as "root" rather than the default "hab" user.  You can do this by adding this line to your plan.sh
+
+```
+pkg_svc_user=root
+```
+
 [node]: https://nodejs.org/en/

--- a/scaffolding-node/doc/reference.md
+++ b/scaffolding-node/doc/reference.md
@@ -179,6 +179,10 @@ scaffolding_pkg_manager=yarn
 
 This would force the Scaffolding code to use Yarn over npm, even if no `yarn.lock` file was present.
 
+## Build and Post-Build scripts
+
+This scaffolding does support running build scripts, etc. that are defined in package.json. However, due to a [known issue](https://github.com/habitat-sh/habitat/issues/1547), you will need to run the Habitat services as "root" rather than the default "hab" user.  You can do this by adding this line to your plan.sh
+
 ## Process Bins
 
 Your app may have one or more top-level processes which map to a [running service or ephemeral task][12factor_processes]. Each of these processes will be wrapped up in a small script which sets up a suitable app environment and invokes a command. By convention the main process bin which the package's `run` hook will invoke is the `web` process.

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.5"
+pkg_version="0.6.6"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"
 pkg_upstream_url="https://github.com/habitat-sh/core-plans/tree/master/scaffolding-node"
-pkg_deps=(core/tar core/rq core/jq-static core/gawk core/curl core/bc)
+pkg_deps=(core/tar core/rq core/jq-static core/gawk core/curl core/bc core/coreutils)
 pkg_build_deps=(core/node core/coreutils)
 
 do_build() {


### PR DESCRIPTION
….json

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>

Fixes #815 

To test:
(Using a build of the scaffolding-node in this branch)
```bash
$ git clone git@github.com:alik0211/pokedex.git
$ cd pokedex
$ npm install
$ hab plan init -s node
$ hab studio enter
$ (studio) build
$ (studio) hab pkg export docker ./results/<hart file>
$ (studio) exit
$ docker run -it -p 8000:8000 core/pokedex
```
Navigate to http://localhost:8000