### PR TITLE
[scaffolding-node] adds explicit dependency on yarn

### DIFF
--- a/scaffolding-node/CHANGELOG.md
+++ b/scaffolding-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-node)
 
+## 0.6.10 (11-28-2017)
+
+- Adds explicit dependency on yarn
+
 ## 0.6.9 (11-27-2017)
 
 - Use more robust compat_regex and fix code readability

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"
 pkg_upstream_url="https://github.com/habitat-sh/core-plans/tree/master/scaffolding-node"
 pkg_deps=(core/tar core/rq core/jq-static core/gawk core/curl core/bc core/coreutils)
-pkg_build_deps=(core/node core/coreutils)
+pkg_build_deps=(core/node core/coreutils core/yarn)
 
 do_build() {
   return 0

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.9"
+pkg_version="0.6.10"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
So that we can more easily find that scaffolding-node depends on yarn (the dependency is currently dynamically added in lib/scaffolding.sh).

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>