### PR TITLE
[nmap] Add pkg_bin_dirs so that hab pkg exec works

### DIFF
--- a/nmap/plan.sh
+++ b/nmap/plan.sh
@@ -30,6 +30,8 @@ pkg_build_deps=(
   core/which
 )
 
+pkg_bin_dirs=(bin)
+
 do_prepare() {
   export CFLAGS="${CFLAGS} -O2 -Wcpp"
   export CXXFLAGS="${CXXFLAGS} -O2 -Wcpp"


### PR DESCRIPTION
There is no default value for pkg_bin_dirs.  Thus, without setting
this, `hab pkg exec` doesn't work for this package.

Signed-off-by: Steven Danna <steve@chef.io>