### PR TITLE
[scaffolding-node] Support Angular Seed Applications

### DIFF
--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -98,7 +98,6 @@ scaffolding_modules_install() {
   fi
 
   build_line "Installing dependencies using $_pkg_manager $("$_pkg_manager" --version)"
-
   # Many node dependencies require /usr/bin/env
   # This directory is not created with Habitat by design
   # Instead, we use core/coreutils for this functionality
@@ -109,6 +108,7 @@ scaffolding_modules_install() {
   start_sec="$SECONDS"
   case "$_pkg_manager" in
     npm)
+
       if [[ ! -f "$CACHE_PATH/package.json" ]]; then
         cp -av package.json "$CACHE_PATH/"
       fi
@@ -118,6 +118,20 @@ scaffolding_modules_install() {
       if [[ -n "$HAB_NONINTERACTIVE" ]]; then
         export NPM_CONFIG_PROGRESS=false
       fi
+
+      # The following files are required
+      # for applications that use Angular-Seed
+      # https://github.com/mgechev/angular-seed
+      if [[ -f "gulpfile.ts" ]]; then
+        cp -av gulpfile.ts "$CACHE_PATH/"
+      fi
+      if [[ -d "tools" ]]; then
+        cp -R tools "$CACHE_PATH/"
+      fi
+      if [[ -f "tsconfig.json" ]]; then
+        cp -av tsconfig.json "$CACHE_PATH/"
+      fi
+
       pushd "$CACHE_PATH" > /dev/null
       npm install \
         --unsafe-perm \


### PR DESCRIPTION
in order to use the scaffolding with Angular Seed

I will be doing a blog post highlighting this process when this is merged and released.

## To test: 
```
$ git clone https://github.com/mgechev/angular-seed
$ cd angular-seed

# install the project's dependencies
$ npm install
$ rm yarn.lock # only use one package manager
$ hab plan init -s node
```

Open up habitat/plan.sh and add in this content:

```
pkg_svc_user=root
```

Now, open up up your app's package.json file and downgrade these two dependencies to these versions:

```
"typescript": "2.4.2",
(...)
"@compodoc/compodoc": "1.0.3",
```

$ hab studio enter
$ (studio) build
$ (studio) hab pkg export docker ./results/<hart file>
$ (studio) exit
$ docker run -it -p 5555:5555 core/angular-seed

Navigate to http://localhost:5555 and check out the app!

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>