### PR TITLE
[glib] Improves build (gtk3)

### DIFF
--- a/glib/README.md
+++ b/glib/README.md
@@ -1,0 +1,10 @@
+# glib
+
+This package provides the glib libraries
+
+## Usage
+
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/glib)

--- a/glib/plan.sh
+++ b/glib/plan.sh
@@ -15,6 +15,7 @@ pkg_upstream_url="https://developer.gnome.org/glib/"
 pkg_shasum="82ee94bf4c01459b6b00cb9db0545c2237921e3060c0b74cff13fbc020cfd999"
 pkg_deps=(
   core/coreutils
+  core/elfutils
   core/glibc
   core/libffi
   core/libiconv
@@ -23,9 +24,14 @@ pkg_deps=(
   core/zlib
 )
 pkg_build_deps=(
+  core/dbus
+  core/diffutils
+  core/file
   core/gcc
   core/gettext
+  core/libxslt
   core/make
+  core/perl
   core/pkg-config
   core/python
 )
@@ -35,17 +41,28 @@ pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)
 pkg_interpreters=(core/coreutils)
 
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
+
 do_build() {
   ./configure \
     --prefix="$pkg_prefix" \
     --with-libiconv \
-    --with-pcre=system \
-    --disable-fam \
     --disable-gtk-doc \
-    --enable-shared
+    --disable-fam
   make
 }
 
 do_after() {
   fix_interpreter "$pkg_prefix/bin/*" core/coreutils bin/env
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
 }


### PR DESCRIPTION
> Linked to #985 

There are two libs recommended by `./configure` that are not linked from any of package members.

Should they be left in runtime deps, or do they belong to build deps?