### PR TITLE
upgrades core/node to latest LTS release

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="6.11.5"
+$pkg_version="8.9.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="33360c037c792457a2e4b37fd107b26c353f70e779f9236b351bd64d7d0c0240"
+$pkg_shasum="cd37ff1fb455f7e6e6fe566cffcea06bbde392501fd7b5be5ec4174b762af523"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=6.11.5
+pkg_version=8.9.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=c4aed94e82dbf246a1c9e0705c3054f0c0f3d9c4d8d025d877e0ef1f7b6cde4c
+pkg_shasum=00b422827f37913576f8e5059c84acab364375cfbfcc083652191165f709de6c
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/python2 core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>

Testing process:

On Linux/OS X:
1) Build this version of core/node
2) Build new version of core/scaffolding-node with this version of core/node
3) Clone and build new app using this version of core/scaffolding-node

```
$ git clone git@github.com:alik0211/pokedex.git
$ cd pokedex
$ npm install
$ hab plan init -s node
$ hab studio enter
$ (studio) build
$ (studio) hab pkg export docker ./results/<hart file>
$ (studio) exit
$ docker run -it -p 8000:8000 core/pokedex
```

Everything built and ran successfully!

On Windows
1) Build this version of core/node

Scaffolding-node currently does NOT work on Windows.  I'm working on finding a way to build a generic node app on Windows using the plan.ps1 files, though the fact that it build successfully gives me confidence that it will work as expected.