### PR TITLE
[traefik] bump: 1.4.1 -> 1.4.2

### DIFF
--- a/traefik/plan.sh
+++ b/traefik/plan.sh
@@ -2,12 +2,12 @@ pkg_name=traefik
 pkg_description="a modern reverse proxy"
 pkg_upstream_url="https://traefik.io"
 pkg_origin=core
-pkg_version="v1.4.1"
+pkg_version="v1.4.2"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MIT")
 pkg_source="http://github.com/containous/traefik"
 pkg_build_deps=(
-  core/node
+  core/node6
   core/sed
   core/yarn
 )
@@ -51,12 +51,12 @@ do_build() {
     pushd webui
       yarn install
 
-      # We can't use `fix_interpreter` as core/node is not a runtime dep
+      # We can't use `fix_interpreter` as core/node6 is not a runtime dep
       for t in node_modules/.bin/*; do
         local interpreter_old
         local interpreter_new
         interpreter_old=".*node"
-        interpreter_new="$(pkg_path_for core/node)/bin/node"
+        interpreter_new="$(pkg_path_for core/node6)/bin/node"
         t="$(readlink --canonicalize --no-newline "$t")"
         build_line "Replacing '${interpreter_old}' with '${interpreter_new}' in '${t}'"
         sed -e "s#\#\!${interpreter_old}#\#\!${interpreter_new}#" -i "$t"

--- a/traefik/plan.sh
+++ b/traefik/plan.sh
@@ -2,7 +2,10 @@ pkg_name=traefik
 pkg_description="a modern reverse proxy"
 pkg_upstream_url="https://traefik.io"
 pkg_origin=core
+# note: to have the version match the codename, please update both values when
+#       updating this for a new release
 pkg_version="v1.4.2"
+traefik_codename="roquefort"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MIT")
 pkg_source="http://github.com/containous/traefik"
@@ -28,6 +31,11 @@ pkg_exports=(
 do_prepare() {
   build_line "adding \$GOPATH/bin to \$PATH"
   export PATH=${scaffolding_go_gopath:?}/bin:$PATH
+
+  build_line "setting \$VERSION to \$pkg_version"
+  export VERSION=$pkg_version
+  build_line "setting \$CODENAME to $traefik_codename"
+  export CODENAME=$traefik_codename
 
   build_line "building go-bindata"
   go get github.com/jteeuwen/go-bindata


### PR DESCRIPTION
Note: the node-sass stuff happening as part of the build breaks for node
versions that aren't listed on https://github.com/sass/node-sass/releases/tag/v3.13.0
(For the lazy: that's node 0.10, 0.12, 1, 2, 3, 4, 5, 6, 7 on Linux)

So, this pins the node-dependency to the latest version we have < 8.9.0.