### PR TITLE
[file] bump 5.32

### DIFF
--- a/file/plan.sh
+++ b/file/plan.sh
@@ -1,10 +1,12 @@
 pkg_name=file
 pkg_origin=core
-pkg_version=5.24
+pkg_version=5.32
+pkg_description="Ian Darwin's implementation of the Unix File(1) command."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('custom')
 pkg_source=ftp://ftp.astron.com/pub/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=802cb3de2e49e88ef97cdcb52cd507a0f25458112752e398445cea102bc750ce
+pkg_upstream_url=https://www.darwinsys.com/file/
+pkg_shasum=8639dc4d1b21e232285cd483604afc4a6ee810710e00e579dbe9591681722b50
 pkg_deps=(core/glibc core/zlib)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
The `pkg_upstream_url` is just a mirror, but the other host doesn't respond...