### PR TITLE
[dovecot] Add dovecot package

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -159,6 +159,8 @@ plan_path = "dotnet-core-lts"
 plan_path = "dotnet-core-sdk"
 [dotnet-core-sdk-lts]
 plan_path = "dotnet-core-sdk-lts"
+[dovecot]
+plan_path = "dovecot"
 [doxygen]
 plan_path = "doxygen"
 [dpkg]

--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -1,0 +1,12 @@
+# dovecot
+
+This package provides the dovecot IMAP server.
+
+## Usage
+
+Typically this is a run-time dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/dovecot)
+
+You'll also have to add your own configuration for dovecot and use a command like `dovecot -c <path to config file>` to your run hook.

--- a/dovecot/plan.sh
+++ b/dovecot/plan.sh
@@ -1,0 +1,49 @@
+pkg_name=dovecot
+pkg_origin=core
+pkg_version=2.3.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Secure IMAP server"
+pkg_upstream_url="https://dovecot.org"
+pkg_license=("LGPL-2.1" "MIT")
+pkg_source="https://dovecot.org/releases/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="de60cb470d025e4dd0f8e8fbbb4b9316dfd4930eb949d307330669ffbeaf8581"
+pkg_dirname="${pkg_name}-ce-${pkg_version}"
+pkg_deps=(
+  core/bzip2
+  core/glibc
+  core/linux-pam
+  core/lz4
+  core/openssl
+  core/zlib
+)
+pkg_build_deps=(
+  core/diffutils
+  core/file
+  core/gcc
+  core/make
+  core/pkg-config
+)
+pkg_bin_dirs=(
+  bin
+  sbin
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O2"
+  export CXXFLAGS="${CXXFLAGS} -O2"
+
+  # The configure script expects `file` binaries to be in `/usr/bin`
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
+
+do_end() {
+  # Clean up
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}


### PR DESCRIPTION
This adds dovecot, the IMAP server.

I've not included any run hook because I think it would have no value, unless we set up a complete configuration scheme, which, IIRC is not the aim of core plans :)