### PR TITLE
[fluentd] upgrading to 1.0.2

### DIFF
--- a/fluentd/plan.sh
+++ b/fluentd/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=fluentd
 pkg_origin=core
-pkg_version=0.14.23
+pkg_version=1.0.2
 pkg_deps=(
   core/ruby
   core/coreutils


### PR DESCRIPTION
Upgrading to fluentd 1.0 release. It doesn't have breaking changes from previous 0.14.xx releases.

Signed-off-by: Rahul Sinha <rahul@rahulwa.com>