### PR TITLE
[nginx] upgrade to 1.12.2

### DIFF
--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.11.10
+pkg_version=1.12.2
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd')
 pkg_source=https://nginx.org/download/nginx-${pkg_version}.tar.gz
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=778b3cabb07633f754cd9dee32fc8e22582bce22bfa407be76a806abd935533d
+pkg_shasum=305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416
 pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Latest nginx stable. v1.12.1 addressed [CVE-2017-7529](http://mailman.nginx.org/pipermail/nginx-announce/2017/000200.html)