### PR TITLE
Predominant/delmo binary

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -135,6 +135,8 @@ plan_path = "dbus"
 plan_path = "dd-agent"
 [dejagnu]
 plan_path = "dejagnu"
+[delmo]
+plan_path = "delmo"
 [dep]
 plan_path = "dep"
 [devicemapper]

--- a/delmo/README.md
+++ b/delmo/README.md
@@ -1,0 +1,18 @@
+# Habitat package: delmo
+
+## Description
+
+[Delmo](1) is a tool to test systems running within multiple docker containers.
+
+This plan provides the static binary for execution within other plans.
+
+## Usage
+
+```
+hab pkg install core/delmo
+hab pkg binlink core/delmo delmo
+
+delmo --help
+```
+
+[1]: https://github.com/bodymindarts/delmo

--- a/delmo/plan.sh
+++ b/delmo/plan.sh
@@ -1,0 +1,24 @@
+pkg_name=delmo
+pkg_origin=core
+pkg_version="0.6.1"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_source="https://github.com/bodymindarts/delmo/releases/download/v${pkg_version}/delmo-linux-amd64"
+pkg_filename="${pkg_name}"
+pkg_shasum="1d7a3a27f5c65a281315325bda9b87c176cd3b6f82b26e4eab290bbe2eefb221"
+pkg_bin_dirs=(bin)
+pkg_description="DelMo is a tool to test systems running within multiple docker containers."
+pkg_upstream_url="https://github.com/bodymindarts/delmo"
+
+do_unpack() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mv "${HAB_CACHE_SRC_PATH}/${pkg_name}" "${SRC_PATH}/${pkg_name}"
+  install -D "${pkg_name}" "${pkg_prefix}/bin/${pkg_name}"
+}


### PR DESCRIPTION
Refs #1129 

I had initially done this plan as a from-source plan. However there's no agreed way to `go get` a specific version, and using the `scaffolding-go` base wasn't going to produce an exact version on each build.

I think long-term the `scaffolding-go` could be enhanced to do a `git clone` in the event that a version is specified, which would result in reproducible builds at specified version numbers. This may open a can of worms based on go deps versioning, though..

So, Binary for the moment.

![tenor-136473512](https://user-images.githubusercontent.com/24568/34809877-509bcd62-f6db-11e7-8616-3f2563ab1c71.gif)