### PR TITLE
Add libpq (postgres client library)

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -427,6 +427,8 @@ plan_path = "libpcap"
 plan_path = "libpipeline"
 [libpng]
 plan_path = "libpng"
+[libpq]
+plan_path = "libpq"
 [libpthread-stubs]
 plan_path = "libpthread-stubs"
 [libressl]

--- a/libpq/README.md
+++ b/libpq/README.md
@@ -1,0 +1,10 @@
+# Habitat Package: libpq
+The Habitat Maintainers humans@habitat.sh
+
+## Description
+Habitat package for the client side libraries of postgresql, including
+libpq and the psql command line client utility.
+
+This is a subset of the postgresql habitat package, leaving out much
+of the server side code and postgis support. It is intended to be a
+lightweight package for client side applications.

--- a/libpq/README.md
+++ b/libpq/README.md
@@ -7,4 +7,9 @@ libpq and the psql command line client utility.
 
 This is a subset of the postgresql habitat package, leaving out much
 of the server side code and postgis support. It is intended to be a
-lightweight package for client side applications.
+lightweight package for client side applications, providing both the
+build and runtime dependencies for clients.
+
+Postgresql-client was considered as a name, to follow mysql-client, but in
+the end the libpq-dev debian package came the closest to what this
+provides.

--- a/libpq/plan.sh
+++ b/libpq/plan.sh
@@ -1,0 +1,56 @@
+pkg_name=libpq
+pkg_origin=core
+pkg_version=9.6.6
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="LibPQ is the client side library for PostgreSQL, a powerful, open source object-relational database system."
+pkg_upstream_url="https://www.postgresql.org/"
+pkg_license=('PostgreSQL')
+pkg_source=https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2
+pkg_dirname=postgresql-${pkg_version}
+pkg_shasum=399cdffcb872f785ba67e25d275463d74521566318cfef8fe219050d063c8154
+
+pkg_deps=(
+  core/glibc
+  core/openssl
+  core/readline
+  core/zlib
+  core/libossp-uuid
+)
+
+pkg_build_deps=(
+  core/coreutils
+  core/gcc
+  core/make
+)
+
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+    # ld manpage: "If -rpath is not used when linking an ELF
+    # executable, the contents of the environment variable LD_RUN_PATH
+    # will be used if it is defined"
+    ./configure --disable-rpath \
+              --with-openssl \
+              --prefix="$pkg_prefix" \
+              --with-uuid=ossp \
+              --with-includes="$LD_INCLUDE_PATH" \
+              --with-libraries="$LD_LIBRARY_PATH" \
+              --sysconfdir="$pkg_svc_config_path" \
+              --localstatedir="$pkg_svc_var_path" \
+              --without-tcl --without-perl --without-python
+    # making everything and throwing away all but the client side is a
+    # little bit slow, but seems to be the simplest way to go
+    make
+}
+
+do_install() {
+    # This is straight out of the 'client-only installation' section of:
+    # https://www.postgresql.org/docs/9.6/static/install-procedure.html#INSTALL
+    # we could delete everthing but psql and be fine, but that is messy
+    make -C src/bin install
+    # not all of the include files are needed for client side, but for simplicit's sake we install them all.
+    make -C src/include install
+    make -C src/interfaces install
+}

--- a/libpq/plan.sh
+++ b/libpq/plan.sh
@@ -27,6 +27,30 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+
+# These commands only make sense for if there's a postgres server
+# running locally, and in that case can use the versions that came
+# with that install
+
+server_execs=(
+    ecpg
+    initdb
+    pg_archivecleanup
+    pg_config
+    pg_controldata
+    pg_resetxlog
+    pg_rewind
+    pg_test_fsync
+    pg_test_timing
+    pg_upgrade
+    pg_xlogdump
+)
+
+server_includes=(
+    postgresql/informix
+    postgresql/server
+)
+
 do_build() {
     # ld manpage: "If -rpath is not used when linking an ELF
     # executable, the contents of the environment variable LD_RUN_PATH
@@ -53,4 +77,21 @@ do_install() {
     # not all of the include files are needed for client side, but for simplicit's sake we install them all.
     make -C src/include install
     make -C src/interfaces install
+
+    # Clean up files needed only for server installs
+    # this shrinks the package by about 60%
+    echo "Purging unneeded execs"
+    for unneeded in "${server_execs[@]}"
+    do
+       target="$pkg_prefix/bin/${unneeded}"
+       echo "rm -f ${target}"
+       rm -f "${target}"
+    done
+    echo "Purging unneeded includes"
+    for unneeded in "${server_includes[@]}"
+    do
+       target="$pkg_prefix/include/${unneeded}"
+       echo "rm -rf ${target}"
+       rm -rf "${target}"
+    done
 }


### PR DESCRIPTION
This includes the psql tool as well as the libpq client side library. It might well be named postgresql-client for better discoverability, but that seemed like a bit of a mysql'ism (there's a utility named mysql-client, but nothing named postgresql-client)

Signed-off-by: Mark Anderson <mark@chef.io>