### PR TITLE
Allow patch files to have trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 
 [*.sh]
 indent_size = 2
+
+[*.patch]
+trim_trailing_whitespace = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.1
+    sha: v1.1.1
     hooks:
     -   id: check-added-large-files
     -   id: check-merge-conflict
@@ -8,6 +8,7 @@
         exclude: config/.*$
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        exclude: .*\.patch
 -   repo: git://github.com/detailyang/pre-commit-shell
     sha: 1.0.2
     hooks:


### PR DESCRIPTION
Since patch files are typically generated from upstream code diffs,
we should not enforce our own style on these files.

Resolves #1004

Signed-off-by: Mike Fiedler <miketheman@gmail.com>