### PR TITLE
[llvm] Don't set file ownership redux

### DIFF
--- a/llvm/plan.sh
+++ b/llvm/plan.sh
@@ -35,7 +35,13 @@ do_unpack() {
   local unpack_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
   mkdir -p "$unpack_dir"
   pushd "$unpack_dir" > /dev/null
-  tar xf "$source_file" --strip 1
+  # Per tar's help output:
+  #
+  #   --no-same-owner        extract files as yourself (default for ordinary users)
+  #
+  # The llvm package has some files owned by specific UIDs that we
+  # can't be sure exist on the builder or target system.
+  tar xf "$source_file" --strip 1 --no-same-owner
   popd > /dev/null
 
   # Download Clang frontend and place it in the correct place
@@ -47,12 +53,6 @@ do_unpack() {
   local clang_src_dir="$unpack_dir/tools/clang"
   mkdir -p "$clang_src_dir"
   pushd "$clang_src_dir" > /dev/null
-  # Per tar's help output:
-  #
-  #   --no-same-owner        extract files as yourself (default for ordinary users)
-  #
-  # The llvm package has some files owned by specific UIDs that we
-  # can't be sure exist on the builder or target system.
   tar xf "$HAB_CACHE_SRC_PATH/cfe-${pkg_version}.src.tar.xz" --strip 1 --no-same-owner
   popd > /dev/null
 }


### PR DESCRIPTION
It turns out, we call tar twice.  Let's try using this flag on both
calls and see if that helps.

Signed-off-by: Steven Danna <steve@chef.io>