### PR TITLE
[kubectl] Add kubectl plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -384,6 +384,8 @@ plan_path = "kibana"
 plan_path = "kmod"
 [krb5]
 plan_path = "krb5"
+[kubectl]
+plan_path = "kubectl"
 [kubernetes]
 plan_path = "kubernetes"
 [kubernetes-apiserver]

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -1,0 +1,6 @@
+# kubectl
+
+The kubectl plan provides the kubectl binary for packages which want
+to interact with a Kubernetes cluster.
+
+For a full Kubernetes plan, please see https://github.com/habitat-sh/core-plans/tree/master/kubernetes

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -1,0 +1,36 @@
+pkg_name=kubectl
+pkg_origin=core
+pkg_description="kubectl CLI tool"
+pkg_upstream_url=https://github.com/kubernetes/kubernetes
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version=1.8.3
+pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
+pkg_shasum=8ab7e41126dfc3bc1a23ff76efc20e5131320530dc1277e5c2ed8c9618041b95
+pkg_dirname="kubernetes-${pkg_version}"
+
+pkg_bin_dirs=(bin)
+
+pkg_build_deps=(
+  core/git
+  core/make
+  core/gcc
+  core/go
+  core/diffutils
+  core/which
+  core/rsync
+)
+
+pkg_deps=(
+  core/glibc
+)
+
+do_build() {
+  make kubectl
+  return $?
+}
+
+do_install() {
+  cp _output/bin/kubectl "${pkg_prefix}/bin/"
+  return $?
+}


### PR DESCRIPTION
While `core/kubernetes` also contains kubectl, it's a large package and
overkill for users which only need access to a Kubernetes cluster via
CLI. Hence, provide a separate kubectl package.

Due to https://github.com/kubernetes/kubernetes/issues/56346 1.8.3 is
currently used and not latest stable 1.8.5

Signed-off-by: Michael Schubert <michael@kinvolk.io>