### PR TITLE
dpkg - Add sbin, and fix build and install

### DIFF
--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -29,6 +29,17 @@ pkg_build_deps=(
   core/xz
   core/zlib
 )
-pkg_bin_dirs=(bin)
+pkg_bin_dirs=(bin sbin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_description="Debian Package Manager"
+
+do_build() {
+  export prefix=$pkg_prefix
+  do_default_build
+}
+
+do_install() {
+  export prefix=$pkg_prefix
+  do_default_install
+}


### PR DESCRIPTION
Pull in sbin to get all of dpkg's binaries.  Also, the Makefile doesn't follow normal gnu patterns, so explicitly set the prefix prior to making.  This gets all of the binaries and libraries into the correct location.


Signed-off-by: Nathan Cerny <ncerny@gmail.com>