### PR TITLE
[traefik] bump 1.4.2 -> 1.4.3

### DIFF
--- a/traefik/plan.sh
+++ b/traefik/plan.sh
@@ -4,7 +4,7 @@ pkg_upstream_url="https://traefik.io"
 pkg_origin=core
 # note: to have the version match the codename, please update both values when
 #       updating this for a new release
-pkg_version="v1.4.2"
+pkg_version="v1.4.3"
 traefik_codename="roquefort"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MIT")


### PR DESCRIPTION
https://github.com/containous/traefik/releases/tag/v1.4.3