### PR TITLE
bump libxslt, libxml2

### DIFF
--- a/libxml2/plan.sh
+++ b/libxml2/plan.sh
@@ -1,19 +1,21 @@
 pkg_name=libxml2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Libxml2 is the XML C parser and toolkit developed for the Gnome project"
+pkg_upstream_url=http://xmlsoft.org/
 pkg_origin=core
-pkg_version=2.9.2
+pkg_version=2.9.6
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://xmlsoft.org/sources/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=8b9038cca7240e881d462ea391882092dfdc6d4f483f72683e817be08df5ebbc
 pkg_deps=(core/zlib core/glibc)
 pkg_build_deps=(core/coreutils core/make core/gcc core/m4)
 pkg_filename=${pkg_name}-${pkg_version}.tar.xz
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
-pkg_shasum=5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc
 
 do_build() {
-  ./configure --prefix=${pkg_prefix} --without-python  --with-zlib=$(pkg_path_for zlib)
+  ./configure --prefix="$pkg_prefix" --without-python  --with-zlib="$(pkg_path_for zlib)"
   make
 }

--- a/libxslt/plan.sh
+++ b/libxslt/plan.sh
@@ -1,11 +1,13 @@
 pkg_name=libxslt
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.1.28
+pkg_description="Libxslt is the XSLT C library developed for the GNOME project"
+pkg_upstream_url=http://xmlsoft.org/XSLT/
+pkg_version=1.1.31
 pkg_origin=core
 pkg_license=('libxslt')
-pkg_source=ftp://xmlsoft.org/libxslt/libxslt-${pkg_version}.tar.gz
+pkg_source=http://xmlsoft.org/sources/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=5fc7151a57b89c03d7b825df5a0fae0a8d5f05674c0e7cf2937ecec4d54a028c
+pkg_shasum=db25e96b6b801144277e67c05b10560ac09dfff82ccd53a154ce86e43622f3ab
 pkg_deps=(core/glibc core/libxml2 core/zlib)
 pkg_build_deps=(core/coreutils core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Latest versions -- at least [one libxml2 CVE](https://nvd.nist.gov/vuln/detail/CVE-2017-9047) should be resolved (but I haven't tried to accumulate a list of CVEs between old_vsn and new_vsn).