### PR TITLE
[openssl] upgrade to 1.0.2n

### DIFF
--- a/openssl/plan.sh
+++ b/openssl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=openssl
 pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=1.0.2l
+pkg_version=1.0.2n
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
 pkg_license=('OpenSSL')
 pkg_upstream_url="https://www.openssl.org"
 pkg_source=https://www.openssl.org/source/${pkg_distname}-${pkg_version}.tar.gz
-pkg_shasum=ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
+pkg_shasum=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(core/glibc core/zlib core/cacerts)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/grep core/perl)


### PR DESCRIPTION
Upgrade openssl to 1.0.2n to address CVE-2017-3737.

[Version published announcement](http://www.mail-archive.com/openssl-announce@openssl.org/msg00258.html).
[Security Advisory](http://www.mail-archive.com/openssl-announce@openssl.org/msg00259.html).