### PR TITLE
[ruby] track and package multiple upstream releases

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -843,6 +843,21 @@ plan_path = "rq"
 plan_path = "rsync"
 [ruby]
 plan_path = "ruby"
+[ruby22]
+plan_path = "ruby22"
+paths = [
+  "ruby/*"
+]
+[ruby23]
+plan_path = "ruby23"
+paths = [
+  "ruby/*"
+]
+[ruby24]
+plan_path = "ruby24"
+paths = [
+  "ruby/*"
+]
 [runit]
 plan_path = "runit"
 [rust]

--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby
 pkg_origin=core
-pkg_version=2.4.2
+pkg_version=2.4.3
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c
+pkg_shasum=fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby22/plan.sh
+++ b/ruby22/plan.sh
@@ -1,0 +1,15 @@
+source ../ruby/plan.sh
+
+pkg_name=ruby22
+pkg_version=2.2.9
+pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
+pkg_shasum=2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6
+pkg_dirname="ruby-$pkg_version"
+
+pkg_version() {
+  echo "$pkg_version"
+}
+
+do_before() {
+  update_pkg_version
+}

--- a/ruby23/plan.sh
+++ b/ruby23/plan.sh
@@ -1,0 +1,15 @@
+source ../ruby/plan.sh
+
+pkg_name=ruby23
+pkg_version=2.3.6
+pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
+pkg_shasum=8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e
+pkg_dirname="ruby-$pkg_version"
+
+pkg_version() {
+  echo "$pkg_version"
+}
+
+do_before() {
+  update_pkg_version
+}

--- a/ruby24/plan.sh
+++ b/ruby24/plan.sh
@@ -1,0 +1,9 @@
+source ../ruby/plan.sh
+
+pkg_name=ruby24
+pkg_dirname="ruby-$pkg_version"
+
+if ! [[ "$pkg_version" =~ ^2.4 ]]; then
+  build_line "ERROR: This plan is intended to build v2.4.x but its sourced plan version is $pkg_version"
+  exit 1
+fi


### PR DESCRIPTION
* Updates to the latest Ruby 2.4.x.
* Adds plans for all currently-maintained upstream Ruby versions.

These plans source `ruby/plan.sh` because so far it looks like the steps to build Ruby are the same for all these versions.

`update_pkg_version` is used to handle updating attributes to the different version from the latest Ruby. Some attributes aren't recomputed there, though--like `pkg_source` and `pkg_dirname` (because it's set to _something_ already)--so they are set again in the specific version plans.

The specific plan that tracks the latest version--`ruby24` here--is a simple sourcing of the main `ruby` plan with a sanity check that the `pkg_version` already set is the `X.Y` expected. This is intended to safeguard against the ruby plan moving to `X.Z` and having the specific version get built and have its name be a lie. e.g. Upgrading `ruby` to `2.5.0` and having `ruby24` get built with that newer version.
  
![Rubiiiies](https://user-images.githubusercontent.com/517302/34541799-af8b6e3e-f0a7-11e7-983e-dbb151526d74.gif)
