### PR TITLE
[scaffolding-(node,ruby)] make git a build dep in dynamic language scaffolds

### DIFF
--- a/scaffolding-node/CHANGELOG.md
+++ b/scaffolding-node/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-node)
 
+## 0.6.11 (12-08-2017)
+
+- Improve git detection with `git rev-parse --is-in-work-tree`, makes
+  core/git a direct build dependency
+
 ## 0.6.10 (11-28-2017)
 
 - Adds explicit dependency on yarn

--- a/scaffolding-node/doc/reference.md
+++ b/scaffolding-node/doc/reference.md
@@ -42,6 +42,7 @@ Most non-trivial apps need more than their own codebase to run correctly. Many h
 The following Habitat package dependencies will be injected into your app's Plan:
 
 * [`core/busybox-static`][]: Used by process bins to have valid [shebangs][] and a consistent minimal command set. Will be injected into your Plan's `pkg_deps` array.
+* `core/git`: Used to detect if your app exists within a git repository to better support installing your app while honoring the `.gitignore` file. Will be injected into your Plan's `pkg_build_deps` array.
 
 ### Detected Dependencies
 
@@ -51,7 +52,6 @@ Additional checks performed by this scaffolding are:
 
 * The app's version of Node will be determined by checking several source locations. See the Node Version section for more details.
 * If your app's root directory contains a `yarn.lock` file, then [Yarn][]-related Habitat packages will be injected into your Plan's `pkg_build_deps` array for resolving and installing Node package dependencies. See the Package Manager section for more details.
-* If your app's root directory contains a `.git/` subdirectory, then Git-related Habitat packages will be injected into your Plan's `pkg_build_deps` array to better support installing your app while honoring the `.gitignore` file.
 
 ###  Specifying Run Dependencies in Your Plan
 

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -22,6 +22,8 @@ do_default_prepare() {
   # required to run build scripts
   export NODE_ENV=development
 
+  _detect_git
+
   # The install prefix path for the app
   scaffolding_app_prefix="$pkg_prefix/$app_prefix"
   build_line "Setting NODE_ENV=$NODE_ENV"
@@ -404,7 +406,7 @@ _update_pkg_build_deps() {
   # Order here is important--entries which should be first in
   # `${pkg_build_deps[@]}` should be called last.
 
-  _detect_git
+  _add_git
   _detect_yarn
 
   # TODO fin: support different version of npm?
@@ -447,13 +449,17 @@ _add_busybox() {
   debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
 }
 
+_add_git() {
+  build_line "Adding git to build dependencies"
+  pkg_build_deps=(core/git ${pkg_build_deps[@]})
+  debug "Updating pkg_build_deps=(${pkg_build_deps[*]}) from Scaffolding detection"
+}
 
 _detect_git() {
-  if [[ -d ".git" ]]; then
-    build_line "Detected '.git' directory, adding git packages as build deps"
-    pkg_build_deps=(core/git ${pkg_build_deps[@]})
-    debug "Updating pkg_build_deps=(${pkg_build_deps[*]}) from Scaffolding detection"
+  if git rev-parse --is-inside-work-tree ; then
+    build_line "Detected build is occuring inside a git work tree."
     _uses_git=true
+    debug "Setting _uses_git to true."
   fi
 }
 

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.10"
+pkg_version="0.6.11"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"

--- a/scaffolding-ruby/CHANGELOG.md
+++ b/scaffolding-ruby/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-ruby)
 
+# 0.8.9 (12-08-2017)
+
+- Improve git detection with `git rev-parse --is-in-work-tree`, makes
+  core/git a direct build dependency
+
 # 0.8.8 (11-27-2017)
 - move the bundle config swap out to do_default_prepare
 

--- a/scaffolding-ruby/doc/reference.md
+++ b/scaffolding-ruby/doc/reference.md
@@ -42,6 +42,7 @@ Most non-trivial apps need more than their own codebase to run correctly. Many h
 The following Habitat package dependencies will be injected into your app's Plan:
 
 * [`core/busybox-static`][]: Used by process bins to have valid [shebangs][] and a consistent minimal command set. Will be injected into your Plan's `pkg_deps` array.
+* `core/git`: Used to detect if your app exists within a git repository to better support installing your app while honoring the `.gitignore` file. Will be injected into your Plan's `pkg_build_deps` array.
 
 ### Detected Dependencies
 
@@ -56,7 +57,6 @@ The following gems will checked for in the `Gemfile.lock` to conditionally injec
 Additional checks performed by this scaffolding are:
 
 * The app's version of Ruby will be determined by checking several source locations. See the Ruby Version section for more details.
-* If your app's root directory contains a `.git/` subdirectory, then Git-related Habitat packages will be injected into your Plan's `pkg_build_deps` array to better support installing your app while honoring the `.gitignore` file.
 
 ###  Specifying Run Dependencies in Your Plan
 

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-ruby
 pkg_origin=core
-pkg_version="0.8.8"
+pkg_version="0.8.9"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"


### PR DESCRIPTION
This changes the git detection from checking for a `.git/` directory in only the `SRC_PATH` to using git itself to determine whether the current working directory exists within a git work tree.

An example where looking for `.git/` in `SRC_PATH` returns a false negative is git repositories with multiple components in sub-directories. The studio is generally entered at the root of the git repository and the build command executed with a sub-directory path. The fallback to `find | tar` ends up including many unnecessary or undesired files in the resultant package.

So long as the studio is entered from a location that includes the git repo root, this new git detection will be correct and the `git ls-files` used to collect the file list for packaging will be relative to the `SRC_PATH`.

* `_add_git` - a new function that injects `core/git` as a build dependency during scaffolding load; takes the place of the call to old `_detect_git`

* `_detect_git` - modified to perform git work tree detection with the git command itself; moved calling this function to do_default_prepare which is executed after dependencies have been retrieved and before any portion of the scaffolding build/install needs to know about whether the build is occurring in a git repo

Examples of using the git command to detect:

```shell
# nope
 ~ > git rev-parse --is-inside-work-tree
fatal: Not a git repository (or any of the parent directories): .git
 ~ > echo $?
128

# yup
 ~/core-plans · robb/change-git-detection-in-ruby-scaffolding > git rev-parse --is-inside-work-tree
true
 ~/core-plans · robb/change-git-detection-in-ruby-scaffolding > echo $?
0
```

Tested with a local build of scaffolding-ruby and a git-managed Rails app. Duplicated implementation to scaffolding-node.