### PR TITLE
[nmap] Fixing core/nmap libpcap bug

### DIFF
--- a/nmap/plan.sh
+++ b/nmap/plan.sh
@@ -13,6 +13,7 @@ pkg_deps=(
   core/openssl
   core/pcre
   core/zlib
+  core/libpcap
 )
 pkg_build_deps=(
   core/bzip2
@@ -45,7 +46,6 @@ do_build() {
     --with-libdnet=included \
     --with-liblinear=included \
     --with-liblua="$(pkg_path_for "core/lua")" \
-    --with-libpcap=included \
     --with-libpcre="$(pkg_path_for "core/pcre")" \
     --with-libssh2=included \
     --with-libz="$(pkg_path_for "core/zlib")"


### PR DESCRIPTION
I discovered that there is a bug with the current build of core/nmap where libpcap was getting installed with nmap's source build, but wasn't working properly. I removed that from the build and added core/libpcap, which worked properly. Upon local testing, I can confirm this fix works when using nmap as a dependency in other projects. 

Please let me know if there are any questions or concerns. 

Signed-off-by: Christopher P. Maher <defilan@gmail.com>