### PR TITLE
[libepoxy] Adds libepoxy (gtk3)

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -444,6 +444,8 @@ plan_path = "libcxx"
 plan_path = "libdrm"
 [libedit]
 plan_path = "libedit"
+[libepoxy]
+plan_path = "libepoxy"
 [liberation-fonts-ttf]
 plan_path = "liberation-fonts-ttf"
 [libev]

--- a/libepoxy/README.md
+++ b/libepoxy/README.md
@@ -1,0 +1,10 @@
+# libepoxy
+
+This package provides the libepoxy libraries, a thin wrapper around OpenGL that eases its usage.
+
+## Usage
+
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/libepoxy)

--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -1,0 +1,52 @@
+pkg_name=libepoxy
+pkg_origin=core
+pkg_version=1.4.3
+pkg_description="Epoxy is a library for handling OpenGL function pointer management for you"
+pkg_upstream_url="https://github.com/anholt/libepoxy"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('MIT')
+pkg_source="https://github.com/anholt/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum=0b808a06c9685a62fca34b680abb8bc7fb2fda074478e329b063c1f872b826f6
+pkg_deps=(
+  core/glibc
+  core/libdrm # not linked to bins/libs
+  core/libxau # not linked to bins/libs
+  core/libxcb # not linked to bins/libs
+  core/libxdamage # not linked to bins/libs
+  core/libxdmcp # not linked to bins/libs
+  core/libxext # not linked to bins/libs
+  core/libxfixes # not linked to bins/libs
+  core/mesa # not linked to bins/libs
+  core/xlib # not linked to bins/libs
+)
+pkg_build_deps=(
+  core/damageproto
+  core/fixesproto
+  core/gcc
+  core/kbproto
+  core/libpthread-stubs
+  core/meson
+  core/ninja
+  core/pkg-config
+  core/python
+  core/xextproto
+  core/xproto
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+  mkdir _build
+  pushd _build > /dev/null
+    meson --prefix="$pkg_prefix" \
+      --buildtype release
+    ninja
+  popd > /dev/null
+}
+
+do_install() {
+  pushd _build > /dev/null
+    ninja install
+  popd > /dev/null
+}


### PR DESCRIPTION
> Linked to #985 

Many libs are wanted by `./configure` but not linked at all in built binaries... If someone knows if we should move them to build deps or if it's normal :)

Note that it builds perfectly fine like this, up to gtk3... ;)