### PR TITLE
returns an error message when both a package-lock.json and yarn.lock file …

### DIFF
--- a/scaffolding-node/CHANGELOG.md
+++ b/scaffolding-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-node)
 
+## 0.6.7 (10-31-2017)
+
+- Detect if both a package-lock.json and yarn.lock are present
+
 ## 0.6.6 (10-18-2017)
 
 - support prebuild and postbuild scripts

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -270,7 +270,10 @@ _detect_package_json() {
     exit_with "Failed to parse package.json as JSON." 6
   fi
 
-  # TODO fin: do we check for any lockfiles here?
+  # Check if both a package.lock and a yarn.lock file are present
+  if [[ -f package-lock.json && -f yarn.lock ]]; then
+    exit_with "Both a package-lock.json and yarn.lock are present. We only can only suppport one .lock file." 6
+  fi
 }
 
 _detect_pkg_manager() {
@@ -291,6 +294,9 @@ _detect_pkg_manager() {
         exit_with "$e" 9
         ;;
     esac
+  elif [[ -f package-lock.json ]]; then
+    _pkg_manager=npm
+    build_line "Detected package-lock.json in root directory, using '$_pkg_manager'"
   elif [[ -f yarn.lock ]]; then
     _pkg_manager=yarn
     build_line "Detected yarn.lock in root directory, using '$_pkg_manager'"

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.6"
+pkg_version="0.6.7"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
…are present

 Scaffolding currently only supports using either yarn or npm for package management, not both.

This commit adds an error message that will show if a user is attempting to use both at once,
indicated by having both a package-lock.json and yarn.lock file in their repo.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>

Fixes #594 

To test:
```
$ git clone git@github.com:alik0211/pokedex.git
$ cd pokedex
$ yarn install
```

This will create a yarn.lock file.

```
$ hab plan init -s node
$ hab studio enter
(studio) $ build
```

Should build successfully.

However, if I add a package-lock.json file, it should NOT build successfully.

```
(studio) $ touch package-lock.json
(studio) $ build
```