### PR TITLE
Jenkins upgrade to 2.89.2 (Security update)

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,27 +1,27 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.89.1
+pkg_version=2.89.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('mit')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="f9f363959042fce1615ada81ae812e08d79075218c398ed28e68e1302c4b272f"
+pkg_shasum="014f669f32bc6e925e926e260503670b32662f006799b133a031a70a794c8a14"
 pkg_deps=(core/jre8 core/curl)
 pkg_exports=(
-    [port]=jenkins.http.port
+  [port]=jenkins.http.port
 )
 pkg_exposes=(port)
 pkg_svc_user="root"
 
 do_unpack() {
-    return 0
+  return 0
 }
 
 do_build() {
-    return 0
+  return 0
 }
 
 do_install() {
-    cp "${HAB_CACHE_SRC_PATH}"/"${pkg_filename}" "${pkg_prefix}"/jenkins.war
+  cp "${HAB_CACHE_SRC_PATH}"/"${pkg_filename}" "${pkg_prefix}"/jenkins.war
 }


### PR DESCRIPTION
Ref: https://jenkins.io/security/advisory/2017-12-14/
Ref: https://jenkins.io/blog/2017/12/14/security-update/

Should be promoted to stable above 2.89.1 also.

Signed-off-by: Graham Weldon <graham@grahamweldon.com>