### PR TITLE
[etcd] various updates

### DIFF
--- a/etcd/config/conf.yml
+++ b/etcd/config/conf.yml
@@ -9,11 +9,17 @@ etcd-server-end: {{cfg.etcd-server-end}}
 
 etcd-auto-tls: {{cfg.etcd-auto-tls}}
 
-{{#if cfg.etcd-auto-tls ~}}
-etcd-http-proto: "https"
-{{else ~}}
-etcd-http-proto: "http"
-{{/if ~}}
+etcd-http-proto: {{cfg.etcd-http-proto}}
+
+etcd-client-cert-auth: {{cfg.etcd-client-cert-auth}}
+etcd-cert-file: {{cfg.etcd-cert-file}}
+etcd-key-file: {{cfg.etcd-key-file}}
+etcd-trusted-ca-file: {{cfg.etcd-trusted-ca-file}}
+
+etcd-peer-client-cert-auth: {{cfg.etcd-peer-client-cert-auth}}
+etcd-peer-cert-file: {{cfg.etcd-peer-cert-file}}
+etcd-peer-key-file: {{cfg.etcd-peer-key-file}}
+etcd-peer-trusted-ca-file: {{cfg.etcd-peer-key-file}}
 
 etcd-listen-client-urls: {{cfg.etcd-listen-client-urls}}
 etcd-listen-peer-urls: {{cfg.etcd-listen-peer-urls}}

--- a/etcd/config/conf.yml
+++ b/etcd/config/conf.yml
@@ -28,3 +28,9 @@ etcd-initial-advertise-peer-urls: {{cfg.etcd-initial-advertise-peer-urls}}
 
 etcd-discovery: {{cfg.etcd-discovery}}
 etcd-initial-cluster-state: {{cfg.etcd-initial-cluster-state}}
+etcd-initial-cluster-token: {{cfg.etcd-initial-cluster-token}}
+etcd-initial-cluster: {{cfg.etcd-initial-cluster}}
+
+etcd-listen-host-ip: {{cfg.etcd-listen-host-ip}}
+
+etcd-env-vars-file: {{cfg.etcd-env-vars-file}}

--- a/etcd/default.toml
+++ b/etcd/default.toml
@@ -14,6 +14,16 @@ etcd-discovery = ""
 
 etcd-listen-host-ip = ""
 
+etcd-client-cert-auth = ""
+etcd-cert-file = ""
+etcd-key-file = ""
+etcd-trusted-ca-file = ""
+
+etcd-peer-client-cert-auth = ""
+etcd-peer-cert-file = ""
+etcd-peer-key-file = ""
+etcd-peer-trusted-ca-file = ""
+
 etcd-listen-client-urls = "http://0.0.0.0"
 etcd-listen-peer-urls = "http://0.0.0.0"
 etcd-advertise-client-urls = "http://0.0.0.0"

--- a/etcd/default.toml
+++ b/etcd/default.toml
@@ -14,6 +14,8 @@ etcd-discovery = ""
 
 etcd-listen-host-ip = ""
 
+etcd-initial-cluster = ""
+
 etcd-client-cert-auth = ""
 etcd-cert-file = ""
 etcd-key-file = ""
@@ -31,3 +33,5 @@ etcd-initial-advertise-peer-urls = "http://0.0.0.0"
 
 etcd-initial-cluster-state = "new"
 etcd-initial-cluster-token = "etcd-cluster-1"
+
+etcd-env-vars-file = ""

--- a/etcd/docs/README.md
+++ b/etcd/docs/README.md
@@ -15,7 +15,7 @@ The Habitat Maintainers <humans@habitat.sh>
 ## Usage
 
 - On the first node: `hab sup start core/etcd --topology leader`
-- On subsequent nodes: `hab sup start core/crate -- topology leader --peer <first node ip>`
+- On subsequent nodes: `hab sup start core/etcd --topology leader --peer <first node ip>`
 
 On all nodes the following ports are available:
 

--- a/etcd/docs/README.md
+++ b/etcd/docs/README.md
@@ -24,13 +24,25 @@ On all nodes the following ports are available:
 
 The ports can be changed.
 
-
 On all nodes the following URLs are accessible:
 - **listen-client-urls**: URLs to listen on for client traffic. Default to https://IP:2379
 - **listen-peer-urls**: URLs to listen on for peer traffic. Default to https://IP:2380
 
 The URLs can be changed.
 
+The plan defaults to automatically generated, self-signed certificates,
+alternatively client and peer certificate locations can be configured.
+
+### Testing with etcdctl
+
+Example:
+
+```
+$ etcdctl --debug --insecure-transport=false --insecure-skip-tls-verify --endpoints https://IP:2379 member list
+b82a52a6ff5c63c3, started, node-1, https://192.168.222.11:2380, https://192.168.222.11:2379
+ddfa35d3c9a4c741, started, node-2, https://192.168.222.12:2380, https://192.168.222.12:2379
+f1986a6cf0ad46aa, started, node-0, https://192.168.222.10:2380, https://192.168.222.10:2379
+```
 
 ### Testing with curl
 
@@ -61,9 +73,6 @@ $ curl -L -k https://10.0.2.15:2379/v2/keys/new
 ```
 
 ## Notes
-
-- This plan uses self-signed certificates with automatic generation. It assumes that
-etcd is not exposed to outside world. The plan will be improved in next versions.
 
 - hab v0.22/0.23 due to a bug in domain resolution inside these versions
 of Habitat, etcd configuration is only using IP addresses to contact

--- a/etcd/hooks/health_check
+++ b/etcd/hooks/health_check
@@ -1,24 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
-raw_data=""
+set -euo pipefail
 
-if [ "{{cfg.etcd-auto-tls}}" = "true" ] ; then
-	raw_data="$(wget -qO - --no-check-certificate "https://{{sys.ip}}:{{cfg.etcd-client-end}}/health" | grep "true")"
-else
-	raw_data="$(wget -qO - "http://{{sys.ip}}:{{cfg.etcd-client-end}}/health" | grep "true")"
+cd {{pkg.svc_path}}
+
+curl_opts=""
+
+if [[ "{{cfg.etcd-auto-tls}}" == "true" ]]; then
+	curl_opts="${curl_opts} --insecure"
+elif [[ "{{cfg.etcd-client-cert-auth}}" == "true" ]]; then
+	curl_opts="${curl_opts} --cacert {{cfg.etcd-trusted-ca-file}} --cert {{cfg.etcd-cert-file}} --key {{cfg.etcd-key-file}}"
 fi
 
-[[ -z $raw_data ]] || exit 3
+if curl -sS ${curl_opts} "{{cfg.etcd-http-proto}}://{{sys.ip}}:{{cfg.etcd-client-end}}/health" | grep -q "true"; then
+  echo "etcd node healthy"
+  exit 0
+fi
 
-status="$(echo "${raw_data::-1}" | cut -d " " -f 2)"
-
-case $status in
-	"true")
-		rc=0 ;;
-	"false")
-		rc=2 ;;
-	*)
-		rc=3 ;;
-esac
-
-exit $rc
+echo "etcd node unhealthy"
+exit 2

--- a/etcd/hooks/run
+++ b/etcd/hooks/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 exec 2>&1
 
@@ -6,9 +6,22 @@ proto="{{cfg.etcd-http-proto}}"
 
 cd {{pkg.svc_path}}
 
-if [ "{{cfg.etcd-auto-tls}}" = "true" ] ; then
+if [[ "{{cfg.etcd-auto-tls}}" == "true" ]]; then
 	export ETCD_AUTO_TLS="true"
 	export ETCD_PEER_AUTO_TLS="true"
+else
+  if [[ "{{cfg.etcd-client-cert-auth}}" == "true" ]]; then
+    export ETCD_CLIENT_CERT_AUTH="true"
+    export ETCD_CERT_FILE="{{cfg.etcd-cert-file}}"
+    export ETCD_KEY_FILE="{{cfg.etcd-key-file}}"
+    export ETCD_TRUSTED_CA_FILE="{{cfg.etcd-trusted-ca-file}}"
+  fi
+  if [[ "{{cfg.etcd-peer-client-cert-auth}}" == "true" ]]; then
+    export ETCD_PEER_CLIENT_CERT_AUTH="true"
+    export ETCD_PEER_CERT_FILE="{{cfg.etcd-peer-cert-file}}"
+    export ETCD_PEER_KEY_FILE="{{cfg.etcd-peer-key-file}}"
+    export ETCD_PEER_TRUSTED_CA_FILE="{{cfg.etcd-peer-trusted-ca-file}}"
+  fi
 fi
 
 listen_ip="{{sys.ip}}"

--- a/etcd/hooks/run
+++ b/etcd/hooks/run
@@ -17,9 +17,9 @@ if [[ "{{cfg.listen-host-ip}}" ]] ; then
         listen_ip="{{cfg.listen-host-ip}}"
 fi
 
-nodes="{{#each svc.members ~}}{{sys.ip}}=${proto}://{{sys.ip}}:{{cfg.etcd-server-end}},{{/each ~}}"
+nodes="{{#each svc.members as |member| ~}}{{member.sys.hostname}}=${proto}://{{member.sys.ip}}:{{../cfg.etcd-server-end}},{{/each ~}}"
 
-export ETCD_NAME="{{sys.ip}}"
+export ETCD_NAME="{{sys.hostname}}"
 export ETCD_DATA_DIR="{{pkg.svc_data_path}}"
 export ETCD_LISTEN_CLIENT_URLS="${proto}://${listen_ip}:{{cfg.etcd-client-end}}"
 export ETCD_LISTEN_PEER_URLS="${proto}://${listen_ip}:{{cfg.etcd-server-end}}"

--- a/etcd/hooks/run
+++ b/etcd/hooks/run
@@ -25,12 +25,14 @@ else
 fi
 
 listen_ip="{{sys.ip}}"
-
-if [[ "{{cfg.listen-host-ip}}" ]] ; then
-        listen_ip="{{cfg.listen-host-ip}}"
+if [[ -n "{{cfg.etcd-listen-host-ip}}" ]]; then
+  listen_ip="{{cfg.etcd-listen-host-ip}}"
 fi
 
 nodes="{{#each svc.members as |member| ~}}{{member.sys.hostname}}=${proto}://{{member.sys.ip}}:{{../cfg.etcd-server-end}},{{/each ~}}"
+if [[ -n "{{cfg.etcd-initial-cluster}}" ]]; then
+  nodes="{{cfg.etcd-initial-cluster}}"
+fi
 
 export ETCD_NAME="{{sys.hostname}}"
 export ETCD_DATA_DIR="{{pkg.svc_data_path}}"
@@ -41,5 +43,9 @@ export ETCD_INITIAL_ADVERTISE_PEER_URLS="${proto}://${listen_ip}:{{cfg.etcd-serv
 export ETCD_INITIAL_CLUSTER_TOKEN="{{cfg.etcd-initial-cluster-token}}"
 export ETCD_INITIAL_CLUSTER_STATE="{{cfg.etcd-initial-cluster-state}}"
 export ETCD_INITIAL_CLUSTER="$nodes"
+
+if [[ -n "{{cfg.etcd-env-vars-file}}" ]]; then
+  source "{{cfg.etcd-env-vars-file}}"
+fi
 
 exec etcd

--- a/etcd/plan.sh
+++ b/etcd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=etcd
 pkg_description="Distributed reliable key-value store for the most critical data of a distributed system"
 pkg_origin=core
-pkg_version="v3.1.5"
+pkg_version="v3.2.9"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=https://github.com/coreos/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}-linux-amd64.tar.gz
 pkg_upstream_url=https://github.com/coreos/etcd/releases/
-pkg_shasum=812f2a8e28330cb1e127177ff81efaa24f8e57ce22d3cd28799ef1f939f71454
+pkg_shasum=1e962459cb649363215eb022eb7ea8857ea95dce836eb9ff3b3dc54c851b4cb1
 pkg_dirname=${pkg_name}-${pkg_version}-linux-amd64
 pkg_deps=()
 pkg_build_deps=(core/gnupg)
@@ -28,7 +28,7 @@ do_download() {
 
   download_file "https://github.com/coreos/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
 	        "${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
-  		"f6ef73ff5b8e70313c0ff759cd9dcb86974e95882dff3b9c762342d568a08121"
+	        "71a1d07ce70b68a35a2c41d16719857d947bed4e4e61509cab21db0b6e2aae8f"
   download_file "https://coreos.com/dist/pubkeys/app-signing-pubkey.gpg" \
 	        "app-signing-pubkey.gpg" \
                 "16b93904e4b3133fe4b5f95f46e3db998c3b2f9d9cee6d4c2eb531f98028bcb3"
@@ -38,7 +38,7 @@ do_verify() {
   do_default_verify
 
   verify_file "${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
-	      "f6ef73ff5b8e70313c0ff759cd9dcb86974e95882dff3b9c762342d568a08121"
+	      "71a1d07ce70b68a35a2c41d16719857d947bed4e4e61509cab21db0b6e2aae8f"
   verify_file "app-signing-pubkey.gpg" \
 	      "16b93904e4b3133fe4b5f95f46e3db998c3b2f9d9cee6d4c2eb531f98028bcb3"
 

--- a/etcd/plan.sh
+++ b/etcd/plan.sh
@@ -8,7 +8,7 @@ pkg_source=https://github.com/coreos/${pkg_name}/releases/download/${pkg_version
 pkg_upstream_url=https://github.com/coreos/etcd/releases/
 pkg_shasum=1e962459cb649363215eb022eb7ea8857ea95dce836eb9ff3b3dc54c851b4cb1
 pkg_dirname=${pkg_name}-${pkg_version}-linux-amd64
-pkg_deps=()
+pkg_deps=(core/curl)
 pkg_build_deps=(core/gnupg)
 pkg_bin_dirs=(/usr/bin)
 


### PR DESCRIPTION
This pull request does the following updates:

* Fix a copypaste typo in the README
* Fix what appears to be a bug in the run scripts (`../cfg...` vs `cfg...`)
* Update etcd to current stable, 3.2.9
* Add support for client and peer cert authentication (and update the health_check hook for that)
* Update the README