### PR TITLE
[acbuild] Updates to 0.4.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,6 +103,7 @@ mg @fnichol
 # inclusion here is voluntary.
 # This list shall be alphabetical, for sanity purposes.
 
+acbuild @rsertelon
 jdk7 @rsertelon
 jdk8 @rsertelon
 jre7 @rsertelon


### PR DESCRIPTION
This updates the `acbuild` tool to 0.4.0.

I changed the build from existing binary modified with patchelf to source build because it seems that patchelf cannot work correctly with the binary (https://github.com/NixOS/patchelf/issues/66).

I did this update while trying to fix ACI export for habitat, but couldn't really test it for now, so I publish this first.