### PR TITLE
[rq] ⚠️ upgrade to v0.10.4

### DIFF
--- a/rq/plan.sh
+++ b/rq/plan.sh
@@ -1,24 +1,23 @@
 pkg_name=rq
 pkg_origin=core
-pkg_version=0.9.2
-pkg_source=https://github.com/dflemstr/rq/releases/download/v${pkg_version}/${pkg_name}-x86_64-unknown-linux-musl
-pkg_shasum=01718bd4e52e5139d050dabbea308566a20c54d62a46fd28ab900819acc31c8b
+pkg_version=0.10.4
+pkg_filename=record-query-v${pkg_version}-x86_64-unknown-linux-gnu.tar.gz
+pkg_source=https://github.com/dflemstr/rq/releases/download/v${pkg_version}/${pkg_filename}
+pkg_shasum=1b9abedd7acca1269ac1c4765d93bab73777feca9a04358ea4f9c9659bf51e62
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Record Query - A tool for doing record analysis and transformation"
 pkg_upstream_url=https://github.com/dflemstr/rq
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
+pkg_deps=(core/glibc core/gcc-libs)
+pkg_build_deps=(core/patchelf)
 
 do_unpack() {
-  return 0
-}
-
-do_prepare() {
-  return 0
-}
-
-do_verify() {
-  return 0
+  do_default_unpack
+  # the source tarball contains a cross-compiled binary in a parent directory
+  # with a vague name. here we'll rename it to the hab standard pkg_dirname
+  # instead of setting pkg_dirname to this vague name.
+  mv "${HAB_CACHE_SRC_PATH}/x86_64-unknown-linux-gnu" "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
 }
 
 do_build() {
@@ -27,5 +26,14 @@ do_build() {
 
 do_install() {
   mkdir -pv "$pkg_prefix/bin"
-  install -v "$HAB_CACHE_SRC_PATH/$pkg_filename" "$pkg_prefix/bin/$pkg_name"
+  install -v "rq" "$pkg_prefix/bin/$pkg_name"
+}
+
+do_strip() {
+  do_default_strip
+  # patching the binary after stripping unneeded symbols because strip does not
+  # like the modifications patchelf makes
+  patchelf --interpreter "$(pkg_path_for core/glibc)/lib/ld-linux-x86-64.so.2" \
+           --set-rpath "${LD_RUN_PATH}" \
+           "${pkg_prefix}/bin/rq"
 }


### PR DESCRIPTION
# Why?

Newer rq uses newer toml library which provides more better output when parsing errors occur.

## Old:

With rq v0.9.2 (using [toml v0.2.1](https://github.com/dflemstr/rq/blob/v0.9.2/Cargo.lock#L27))
```
[ERROR] [rq] Encountered: control character `\n` must be escaped
```

## New:

With rq v0.10.4 (using [toml v0.3.1](https://github.com/dflemstr/rq/blob/v0.10.4/Cargo.lock#L472))
```
[ERROR] [rq] Encountered: newline in string found at line 14
```

Habitat itself uses rq ([only in one place](https://github.com/habitat-sh/habitat/search?utf8=%E2%9C%93&q=_rq_cmd&type=)) to [pluck out exposed/exported ports from a plan's
default.toml](https://github.com/habitat-sh/habitat/blob/1fb090b35943dd013128f49588287a3114dadd06/components/plan-build/bin/shared.sh#L64). This would improve error messaging when there is something awry there.

# How?

The changes to this plan are mostly around the new way upstream offers their precompiled assets. Names changed. Contents changed. And it's cross-compiled, but now needs some patchelf rubbed upon the build.

With all the elves getting patched in this plan, we could consider building rq from source, but core needs a v8 engine package for this to depend on to do that.