### PR TITLE
[scaffolding-ruby] move the bundle config swap out to do_default_prepare

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -48,6 +48,15 @@ EOF
   # Silence Bundler warning when run as root user
   export BUNDLE_SILENCE_ROOT_WARNING=1
 
+  # Attempt to preserve any original Bundler config by moving it to the side
+  if [[ -f .bundle/config ]]; then
+    build_line "Detecting existing bundler config. Temporarily renaming ..."
+    mv .bundle/config .bundle/config.prehab
+    dot_bundle=true
+  elif [[ -d .bundle ]]; then
+    dot_bundle=true
+  fi
+
   GEM_HOME="$gem_dir"
   build_line "Setting GEM_HOME=$GEM_HOME"
   GEM_PATH="$gem_dir:$gem_path"
@@ -184,15 +193,7 @@ EOT
 
 
 scaffolding_bundle_install() {
-  local start_sec elapsed dot_bundle
-
-  # Attempt to preserve any original Bundler config by moving it to the side
-  if [[ -f .bundle/config ]]; then
-    mv .bundle/config .bundle/config.prehab
-    dot_bundle=true
-  elif [[ -d .bundle ]]; then
-    dot_bundle=true
-  fi
+  local start_sec elapsed
 
   build_line "Installing dependencies using $(_bundle --version)"
   start_sec="$SECONDS"
@@ -1025,7 +1026,9 @@ EOF
 }
 
 _restore_bundle_config() {
-  rm -f .bundle/config
-  mv .bundle/config.prehab .bundle/config
-  rm -f .bundle/config.prehab
+  build_line "Restoring original bundler config"
+  if [[ -f .bundle/config.prehab ]]; then
+    rm -f .bundle/config
+    mv .bundle/config.prehab .bundle/config
+  fi
 }


### PR DESCRIPTION
Separating the swap out of `.bundle/config` and the execution of `bundle install` to different plan phases allows plan authors the opportunity to write to the config file before the install occurs. As described in Issue #927, some gems have hyphens in their name which prevents the usual trick of setting bundler build configs via an environment variable like:

```
BUNDLE_BUILD__GEMNAME="--some-config-switcheroos"
```

An attempt to set `BUNDLE_BUILD_GEM-NAME` with a hyphen results in the shell error: "not a valid identifier."

Closes #927