### PR TITLE
[nmap] Improves package

### DIFF
--- a/nmap/plan.sh
+++ b/nmap/plan.sh
@@ -9,14 +9,55 @@ pkg_source=https://nmap.org/dist/${pkg_name}-${pkg_version}.tar.bz2
 pkg_shasum=a8796ecc4fa6c38aad6139d9515dc8113023a82e9d787e5a5fb5fa1b05516f21
 pkg_deps=(
   core/glibc
-  core/zlib
-  core/nghttp2
   core/gcc-libs
   core/openssl
+  core/pcre
+  core/zlib
 )
 pkg_build_deps=(
+  core/bzip2
   core/coreutils
+  core/diffutils
+  core/file
   core/gcc
+  core/inetutils
+  core/lua
   core/make
+  core/openssh
   core/pkg-config
+  core/readline
+  core/which
 )
+
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O2 -Wcpp"
+  export CXXFLAGS="${CXXFLAGS} -O2 -Wcpp"
+
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}" \
+    --without-zenmap \
+    --with-libdnet=included \
+    --with-liblinear=included
+    --with-liblua="$(pkg_path_for "core/lua")" \
+    --with-libpcap=included \
+    --with-libpcre="$(pkg_path_for "core/pcre")" \
+    --with-libssh2=included \
+    --with-libz="$(pkg_path_for "core/zlib")" \
+  make
+}
+
+do_check() {
+  make check
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}


### PR DESCRIPTION
Improvements:
* `core/pcre` instead of local `libpcre`
* adds packages to satisfy `./configure` checks
* adds compiler flags to avoid warnings and, I think, compile closer to what authors of nmap intended
* `do_check()` implementation (all tests pass, yay!)

I couldn't use `core/libpcap`, the build failed because there were the same libpcap stuff declared twice. I suspect the `--with-libpcap="$(pkg_path_for "core/libpcap")"` doesn't work properly, I'll continue investigating on it. If you have any pointers, they're most welcome :)