### PR TITLE
[randrproto] Add version 1.5.0

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -709,6 +709,8 @@ plan_path = "rabbitmq"
 plan_path = "rabbitmqadmin"
 [raml2html]
 plan_path = "raml2html"
+[randrproto]
+randrproto = "randrproto"
 [re2c]
 plan_path = "re2c"
 [readline]

--- a/randrproto/README.md
+++ b/randrproto/README.md
@@ -1,0 +1,11 @@
+# randrproto
+
+This package provides the C header files for building software that
+uses the X11 RandR wire protocol.
+
+## Usage
+
+Typically this is a build time dependency that can be added to your
+plan.sh:
+
+    pkg_build_deps=(core/randrproto)

--- a/randrproto/plan.sh
+++ b/randrproto/plan.sh
@@ -1,0 +1,17 @@
+pkg_name=randrproto
+pkg_origin=core
+pkg_version=1.5.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="X11 RandR extension wire protocol"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/individual/proto/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum="4c675533e79cd730997d232c8894b6692174dce58d3e207021b8f860be498468"
+pkg_build_deps=(core/gcc core/make core/pkg-config core/util-macros)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_check() {
+  make check
+}


### PR DESCRIPTION
randrproto is required to build libxrandr (to be submitted shortly)

Signed-off-by: Steven Danna <steve@chef.io>