### PR TITLE
[llvm] Don't set file ownership on archive extract

### DIFF
--- a/llvm/plan.sh
+++ b/llvm/plan.sh
@@ -47,7 +47,13 @@ do_unpack() {
   local clang_src_dir="$unpack_dir/tools/clang"
   mkdir -p "$clang_src_dir"
   pushd "$clang_src_dir" > /dev/null
-  tar xf "$HAB_CACHE_SRC_PATH/cfe-${pkg_version}.src.tar.xz" --strip 1
+  # Per tar's help output:
+  #
+  #   --no-same-owner        extract files as yourself (default for ordinary users)
+  #
+  # The llvm package has some files owned by specific UIDs that we
+  # can't be sure exist on the builder or target system.
+  tar xf "$HAB_CACHE_SRC_PATH/cfe-${pkg_version}.src.tar.xz" --strip 1 --no-same-owner
   popd > /dev/null
 }
 


### PR DESCRIPTION
The build was failing because UID 1000 is the owner on some files in
the upstream tar archive but doesn't exist on the builder.

Signed-off-by: Steven Danna <steve@chef.io>