### PR TITLE
[node] Fix bad interpretters in node-gyp and some other scripts

### DIFF
--- a/node/plan.sh
+++ b/node/plan.sh
@@ -7,8 +7,8 @@ pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
 pkg_shasum=729b44b32b2f82ecd5befac4f7518de0c4e3add34e8fe878f745740a66cbbc01
-pkg_deps=(core/glibc core/gcc-libs)
-pkg_build_deps=(core/python2 core/gcc core/grep core/make)
+pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
+pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_interpreters=(bin/node)
@@ -39,5 +39,11 @@ do_install() {
   # fix that everywhere to point directly at the env binary in core/coreutils.
   grep -nrlI '^\#\!/usr/bin/env' "$pkg_prefix" | while read -r target; do
     sed -e "s#\#\!/usr/bin/env node#\#\!${pkg_prefix}/bin/node#" -i "$target"
+    sed -e "s#\#\!/usr/bin/env sh#\#\!$(pkg_path_for bash)/bin/sh#" -i "$target"
+    sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" -i "$target"
+    sed -e "s#\#\!/usr/bin/env python#\#\!$(pkg_path_for python2)/bin/python2#" -i "$target"
   done
+
+  # This script has a hardcoded bare `node` command
+  sed -e "s#^\([[:space:]]\)\+node\([[:space:]]\)#\1${pkg_prefix}/bin/node\2#" -i "${pkg_prefix}/lib/node_modules/npm/bin/node-gyp-bin/node-gyp"
 }


### PR DESCRIPTION
All node version plans appear to be affected by this issue.

`npm install` fails when `node-gyp` needs to be called in due to various uncorrected non-node shebangs and one rogue bare `node` invocation:

## `npm install`

```
> msgpack@https://registry.npmjs.org/msgpack/-/msgpack-1.0.2.tgz install /src/node_modules/msgpack
> node-gyp rebuild

sh: /hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/bin/node-gyp-bin/node-gyp: /usr/bin/env: bad interpreter: No such file or directory

> posix@4.1.1 install /src/node_modules/posix
> node-gyp rebuild

sh: /hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/bin/node-gyp-bin/node-gyp: /usr/bin/env: bad interpreter: No such file or directory
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: msgpack@https://registry.npmjs.org/msgpack/-/msgpack-1.0.2.tgz (node_modules/msgpack):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: msgpack@https://registry.npmjs.org/msgpack/-/msgpack-1.0.2.tgz install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 126

npm ERR! code ELIFECYCLE
npm ERR! errno 126
npm ERR! posix@4.1.1 install: `node-gyp rebuild`
npm ERR! Exit status 126
npm ERR!
npm ERR! Failed at the posix@4.1.1 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2018-01-01T00_50_39_128Z-debug.log
```

## `grep -nrI '^\#\!/usr/bin/env' "$(hab pkg path core/node)"`

```
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/bin/node-gyp-bin/node-gyp:1:#!/usr/bin/env sh
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/travis-gh-pages:1:#!/usr/bin/env bash
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests:1:#!/usr/bin/env sh
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/setup.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/tools/graphviz.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/gyptest.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/easy_xml_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/common_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input_test.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py:1:#!/usr/bin/env python
/hab/pkgs/core/node/8.9.1/20171116162209/lib/node_modules/npm/scripts/doc-build.sh:1:#!/usr/bin/env bash
```

## `cat "$(hab pkg path core/node)/lib/node_modules/npm/bin/node-gyp-bin/node-gyp"`

```
#!/usr/bin/env sh
if [ "x$npm_config_node_gyp" = "x" ]; then
  node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
else
  "$npm_config_node_gyp" "$@"
fi
```