### PR TITLE
Update postgresql to latest and enable it to run without root permissions

### DIFF
--- a/postgresql/config/.pgpass
+++ b/postgresql/config/.pgpass
@@ -1,2 +1,0 @@
-*:*:*:{{cfg.superuser.name}}:{{cfg.superuser.password}}
-*:*:*:{{cfg.replication.name}}:{{cfg.replication.password}}

--- a/postgresql/config/postgresql.conf
+++ b/postgresql/config/postgresql.conf
@@ -17,7 +17,7 @@ datestyle = 'iso, mdy'
 
 default_text_search_config = 'pg_catalog.english'
 
-data_directory = '{{pkg.svc_data_path}}'
+data_directory = '{{pkg.svc_data_path}}/pgdata'
 hba_file = '{{pkg.svc_config_path}}/pg_hba.conf'
 
 wal_level = hot_standby
@@ -44,7 +44,7 @@ dynamic_shared_memory_type = 'none'
 
 {{ #if cfg.replication.enable }}
 archive_mode = 'on'
-archive_command = 'cp %p  {{cfg.replication.archive_path}}/%f'
+archive_command = 'cp %p  {{pkg.svc_data_path}}/archive/%f'
 archive_timeout = '10min'
 max_standby_archive_delay = '30s'
 synchronous_commit = local

--- a/postgresql/default.toml
+++ b/postgresql/default.toml
@@ -15,4 +15,3 @@ name = 'replication'
 password = 'replication'
 lag_health_threshold = 1048576
 enable = false
-archive_path = "{{pkg.svc_path}}/archive"

--- a/postgresql/hooks/init
+++ b/postgresql/hooks/init
@@ -1,5 +1,6 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 #
+shopt -s extglob
 
 exec 2>&1
 
@@ -7,18 +8,28 @@ source {{pkg.svc_config_path}}/functions.sh
 
 mkdir -p {{pkg.svc_config_path}}/conf.d
 mkdir -p {{pkg.svc_var_path}}/pg_stat_tmp
-mkdir -p {{pkg.svc_path}}/archive
 
+# Auto-detect pg data in the root of svc_data_path, where older versions of this plan had it
+if [[ -f "{{pkg.svc_data_path}}/PG_VERSION" ]]; then
+  echo "PGDATA detected in the root of the data path ( {{pkg.svc_data_path}} ), relocating it to {{pkg.svc_data_path}}/pgdata"
+  mkdir -p {{pkg.svc_data_path}}/pgdata
+  # bash extended globbing can cleanly move everything under a subfolder http://www.linuxjournal.com/content/bash-extended-globbing
+  mv {{pkg.svc_data_path}}/!(pgdata) {{pkg.svc_data_path}}/pgdata/
+  chmod 0700 {{pkg.svc_data_path}}/pgdata
+else
+  mkdir -p {{pkg.svc_data_path}}/pgdata
+fi
+
+mkdir -p {{pkg.svc_data_path}}/archive
 init_pgpass
 ensure_dir_ownership
 
 {{#unless svc.me.follower ~}}
-if [[ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]]; then
+if [[ ! -f "{{pkg.svc_data_path}}/pgdata/PG_VERSION" ]]; then
   echo " Database does not exist, creating with 'initdb'"
-  chpst -U hab:hab -u hab:hab \
     initdb -U {{cfg.superuser.name}} \
     -E utf8 \
-    -D {{pkg.svc_data_path}} \
+    -D {{pkg.svc_data_path}}/pgdata \
     --pwfile {{pkg.svc_config_path}}/pwfile \
     --locale POSIX \
     --data-checksums

--- a/postgresql/hooks/reconfigure
+++ b/postgresql/hooks/reconfigure
@@ -4,15 +4,6 @@ source {{pkg.svc_config_path}}/functions.sh
 
 init_pgpass
 
-{{ #unless svc.me.follower }}
-if [ -f {{pkg.svc_data_path}}/recovery.conf ]; then
-  echo "Promoting database"
-  until pg_isready -U {{cfg.superuser.name}} -h localhost -p {{cfg.port}}; do
-    echo "Waiting for database to start"
-    sleep 1
-  done
-
-  chpst -U hab:hab -u hab:hab pg_ctl promote -D {{pkg.svc_data_path}}
-fi
-
+{{~ #unless svc.me.follower }}
+promote_to_leader
 {{~/unless}}

--- a/postgresql/hooks/run
+++ b/postgresql/hooks/run
@@ -12,16 +12,16 @@ init_pgpass
 write_local_conf
 
 {{#if svc.me.follower }}
-if [[ ! -f "{{pkg.svc_data_path}}/PG_VERSION" ]]; then
+if [[ ! -f "{{pkg.svc_data_path}}/pgdata/PG_VERSION" ]]; then
   bootstrap_replica_via_pg_basebackup
 fi
 
-cp {{pkg.svc_config_path}}/recovery.conf {{pkg.svc_data_path}}/
+cp {{pkg.svc_config_path}}/recovery.conf {{pkg.svc_data_path}}/pgdata/recovery.conf
 {{/if}}
 
 ensure_dir_ownership
 
 echo "Starting PostgreSQL"
-export PGDATA={{pkg.svc_data_path}}
-exec chpst -U hab:hab -u hab:hab postgres \
+export PGDATA={{pkg.svc_data_path}}/pgdata
+exec postgres \
   -c config_file={{pkg.svc_config_path}}/postgresql.conf

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=postgresql
-pkg_version=9.6.3
+pkg_version=9.6.6
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source=https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2
-pkg_shasum=1645b3736901f6d854e695a937389e68ff2066ce0cde9d73919d6ab7c995b9c6
+pkg_shasum=399cdffcb872f785ba67e25d275463d74521566318cfef8fe219050d063c8154
 
 pkg_deps=(
   core/bash
@@ -44,13 +44,10 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
-pkg_svc_user=root
-pkg_svc_group=$pkg_svc_user
-
-ext_postgis_version=2.3.2
+ext_postgis_version=2.4.2
 ext_postgis_source=http://download.osgeo.org/postgis/source/postgis-${ext_postgis_version}.tar.gz
 ext_postgis_filename=postgis-${ext_postgis_version}.tar.gz
-ext_postgis_shasum=e92e34c18f078a3d1a2503cd870efdc4fa9e134f0bcedbbbdb8b46b0e6af09e4
+ext_postgis_shasum=23625bc99ed440d53a20225721095a3f5c653b62421c4d597c8038f0d7a321d9
 
 do_before() {
   ext_postgis_dirname="postgis-${ext_postgis_version}"


### PR DESCRIPTION
This PR updates postgresql and postgis to the latest (9.6.6 and 2.4.2 respectively) and also enables it to run without root permissions.  In order to accomplish that I had to:
- reorganize `svc_data_path` to include the `pgdata` and `archive` subfolders
- remove all chown/chmod commands that require root permissions
- remove all chpst statements which are no longer needed