### PR TITLE
[cyrus-sasl] Fix plugindir path at compile time

### DIFF
--- a/cyrus-sasl/plan.sh
+++ b/cyrus-sasl/plan.sh
@@ -15,6 +15,7 @@ pkg_lib_dirs=(lib)
 
 do_build() {
   ./configure --prefix="${pkg_prefix}" \
+              --with-plugindir="${pkg_prefix}/lib/sasl2" \
               --enable-auth-sasldb \
               --with-saslauthd="${pkg_svc_var_path}/run/saslauthd"
   make


### PR DESCRIPTION
This fixes a problem with cyrus-sasl looking for its plugins in the default location `/usr/lib/sasl2`