### PR TITLE
Fix health check for elasticsearch

### DIFF
--- a/elasticsearch/hooks/health_check
+++ b/elasticsearch/hooks/health_check
@@ -2,18 +2,20 @@
 #
 # Elasticsearch Health Check for Habitat
 
+# For details on the elasticsearch health colors, see:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
 status="$(wget -qO - "{{svc.me.sys.ip}}:{{svc.me.cfg.http-port}}/_cat/health")"
 color="$(echo "$status" | awk '{print $4}')"
 
 case $color in
   "green")
-    rc=0 ;;
-  "orange")
-    rc=1 ;;
+    rc=0 ;;                     # OK (200)
+  "yellow")
+    rc=1 ;;                     # WARNING (200)
   "red")
-    rc=2 ;;
+    rc=2 ;;                     # CRITICAL (503)
   *)
-    rc=3 ;;
+    rc=3 ;;                     # UNKNOWN (500)
 esac
 
 exit $rc


### PR DESCRIPTION
Elasticsearch's health api returns three color coded values: green,
yellow, and red. Orange is never returned.