### PR TITLE
Add elasticsearch5 plan which is a clone of the elasticsearch plan when it referred to 5.6.4

### DIFF
--- a/elasticsearch5/.studiorc
+++ b/elasticsearch5/.studiorc
@@ -1,0 +1,2 @@
+## This makes it work in a studio.
+mount --bind / /

--- a/elasticsearch5/config/elasticsearch.yml
+++ b/elasticsearch5/config/elasticsearch.yml
@@ -1,0 +1,71 @@
+cluster.name: {{cfg.cluster.name}}
+
+cluster.routing.allocation.node_concurrent_recoveries: {{cfg.cluster.routing.allocation.node_concurrent_recoveries}}
+cluster.routing.allocation.node_initial_primaries_recoveries: {{cfg.cluster.routing.allocation.node_initial_primaries_recoveries}}
+cluster.routing.allocation.same_shard.host: {{cfg.cluster.routing.allocation.same_shard-host}}
+
+{{#if cfg.cluster.routing.allocation.awareness-attributes ~}}
+cluster.routing.allocation.awareness.attributes: {{cfg.cluster.routing.allocation.awareness-attributes}}
+{{/if ~}}
+
+{{#if cfg.node.name ~}}
+node.name: {{cfg.node.name}}
+{{/if ~}}
+node.max_local_storage_nodes: {{cfg.node.max_local_storage_nodes}}
+
+{{#if cfg.node.rack_id ~}}
+node.rack_id: {{cfg.node.rack_id}}
+{{/if ~}}
+{{#if cfg.node.zone ~}}
+node.zone: {{cfg.node.zone}}
+{{/if ~}}
+{{#if cfg.node.master ~}}
+node.master: {{cfg.node.master}}
+{{/if ~}}
+{{#if cfg.node.data ~}}
+node.data: {{cfg.node.data}}
+{{/if ~}}
+
+path.logs: {{pkg.svc_var_path}}/logs
+path.data: {{pkg.svc_data_path}}/{{cfg.path.data}}
+
+indices.recovery.max_bytes_per_sec: {{cfg.indices.recovery.max_bytes_per_sec}}
+
+{{#if cfg.indices.fielddata.cache-size ~}}
+indices.fielddata.cache.size: {{cfg.indices.fielddata.cache-size}}
+{{/if ~}}
+
+indices.breaker.total.limit: {{cfg.indices.breaker.total-limit}}
+indices.breaker.fielddata.limit: {{cfg.indices.breaker.fielddata-limit}}
+indices.breaker.fielddata.overhead: {{cfg.indices.breaker.fielddata-overhead}}
+indices.breaker.request.limit: {{cfg.indices.breaker.request-limit}}
+indices.breaker.request.overhead: {{cfg.indices.breaker.request-overhead}}
+
+bootstrap.memory_lock: {{cfg.bootstrap.memory_lock}}
+
+network.host: {{cfg.network.host}}
+http.port: {{cfg.network.port}}
+transport.tcp.port: {{cfg.transport.port}}
+discovery.zen.fd.ping_timeout: {{cfg.discovery.zen_fd_ping_timeout}}
+{{#if bind.elasticsearch ~}}
+discovery.zen.ping.unicast.hosts: [{{#each bind.elasticsearch.members ~}} "{{sys.ip}}", {{/each ~}}]
+{{else ~}}
+discovery.zen.ping.unicast.hosts: {{cfg.discovery.ping_unicast_hosts}}
+{{/if ~}}
+discovery.zen.minimum_master_nodes: {{cfg.discovery.minimum_master_nodes}}
+
+{{#if cfg.gateway.recover_after_nodes ~}}
+gateway.recover_after_nodes: {{cfg.gateway.recover_after_nodes}}
+{{/if ~}}
+gateway.expected_nodes: {{cfg.gateway.expected_nodes}}
+gateway.expected_master_nodes: {{cfg.gateway.expected_master_nodes}}
+gateway.expected_data_nodes: {{cfg.gateway.expected_data_nodes}}
+{{#if cfg.gateway.recover_after_time ~}}
+gateway.recover_after_time: {{cfg.gateway.recover_after_time}}
+{{/if ~}}
+
+action.destructive_requires_name: {{cfg.action.destructive_requires_name}}
+
+{{#if cfg.plugins.cloud_aws_signer ~}}
+cloud.aws.signer: {{cfg.plugins.cloud_aws_signer}}
+{{/if ~}}

--- a/elasticsearch5/config/jvm.options
+++ b/elasticsearch5/config/jvm.options
@@ -1,0 +1,53 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms{{cfg.runtime.heapsize}}
+-Xmx{{cfg.runtime.heapsize}}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+-XX:+DisableExplicitGC
+-XX:+AlwaysPreTouch
+-server
+-Xss1m
+-Djava.awt.headless=true
+-Dfile.encoding=UTF-8
+-Djna.nosys=true
+-Djdk.io.permissionsUseCanonicalPath=true
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+-XX:+HeapDumpOnOutOfMemoryError
+{{cfg.runtime.es_java_opts}}

--- a/elasticsearch5/config/log4j2.properties
+++ b/elasticsearch5/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/elasticsearch5/default.toml
+++ b/elasticsearch5/default.toml
@@ -1,0 +1,234 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please see the documentation for further information on configuration options:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
+#
+# ---------------------------------- Cluster -----------------------------------
+#
+[cluster]
+  #
+  # Use a descriptive name for your cluster:
+  #
+  name = "elasticsearch"
+
+  [cluster.routing.allocation]
+    #
+    # How many concurrent shard recoveries are allowed to happen on a node.
+    # Defaults to 2.
+    #
+    node_concurrent_recoveries = "2"
+    #
+    # While the recovery of replicas happens over the network, the recovery of
+    # an unassigned primary after node restart uses data from the local disk.
+    # These should be fast so more initial primary recoveries can happen in
+    # parallel on the same node. Defaults to 4.
+    #
+    node_initial_primaries_recoveries = "4"
+    #
+    # Allows to perform a check to prevent allocation of multiple instances of
+    # the same shard on a single host, based on host name and host address.
+    # Defaults to false, meaning that no check is performed by default. This
+    # setting only applies if multiple nodes are started on the same machine.
+    #
+    same_shard-host = "false"
+    #
+    # https://www.elastic.co/guide/en/elasticsearch/reference/2.3/allocation-awareness.html
+    #
+    awareness-attributes = ""
+#
+# ------------------------------------ Node ------------------------------------
+#
+[node]
+  # Use a descriptive name for the node:
+  #
+  name = ""
+  #
+  # Add custom attributes to the node:
+  #
+  # node.rack: r1
+  #
+  rack_id = ""
+  zone    = ""
+  #
+  # Disable starting multiple nodes on a single system:
+  #
+  max_local_storage_nodes = 1
+  #
+  # Configure node as master-only, master-eligible, data-only, or client
+  # (https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-node.html#master-node)
+  # Default is master-eligible (master and data are both "true")
+  #
+  master = "true"
+  data   = "true"
+
+#
+# ----------------------------------- Paths ------------------------------------
+#
+[path]
+  #
+  # Path to directory where to store the data (separate multiple locations by comma):
+  #
+  data =    ""
+  #
+  # Path to log files:
+  #
+  logs =    "logs"
+
+#
+# ----------------------------------- Indices ----------------------------------
+#
+[indices]
+  [indices.recovery]
+    max_bytes_per_sec  =            "20mb"
+
+  [indices.fielddata]
+    #
+    # The max size of the field data cache, eg 30% of node heap space, or an absolute
+    # value, eg 12GB. Defaults to unbounded.
+    #
+    cache-size =                   ""
+
+  [indices.breaker]
+    #
+    # Starting limit for overall parent breaker, defaults to 70% of JVM heap.
+    #
+    total-limit =                    "70%"
+    #
+    # Limit for fielddata breaker, defaults to 60% of JVM heap.
+    #
+    fielddata-limit =                "60%"
+    #
+    # A constant that all field data estimations are multiplied with to determine a
+    # final estimation. Defaults to 1.03
+    #
+    fielddata-overhead =             "1.03"
+    #
+    # Limit for request breaker, defaults to 40% of JVM heap.
+    #
+    request-limit =                  "40%"
+    #
+    # A constant that all request estimations are multiplied with to determine a
+    # final estimation. Defaults to 1.
+    #
+    request-overhead =               "1"
+
+#
+# ----------------------------------- Memory -----------------------------------
+#
+[bootstrap]
+  # Lock the memory on startup:
+  #
+  memory_lock = "false"
+  #
+  # Make sure that the heap size is set to about half the memory available
+  # on the system and that the owner of the process is allowed to use this
+  # limit.
+  #
+  # Elasticsearch performs poorly when the system is swapping the memory.
+  #
+
+#
+# ---------------------------------- Network -----------------------------------
+#
+[network]
+  #
+  # Set the bind address to a specific IP (IPv4 or IPv6):
+  #
+  host =  "_site_"
+  #
+  # Set a custom port for HTTP:
+  #
+  port = 9200
+  #
+  # For more information, see the documentation at:
+  # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+
+[transport]
+  port = 9300
+
+#
+# --------------------------------- Discovery ----------------------------------
+#
+[discovery]
+  # Pass an initial list of hosts to perform discovery when new node is started:
+  # The default list of hosts is ["127.0.0.1", "[::1]"]
+  #
+  ping_unicast_hosts = "[]"
+  #
+  # Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+  #
+  minimum_master_nodes = 1
+  #
+  # For more information, see the documentation at:
+  # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+  #
+  zen_fd_ping_timeout = "30s"
+
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+[gateway]
+  #
+  # Block initial recovery after a full cluster restart until N nodes are started:
+  #
+  recover_after_nodes   = ""
+  #
+  # The number of (data or master) nodes that are expected to be in the cluster.
+  # Recovery of local shards will start as soon as the expected number of nodes
+  # have joined the cluster. Defaults to 0
+  #
+  expected_nodes        = "0"
+  #
+  # The number of master nodes that are expected to be in the cluster. Recovery
+  # of local shards will start as soon as the expected number of master nodes
+  # have joined the cluster. Defaults to 0
+  #
+  expected_master_nodes = "0"
+  #
+  # The number of data nodes that are expected to be in the cluster. Recovery of
+  # local shards will start as soon as the expected number of data nodes have
+  # joined the cluster. Defaults to 0
+  #
+  expected_data_nodes   = "0"
+  #
+  # If the expected number of nodes is not achieved, the recovery process waits
+  # for the configured amount of time before trying to recover regardless.
+  # Defaults to 5m if one of the expected_nodes settings is configured.
+  #
+  recover_after_time    = ""
+  #
+  # For more information, see the documentation at:
+  # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+  #
+
+#
+# ---------------------------------- Various -----------------------------------
+#
+[action]
+  #
+  # Require explicit names when deleting indices:
+  #
+  destructive_requires_name  = "true"
+
+# ======================== Elasticsearch Logger Configuration =========================
+[logger]
+  level = "info"
+
+# ======================== Elasticsearch Plugins Configuration =========================
+[plugins]
+  cloud_aws_signer = ""
+
+# ======================== Runtime Configuration =========================
+[runtime]
+  max_open_files = ""
+  max_locked_memory = ""
+  es_startup_sleep_time = ""
+  es_java_opts = ""
+  heapsize = "1g"

--- a/elasticsearch5/hooks/health_check
+++ b/elasticsearch5/hooks/health_check
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Elasticsearch Health Check for Habitat
+
+# For details on the elasticsearch health colors, see:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+status="$(wget -qO - "{{svc.me.sys.ip}}:{{svc.me.cfg.http-port}}/_cat/health")"
+color="$(echo "$status" | awk '{print $4}')"
+
+case $color in
+  "green")
+    rc=0 ;;                     # OK (200)
+  "yellow")
+    rc=1 ;;                     # WARNING (200)
+  "red")
+    rc=2 ;;                     # CRITICAL (503)
+  *)
+    rc=3 ;;                     # UNKNOWN (500)
+esac
+
+exit $rc

--- a/elasticsearch5/hooks/init
+++ b/elasticsearch5/hooks/init
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p {{pkg.svc_var_path}}/logs
+mkdir -p {{pkg.svc_var_path}}/plugins

--- a/elasticsearch5/hooks/run
+++ b/elasticsearch5/hooks/run
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+exec 2>&1
+
+{{#if cfg.runtime.es_startup_sleep_time ~}}
+export ES_STARTUP_SLEEP_TIME={{cfg.runtime.es_startup_sleep_time}}
+{{/if ~}}
+{{#if cfg.runtime.max_locked_memory ~}}
+ulimit -l {{cfg.runtime.max_locked_memory}}
+{{/if ~}}
+{{#if cfg.runtime.max_open_files ~}}
+ulimit -n {{cfg.runtime.max_open_files}}
+{{/if ~}}
+
+export ES_JVM_OPTIONS="{{pkg.svc_config_path}}/jvm.options"
+exec elasticsearch -Epath.conf={{pkg.svc_config_path}}

--- a/elasticsearch5/plan.sh
+++ b/elasticsearch5/plan.sh
@@ -1,0 +1,47 @@
+pkg_name=elasticsearch5
+pkg_origin=core
+pkg_version=5.6.4
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Open Source, Distributed, RESTful Search Engine"
+pkg_upstream_url="https://elastic.co"
+pkg_license=('Revised BSD')
+pkg_source=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz
+pkg_shasum=1098fc776fae8c74e65f8e17cf2ea244c1d07c4e6711340c9bb9f6df56aa45b0
+pkg_dirname="elasticsearch-${pkg_version}"
+pkg_deps=(
+  core/busybox-static
+  core/glibc
+  core/jre8
+)
+pkg_bin_dirs=(es/bin)
+pkg_binds_optional=(
+  [elasticsearch]="http-port transport-port"
+)
+pkg_lib_dirs=(es/lib)
+pkg_exports=(
+  [http-port]=network.port
+  [transport-port]=transport.port
+)
+pkg_exposes=(http-port transport-port)
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  install -vDm644 README.textile "${pkg_prefix}/README.textile"
+  install -vDm644 LICENSE.txt "${pkg_prefix}/LICENSE.txt"
+  install -vDm644 NOTICE.txt "${pkg_prefix}/NOTICE.txt"
+
+  # Elasticsearch is greedy when grabbing config files from /bin/..
+  # so we need to put the untemplated config dir out of reach
+  mkdir -p "${pkg_prefix}/es"
+  cp -a ./* "${pkg_prefix}/es"
+
+  # jvm.options needs to live relative to the binary.
+  # mkdir -p mkdir -p "$pkg_prefix/es/config"
+  # install -vDm644 config/jvm.options "$pkg_prefix/es/config/jvm.options"
+
+  # Delete unused binaries to save space
+  rm "${pkg_prefix}/es/bin/"*.bat "${pkg_prefix}/es/bin/"*.exe
+}


### PR DESCRIPTION
Now that the `elasticsearch` plan has moved on to version 6, some users still want to track Elasticsearch 5.x for the foreseeable future.