### PR TITLE
Adds zlib-static package

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -894,6 +894,8 @@ plan_path = "zlib-musl"
 paths = [
   "zlib/*",
 ]
+[zlib-static]
+plan_path = "zlib-static"
 [zookeeper]
 plan_path = "zookeeper"
 [zsh]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,3 +104,4 @@ mg @fnichol
 # This list shall be alphabetical, for sanity purposes.
 
 rabbitmqadmin @predominant
+zlib-static @rsertelon

--- a/zlib-static/README.md
+++ b/zlib-static/README.md
@@ -1,0 +1,7 @@
+# Zlib static
+
+This plan packages [zlib](http://www.zlib.net) as a static library (`libz.a`).
+
+## Usage
+
+This package is intended as a dependency only, and will not run anything.

--- a/zlib-static/plan.sh
+++ b/zlib-static/plan.sh
@@ -1,0 +1,25 @@
+pkg_name=zlib-static
+pkg_origin=core
+pkg_version=1.2.8
+pkg_description="Zlib static library"
+pkg_upstream_url="http://zlib.net/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('zlib')
+pkg_source=http://zlib.net/fossils/zlib-${pkg_version}.tar.gz
+pkg_shasum=36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
+pkg_dirname=zlib-${pkg_version}
+pkg_build_deps=(core/make core/gcc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+    pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+        ./configure --static
+        make
+    popd
+}
+
+do_install() {
+    cp "$HAB_CACHE_SRC_PATH/$pkg_dirname/libz.a" "$pkg_prefix/lib/"
+    cp "$HAB_CACHE_SRC_PATH/$pkg_dirname/*.h" "$pkg_prefix/include/"
+}


### PR DESCRIPTION
This package contains only header files for zlib and `libz.a`, to use as a static dependency.

The need for such a package is required for any software which needs to statically compile zlib in. I think it might be useful in core then.

It's inspired by my own package at https://github.com/rsertelon/rsertelon-plans/tree/master/zlib-static which I plan to deprecate if you accept this pull request :)