### PR TITLE
[bash-completion] Update to 2.7

### DIFF
--- a/bash-completion/plan.sh
+++ b/bash-completion/plan.sh
@@ -1,11 +1,16 @@
 pkg_name=bash-completion
 pkg_origin=core
-pkg_version=2.3
-pkg_license=('GPLv2')
+pkg_version=2.7
+pkg_license=('GPL-2.0')
+pkg_upstream_url="https://github.com/scop/bash-completion"
+pkg_description="Programmable completion functions for bash"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://github.com/scop/bash-completion/releases/download/${pkg_version}/bash-completion-${pkg_version}.tar.xz
-pkg_shasum=b2e081af317f3da4fff3a332bfdbebeb5514ebc6c2d2a9cf781180acab15e8e9
-pkg_bin_dirs=(bin)
-pkg_build_deps=(core/make core/gcc core/autoconf core/automake)
-pkg_deps=(core/glibc)
-
+pkg_source="https://github.com/scop/bash-completion/releases/download/${pkg_version}/bash-completion-${pkg_version}.tar.xz"
+pkg_shasum="41ba892d3f427d4a686de32673f35401bc947a7801f684127120cdb13641441e"
+pkg_deps=(
+  core/bash
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)


### PR DESCRIPTION
I've not found any other core package that uses this one. The package structure seems a bit cumbersome to be used in another one.

Anyways, this PR upgrades it to 2.7 in case someone uses it externally.