### PR TITLE
Breakout LLVM and upgrade to 5.0.1

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -87,6 +87,10 @@ plan_path = "ccache"
 plan_path = "certstrap"
 [check]
 plan_path = "check"
+[clang]
+plan_path = "clang"
+[clang-tools-extra]
+plan_path = "clang-tools-extra"
 [clens]
 plan_path = "clens"
 [clingo]

--- a/clang-tools-extra/README.md
+++ b/clang-tools-extra/README.md
@@ -1,0 +1,19 @@
+# clang-tools-extra
+
+Clang Tools are standalone command line (and potentially GUI) tools designed for use by C++
+developers who are already using and enjoying Clang as their compiler. These tools provide
+developer-oriented functionality such as fast syntax checking, automatic formatting, refactoring,
+etc.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Include `core/clang-tools-extra` if you need any of the extra clang tools.  For additional
+usage, refer to the [`pkg_upstream_url`](https://clang.llvm.org/docs/ClangTools.html#extra-clang-tools)

--- a/clang-tools-extra/plan.sh
+++ b/clang-tools-extra/plan.sh
@@ -1,0 +1,73 @@
+pkg_name=clang-tools-extra
+pkg_origin=core
+pkg_version=5.0.1
+pkg_license=('NCSA')
+pkg_description="Clang Tools are standalone command line (and potentially GUI) tools designed for use by C++ developers who are already using and enjoying Clang as their compiler. These tools provide developer-oriented functionality such as fast syntax checking, automatic formatting, refactoring, etc."
+pkg_upstream_url="https://clang.llvm.org/docs/ClangTools.html#extra-clang-tools"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="${pkg_name}-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/${pkg_name}-${pkg_version}.src.tar.xz"
+pkg_shasum="9aada1f9d673226846c3399d13fab6bba4bfd38bcfe8def5ee7b0ec24f8cd225"
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+  core/zlib
+)
+pkg_build_deps=(
+  core/llvm
+  core/cmake
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/make
+  core/python2
+)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  # The tarball's structure has `.src` as part of the base directory.
+  # This reimplements a large portion of the default unpack, only to
+  # add `--strip` to the tar command.
+  # There may be some more awesome way to do this - I don't know that yet.
+  local source_file=$HAB_CACHE_SRC_PATH/$pkg_filename
+  local unpack_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
+
+  # Download Clang frontend and place it in the correct place
+  build_line "Unpacking Clang FrontEnd Source to custom cache dir"
+  download_file http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz \
+    cfe-${pkg_version}.src.tar.xz \
+    135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff
+
+  local clang_src_dir="$unpack_dir"
+  mkdir -p "$clang_src_dir"
+  pushd "$clang_src_dir" > /dev/null || exit
+  tar xf "$HAB_CACHE_SRC_PATH/cfe-${pkg_version}.src.tar.xz" --strip 1 --no-same-owner
+  popd > /dev/null || exit
+
+  # Unpack Clang-Tools-Extra and place it in the correct place
+  build_line "Unpacking Clang-Tools-Extra to custom cache dir"
+  local clang_tools_extra_src_dir="$unpack_dir/tools/extra"
+  mkdir -p "$clang_tools_extra_src_dir"
+  pushd "$clang_tools_extra_src_dir" > /dev/null || exit
+  tar xf "$source_file" --strip 1 --no-same-owner
+  popd > /dev/null || exit
+}
+
+do_build() {
+  mkdir -p build
+  cd build || exit
+  cmake -DCMAKE_INSTALL_PREFIX:PATH="$pkg_prefix" -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../
+  cd tools/extra || exit
+  make
+}
+
+do_check() {
+  cd build/tools/extra || exit
+  make test
+}
+
+do_install() {
+  cd build/tools/extra || exit
+  make install
+}

--- a/clang/README.md
+++ b/clang/README.md
@@ -1,0 +1,16 @@
+# clang
+
+LLVM native C/C++/Objective-C compiler
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Include `core/clang` if you need any of the libraries, includes and clang tools.  For additional
+usage, refer to the [`pkg_upstream_url`](http://clang.llvm.org/)

--- a/clang/plan.sh
+++ b/clang/plan.sh
@@ -1,0 +1,68 @@
+pkg_name=clang
+pkg_origin=core
+pkg_version=5.0.1
+pkg_license=('NCSA')
+pkg_description="LLVM native C/C++/Objective-C compiler"
+pkg_upstream_url="http://clang.llvm.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="${pkg_name}-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz"
+pkg_shasum="135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff"
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+  core/zlib
+)
+pkg_build_deps=(
+  core/llvm
+  core/cmake
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/make
+  core/python2
+)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  # The tarball's structure has `.src` as part of the base directory.
+  # This reimplements a large portion of the default unpack, only to
+  # add `--strip` to the tar command.
+  # There may be some more awesome way to do this - I don't know that yet.
+  build_line "Unpacking $pkg_filename to custom cache dir"
+  local source_file=$HAB_CACHE_SRC_PATH/$pkg_filename
+  local unpack_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
+  mkdir -p "$unpack_dir"
+  pushd "$unpack_dir" > /dev/null || exit
+  # Per tar's help output:
+  #
+  #   --no-same-owner        extract files as yourself (default for ordinary users)
+  #
+  # The llvm package has some files owned by specific UIDs that we
+  # can't be sure exist on the builder or target system.
+  tar xf "$source_file" --strip 1 --no-same-owner
+  popd > /dev/null || exit
+}
+
+do_build() {
+  mkdir -p build
+  cd build || exit
+  cmake \
+    -DCMAKE_INSTALL_PREFIX:PATH="$pkg_prefix" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -G "Unix Makefiles" \
+    ../
+  make
+}
+
+do_check() {
+  cd build || exit
+  make test
+}
+
+do_install() {
+  cd build || exit
+  make install
+}


### PR DESCRIPTION
Everyone ❤️  smaller plans and more modular!

- Changed from `ninja` to `cmake/make` since the former did not allow to build and install parts of the tools.
- `core/llvm` needs to be built first before building `core/clang` and `core/clang-tools-extra`

Signed-off-by: Ben Dang <me@bdang.it>