### PR TITLE
[dotnet-core-*] Add `--no-same-owner` flag to custom tar extraction.

### DIFF
--- a/dotnet-core-lts/plan.sh
+++ b/dotnet-core-lts/plan.sh
@@ -30,7 +30,9 @@ pkg_bin_dirs=(bin)
 do_unpack() {
   # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
   mkdir -p "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  tar xfz "$HAB_CACHE_SRC_PATH/$pkg_filename" -C "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" \
+    -C "$HAB_CACHE_SRC_PATH/$pkg_dirname" \
+    --no-same-owner
 }
 
 do_prepare() {

--- a/dotnet-core-lts/plan.sh
+++ b/dotnet-core-lts/plan.sh
@@ -36,9 +36,9 @@ do_unpack() {
 }
 
 do_prepare() {
-  find -type f -name 'dotnet' \
+  find . -type f -name 'dotnet' \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
-  find -type f -name '*.so*' \
+  find . -type f -name '*.so*' \
     -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
 }
 

--- a/dotnet-core-sdk-lts/plan.sh
+++ b/dotnet-core-sdk-lts/plan.sh
@@ -31,7 +31,9 @@ pkg_bin_dirs=(bin)
 do_unpack() {
   # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
   mkdir -p "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  tar xfz "$HAB_CACHE_SRC_PATH/$pkg_filename" -C "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" \
+    -C "$HAB_CACHE_SRC_PATH/$pkg_dirname" \
+    --no-same-owner
 }
 
 do_prepare() {

--- a/dotnet-core-sdk-lts/plan.sh
+++ b/dotnet-core-sdk-lts/plan.sh
@@ -37,9 +37,9 @@ do_unpack() {
 }
 
 do_prepare() {
-  find -type f -name 'dotnet' \
+  find . -type f -name 'dotnet' \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
-  find -type f -name '*.so*' \
+  find . -type f -name '*.so*' \
     -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
   fix_interpreter "$HAB_CACHE_SRC_PATH/$pkg_dirname/sdk/${pkg_version}/Roslyn/RunCsc.sh" core/coreutils bin/env
 }

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -31,7 +31,9 @@ pkg_bin_dirs=(bin)
 do_unpack() {
   # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
   mkdir -p "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  tar xfz "$HAB_CACHE_SRC_PATH/$pkg_filename" -C "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" \
+    -C "$HAB_CACHE_SRC_PATH/$pkg_dirname" \
+    --no-same-owner
 }
 
 do_prepare() {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -37,9 +37,9 @@ do_unpack() {
 }
 
 do_prepare() {
-  find -type f -name 'dotnet' \
+  find . -type f -name 'dotnet' \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
-  find -type f -name '*.so*' \
+  find . -type f -name '*.so*' \
     -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
   fix_interpreter "$HAB_CACHE_SRC_PATH/$pkg_dirname/sdk/${pkg_version}/Roslyn/RunCsc.sh" core/coreutils bin/env
 }

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -30,7 +30,9 @@ pkg_bin_dirs=(bin)
 do_unpack() {
   # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
   mkdir -p "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  tar xfz "$HAB_CACHE_SRC_PATH/$pkg_filename" -C "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" \
+    -C "$HAB_CACHE_SRC_PATH/$pkg_dirname" \
+    --no-same-owner
 }
 
 do_prepare() {

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -36,9 +36,9 @@ do_unpack() {
 }
 
 do_prepare() {
-  find -type f -name 'dotnet' \
+  find . -type f -name 'dotnet' \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;
-  find -type f -name '*.so*' \
+  find . -type f -name '*.so*' \
     -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
 }
 


### PR DESCRIPTION
This change will ignore the user/group metadata when extracting tar
archives in privilege-reduced environments.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>