### PR TITLE
[mysql] Initial pass at adding replication to the MySQL plan, plus a version bump

### DIFF
--- a/mysql-client/plan.sh
+++ b/mysql-client/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=mysql-client
 pkg_origin=core
-pkg_version=5.7.14
+pkg_version=5.7.21
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0')
 pkg_source=http://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-${pkg_version}.tar.gz
-pkg_shasum=f7415bdac2ca8bbccd77d4f22d8a0bdd7280b065bd646a71a506b77c7a8bd169
+pkg_shasum=fa205079c27a39c24f3485e7498dd0906a6e0b379b4f99ebc0ec38a9ec5b09b7
 pkg_upstream_url=https://www.mysql.com/
 pkg_description="MySQL Client Tools"
 pkg_deps=(
@@ -46,7 +46,7 @@ do_build() {
           -DCRYPTO_LIBRARY="$(pkg_path_for core/openssl)/lib/libcrypto.so" \
           -DWITHOUT_SERVER:BOOL=ON \
           -DCMAKE_INSTALL_PREFIX="$pkg_prefix"
-  make
+  make -j4
 }
 
 do_install() {

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,120 @@
+# MySQL
+
+This MySQL plan supports standalone and clustered modes
+
+## Standalone
+
+To run a standalone MySQL instance simply run
+```
+hab start core/mysql
+```
+or
+```
+docker run habitat/mysql
+```
+if you want to bring up the pre-exported docker image.
+
+## Cluster
+
+This plan supports running clustered MySQL by utilizing Habitat's native leader election.
+
+You can run an example cluster via docker-compose after exporting a docker container from this plan:
+```
+$ hab pkg export docker $(ls -1t results/*.hart | head -1)
+```
+
+The docker post-process should create a docker image named `core/mysql` and it should be available on your local machine
+
+example `docker-compose.yml` file:
+```
+version: '3'
+services:
+  mysql1:
+    image: habitat/mysql:latest
+    environment:
+      HAB_MYSQL: |
+        app_username = 'appadmin'
+        app_password = 'SuperSecurePassword42'
+        bind = '0.0.0.0'
+        root_password = 'EvenMoreSecurePassword2018'
+        server_id = 1
+    volumes:
+      - mysql1-data:/hab/svc/mysql/data
+    command: --group cluster
+      --topology leader
+
+  mysql2:
+    image: habitat/mysql:latest
+    environment:
+      HAB_MYSQL: |
+        app_username = 'appadmin'
+        app_password = 'SuperSecurePassword42'
+        bind = '0.0.0.0'
+        root_password = 'EvenMoreSecurePassword2018'
+        server_id = 2
+    volumes:
+      - mysql2-data:/hab/svc/mysql/data
+    command: --peer mysql1
+      --group cluster
+      --topology leader
+
+  mysql3:
+    image: habitat/mysql:latest
+    environment:
+      HAB_MYSQL: |
+        app_username = 'appadmin'
+        app_password = 'SuperSecurePassword42'
+        bind = '0.0.0.0'
+        root_password = 'EvenMoreSecurePassword2018'
+        server_id = 3
+    volumes:
+      - mysql3-data:/hab/svc/mysql/data
+    command: --peer mysql1
+      --group cluster
+      --topology leader
+
+volumes:
+  mysql1-data:
+  mysql2-data:
+  mysql3-data:
+```
+
+## Binding
+
+Consuming services can bind to MySQL via:
+
+```
+hab start <origin>/<app> --bind database:mysql.default --peer <pg-host>
+```
+
+Superuser access is exposed to consumers when binding and we advise that required databases, schemas and roles be created and migrations get run in the init hook of the consuming service. The created roles (with restricted access) should then be exposed to the application code that will get run.
+
+In the template of the consuming service, there is currently a difference between the binding syntax for binding to the leader in a clustered topology vs binding to any member.  A [future enhancement](https://github.com/habitat-sh/habitat/issues/4127) may improve upon that, but for now something like this could work if used in an interpreted script file:
+
+```
+# Use the eachAlive and @first helpers to bind to the oldest alive member of the bound service group
+#   - members are processed in the chronological order of when they joined the ring
+# If a later member comes along that is the leader of a cluster topology, override the environment variable definitions with that
+#   - if not, the second section is omitted
+{{~ #if bind.database}}
+  {{~ #eachAlive bind.database.members as |member|}}
+    {{~ #if @first}}
+# First alive member
+DBHOST="{{member.sys.ip}}"
+DBPORT="{{member.cfg.port}}"
+DBUSER="{{member.cfg.app_username}}"
+DBPASSWORD="{{member.cfg.app_password}}"
+    {{~ /if}}
+
+    {{~ #if member.leader}}
+# Leader node override
+DBHOST="{{member.sys.ip}}"
+DBPORT="{{member.cfg.port}}"
+DBUSER="{{member.cfg.app_username}}"
+DBPASSWORD="{{member.cfg.app_password}}"
+    {{~ /if}}
+  {{~ /eachAlive}}
+{{~ /if}}
+```
+
+However if you're using more of a rigid configuration file syntax then you still need to know and choose in advance whether or not you're expecting to connect to a leader topology or not.

--- a/mysql/config/client.cnf
+++ b/mysql/config/client.cnf
@@ -1,0 +1,4 @@
+[client]
+user = root
+host = 127.0.0.1
+password = {{cfg.root_password}}

--- a/mysql/config/init.sql
+++ b/mysql/config/init.sql
@@ -1,10 +1,22 @@
-UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N', host='127.0.0.1' WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
+{{~#if svc.me.leader}}
+-- Enable remote root access if in a topology, be sure to protect access via firewalls
+-- this host is a leader
+UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N', host='%' WHERE user = 'root';
+{{else}}
+{{~#if svc.me.follower}}
+-- Enable remote root access if in a topology, be sure to protect access via firewalls
+-- this host is a follower
+UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N', host='%' WHERE user = 'root';
+{{~/if}}
+-- Disable remote root access by default for a standalone mysql node
+UPDATE mysql.user SET {{cfg.password_column_name}}=PASSWORD('{{cfg.root_password}}'), password_expired='N', host='127.0.0.1' WHERE user = 'root';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
-{{#if cfg.app_username ~}}
+{{~/if}}
+{{~#if cfg.app_username}}
 CREATE USER '{{cfg.app_username}}'@'%' IDENTIFIED BY '{{cfg.app_password}}';
 GRANT ALL PRIVILEGES ON *.* TO '{{cfg.app_username}}'@'%';
-{{/if ~}}
+{{~/if}}
 FLUSH PRIVILEGES;
 DELETE FROM mysql.db WHERE db LIKE 'test%';
-DROP DATABASE IF EXISTS test ;
+DROP DATABASE IF EXISTS test;

--- a/mysql/config/my.cnf
+++ b/mysql/config/my.cnf
@@ -48,3 +48,8 @@ log-error    = {{pkg.svc_var_path}}/error.log
 
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
+
+# clustering
+log-bin       = mysql-bin
+binlog-format = {{cfg.binlog-format}}
+server-id     = {{cfg.server_id}}

--- a/mysql/default.toml
+++ b/mysql/default.toml
@@ -5,3 +5,5 @@ root_password = ""
 app_username = false
 app_password = false
 password_column_name = "authentication_string"
+binlog-format = "ROW"
+server-id = 1

--- a/mysql/hooks/health_check
+++ b/mysql/hooks/health_check
@@ -1,0 +1,19 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash -e
+
+
+{{#if svc.me.follower ~}}
+# MySQL follower (aka "slave" in MySQL parlance) status
+echo "[mysql] status: FOLLOWER my_ip: {{sys.ip}} leader_ip: {{svc.leader.sys.ip}}"
+mysqladmin --defaults-extra-file={{pkg.svc_config_path}}/client.cnf --wait=5 status
+mysql --defaults-extra-file={{pkg.svc_config_path}}/client.cnf -e "SHOW SLAVE STATUS" --auto-vertical-output | egrep "Master_Host|State|Running|Behind"
+
+# TODO: have this error out if a $seconds_behind breaches a threshold multiple times
+seconds_behind=$(mysql --defaults-extra-file={{pkg.svc_config_path}}/client.cnf -e "SHOW SLAVE STATUS" --auto-vertical-output | grep "Seconds_Behind_Master" | awk '{print $2}' )
+if [[ $seconds_behind -gt 5 ]]; then
+  echo "PROBLEM: this follower is $seconds_behind seconds behind the leader"
+fi
+
+{{else}}
+echo "[mysql] status: LEADER my_ip: {{sys.ip}}"
+mysqladmin --defaults-extra-file={{pkg.svc_config_path}}/client.cnf --wait=5 status
+{{~/if}}

--- a/mysql/hooks/post-run
+++ b/mysql/hooks/post-run
@@ -1,0 +1,44 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash -e
+
+{{#if svc.me.follower ~}}
+# MySQL follower (aka "slave" in MySQL parlance) setup
+REMOTE_CONNECT_STRING="-h {{svc.leader.sys.ip}} -u root -p{{cfg.root_password}}"
+LOCAL_CONNECT_STRING="--defaults-extra-file={{pkg.svc_config_path}}/client.cnf"
+
+# Wait for both the remote and local mysql instances to be ready
+mysqladmin $REMOTE_CONNECT_STRING --wait=5 ping
+mysqladmin $LOCAL_CONNECT_STRING --wait=5 ping
+
+# Grab the binlog file and position, needed for replication
+master_status=`mysql $REMOTE_CONNECT_STRING mysql -e "SHOW MASTER STATUS" |grep mysql-bin`
+master_status_file=`echo $master_status | cut -d " " -f 1`
+master_status_position=`echo $master_status | cut -d " " -f 2`
+
+# Now dump the data
+echo "Performing mysqldump of all databases from leader {{svc.leader.sys.ip}}"
+mysqldump $REMOTE_CONNECT_STRING \
+  --single-transaction \
+  --order-by-primary \
+  --compress \
+  --quick \
+  --extended-insert \
+  --all-databases | mysql $LOCAL_CONNECT_STRING
+
+# What do all these mysqldump flags mean?
+# from: http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html
+# --single-transaction  - runs the entire dump as a single consistent snapshot.  Prevents all locks from happening in InnoDB tables (NOTE: this is very important to prevent website outages)
+# --order-by-primary - Dump each table's rows sorted by its primary key, or by its first unique index
+# --compress - compresses data over the wire, to speed transfers from the source
+# --quick - Grabs a row at a time rather than buffering the whole table into RAM.  Prevents failures for very large tables
+# --extended-insert - Write INSERT statements using multiple-row syntax that includes several VALUES lists. This results in a smaller dump file and speeds up inserts when the file is reloaded.
+
+echo "Configuring local mysql instance as a follower"
+mysql $LOCAL_CONNECT_STRING -e "CHANGE MASTER TO MASTER_HOST='{{svc.leader.sys.ip}}', MASTER_USER='root', MASTER_PASSWORD='{{cfg.root_password}}', MASTER_LOG_FILE='${master_status_file}', MASTER_LOG_POS=${master_status_position}"
+mysql $LOCAL_CONNECT_STRING -e "START SLAVE"
+mysql $LOCAL_CONNECT_STRING -e "SHOW SLAVE STATUS"
+echo "Success"
+
+{{else}}
+# MySQL leader
+exit 0
+{{~/if}}

--- a/mysql/hooks/reconfigure
+++ b/mysql/hooks/reconfigure
@@ -1,0 +1,32 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash -e
+#
+LOCAL_CONNECT_STRING="--defaults-extra-file={{pkg.svc_config_path}}/client.cnf"
+
+# Wait for both the local mysql instance to be ready
+mysqladmin $LOCAL_CONNECT_STRING --wait=5 ping
+# get current follower status (blank if a leader)
+SLAVE_STATUS=$(mysql $LOCAL_CONNECT_STRING -e "SHOW SLAVE STATUS" --auto-vertical-output)
+CURRENT_MASTER_HOST=$(mysql $LOCAL_CONNECT_STRING -e "SHOW SLAVE STATUS" --auto-vertical-output | grep "Master_Host:" | awk '{print $2}')
+
+{{~#if svc.me.follower}}
+# MySQL follower (aka "slave" in MySQL parlance) setup
+
+if ! [ "${CURRENT_MASTER_HOST}" == "{{svc.leader.sys.ip}}" ]; then
+  echo "Reconfiguring local mysql instance as a follower"
+  mysql $LOCAL_CONNECT_STRING -e "STOP SLAVE"
+  mysql $LOCAL_CONNECT_STRING -e "CHANGE MASTER TO MASTER_HOST='{{svc.leader.sys.ip}}', MASTER_USER='root', MASTER_PASSWORD='{{cfg.root_password}}'"
+  mysql $LOCAL_CONNECT_STRING -e "START SLAVE"
+  mysql $LOCAL_CONNECT_STRING -e "SHOW SLAVE STATUS"
+  echo "Success"
+fi
+{{~else}}
+# MySQL leader
+
+# determine if this leader was previously a follower, if so it needs to be reconfigured
+if ! [ "${SLAVE_STATUS}" == '' ]; then
+  echo "Reconfiguring local mysql instance as a leader"
+  mysql $LOCAL_CONNECT_STRING -e "STOP SLAVE"
+  mysql $LOCAL_CONNECT_STRING -e "RESET MASTER"
+  echo "Success"
+fi
+{{~/if}}

--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=mysql
 pkg_origin=core
-pkg_version=5.7.17
+pkg_version=5.7.21
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0')
 pkg_source=http://dev.mysql.com/get/Downloads/MySQL-5.7/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=cebf23e858aee11e354c57d30de7a079754bdc2ef85eb684782458332a4b9651
+pkg_shasum=fa205079c27a39c24f3485e7498dd0906a6e0b379b4f99ebc0ec38a9ec5b09b7
 pkg_upstream_url=https://www.mysql.com/
 pkg_description=$(cat << EOF
 Starts MySQL with a basic configuration. Configurable at run time:
@@ -64,7 +64,7 @@ do_build() {
           -DCMAKE_INSTALL_PREFIX="$pkg_prefix" \
           -DWITH_EMBEDDED_SERVER=no \
           -DWITH_EMBEDDED_SHARED_LIBRARY=no
-  make
+  make -j4
 }
 
 do_install() {

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -56,7 +56,7 @@ do_build() {
     --with-cc-opt="$CFLAGS" \
     --with-ld-opt="$LDFLAGS"
 
-  make
+  make -j4
 }
 
 do_install() {

--- a/redis/plan.sh
+++ b/redis/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=redis
 pkg_origin=core
-pkg_version=3.2.4
+pkg_version=3.2.11
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url=http://redis.io/
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=2ad042c5a6c508223adeb9c91c6b1ae091394b4026f73997281e28914c9369f1
+pkg_shasum=31ae927cab09f90c9ca5954aab7aeecc3bb4da6087d3d12ba0a929ceb54081b5
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc)
 pkg_deps=(core/glibc)


### PR DESCRIPTION
this adds leader/follower setup to the MySQL plan, plus updates the version to the latest

TODO:
- [x] Add logic to support MySQL failovers to a `reconfigure` hook
- [x] squash and rebase