### PR TITLE
Include tools to investigate hardened builds

### DIFF
--- a/bin/check-security-features.sh
+++ b/bin/check-security-features.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#
+# check-security-features.sh: Report on compiler and linker-level
+# security features for a given package.
+#
+error() {
+  echo "$1" 2>&1
+}
+
+usage() {
+  error "usage: $0 PACKAGE_NAME"
+}
+
+bins_for_pkg() {
+  find "/hab/pkgs/$1" -type f -perm -u+w -print0 2> /dev/null \
+    | while read -rd '' f; do
+      case "$(file -bi "$f")" in
+        *application/x-executable*) echo "$f";;
+        *application/x-sharedlib*) echo "$f";;
+        *) continue;;
+      esac
+   done
+}
+
+
+check_nx_stack() {
+   if echo "$1" | grep -q "GNU_STACK.*RWX"; then
+      echo "No"
+   else
+      echo "Yes"
+   fi
+}
+
+check_relro() {
+  if echo "$1" | grep -q "GNU_RELRO"; then
+    echo "Yes"
+  else
+    echo "No"
+  fi
+}
+
+check_bindnow() {
+  if echo "$1" | grep -q "BIND_NOW"; then
+    echo "Yes"
+  else
+    echo "No"
+  fi
+}
+
+check_stack_canary() {
+  if echo "$1" | grep -q "__stack_chk_fail"; then
+    echo "Yes"
+  else
+    echo "No"
+  fi
+}
+
+check_fortify() {
+  if echo "$1" | grep -q "_chk@"; then
+    echo "Yes"
+  else
+    echo "No"
+  fi
+}
+
+run_readelf() {
+  out=$(readelf -W -a "$filename")
+  if [[ -z "$out" ]]; then
+    error "readelf produced no output!"
+    error "Is $filename a shared object or executable file?"
+    exit 1
+  fi
+  echo "$out"
+}
+
+do_check() {
+   filename=$1
+   readelf_output=$(run_readelf)
+   canary=$(check_stack_canary "$readelf_output")
+   nx_stack=$(check_nx_stack "$readelf_output")
+   fortify=$(check_fortify "$readelf_output")
+   relro=$(check_relro "$readelf_output")
+   bindnow=$(check_bindnow "$readelf_output")
+   echo "${filename}%${canary}%${nx_stack}%${fortify}%${relro}%${bindnow}"
+}
+
+if [ -z "$1" ]; then
+  error "No package name provided"
+  usage
+  exit 1
+fi
+
+header="FILENAME%STACK_CANARY%NX_STACK%FORTIFY%RELRO%BIND_NOW"
+body=""
+
+for file in $(bins_for_pkg "$1"); do
+  body="${body}\n$(do_check "$file")"
+done
+
+echo -e "${header}\n${body}" | column -s'%' -t

--- a/coreutils/plan.sh
+++ b/coreutils/plan.sh
@@ -13,6 +13,8 @@ pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/env)
 
+source ../includes/hardening-defaults.sh
+
 do_build() {
   # The `FORCE_` variable allows the software to compile with the root user,
   # and the `--enable-no-install-program` flag skips installation of binaries

--- a/includes/hardening-defaults.sh
+++ b/includes/hardening-defaults.sh
@@ -1,0 +1,42 @@
+build_line "Using hardened build flags"
+#
+# Stack canaries
+#
+# -fstack-protector-strong provides more protection than
+# --fstack-protector without the performance hit of
+# --fstack-protector-all.
+#
+# See: https://lwn.net/Articles/584225/
+#
+DEFAULT_HARDENING_CFLAGS="-fstack-protector-strong"
+#
+# RELRO
+#
+# Sets relocation-related memory sections to read-only before
+# execution is turned over to the program, preventing overwriting of
+# the Global Offset Table.
+#
+DEFAULT_HARDENING_LDFLAGS="-Wl,-z,relro"
+#
+# BIND_NOW
+#
+# Resolve all symbols when loading the program rather than lazily.
+# This, with RELRO, allows the entire GOT to be marked read-only.
+#
+DEFAULT_HARDENING_LDFLAGS="${DEFAULT_HARDENING_LDFLAGS} -Wl,-z,now"
+#
+# _FORTIFY_SOURCE is a glibc macro that adds checks to commonly
+# misused functions in order to prevent buffe oveflow errors.
+#
+# _FORTIFY_SOURCE requires an optimized build of at least -O1.
+#
+# See: http://man7.org/linux/man-pages/man7/feature_test_macros.7.html
+#
+DEFAULT_HARDENING_CFLAGS="${DEFAULT_HARDENING_CFLAGS} -O2"
+DEFAULT_HARDENING_CPPFLAGS="-D_FORTIFY_SOURCE=2"
+
+
+export CFLAGS="$CFLAGS $DEFAULT_HARDENING_CFLAGS"
+export CPPFLAGS="$CPPFLAGS $DEFAULT_HARDENING_CPPFLAGS"
+export CXXFLAGS="$CXXLAGS $DEFAULT_HARDENING_CFLAGS"
+export LDFLAGS="$LDFLAGS $DEFAULT_HARDENING_LDFLAGS"


### PR DESCRIPTION
The desire for more robust default build flags was raised in
habitat-sh/core-plans#587. The goal of this build is to add a couple
of tools to make it easier to start investigating hardening
core-plans:

 - a shell script that can be included in plans to enable
   compiler- and linker-level security features.

 - a new bin/check-security-feature.sh script can be used
   to check that the resulting package actually has the features in the
   compiled executables.

Currently, we include the following flags:

- `-fstack-protector-strong`
- `-Wl,-z,relro`
- `-Wl,-z,now`
- `-D_FORTIFY_SOURCE=2 -O2`

For details on these flags, see in source comments.

### Possible Future Work

I've excluded PIE-related flags for now because I've found them hard
to set generally via CFLAGS.  It may be easier to pursue PIE builds
with a gcc built with `--default-enable-pie`.

Another often-used set of flags are format-security warning flags.
These flags would be useful if and only if we have a plan to maintain
patches to fix the warnings or contribute fixes upstream.

### Further Reading

For information on what other large distributions do:

- https://wiki.debian.org/Hardening
- https://wiki.gentoo.org/wiki/Project:Hardened
- https://fedoraproject.org/wiki/Changes/Harden_All_Packages

Signed-off-by: Steven Danna <steve@chef.io>