### PR TITLE
update to node 8.9.1 LTS

### DIFF
--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=8.9.0
+pkg_version=8.9.1
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=00b422827f37913576f8e5059c84acab364375cfbfcc083652191165f709de6c
+pkg_shasum=32491b7fcc4696b2cdead45c47e52ad16bbed8f78885d32e873952fee0f971e1
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/python2 core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated this and used `scaffolding_node_pkg="echohack/node/8.9.1"` in one of my nodejs projects to confirm it works~!

Signed-off-by: echohack <echohack@users.noreply.github.com>