### PR TITLE
[postgresql] Fix data directory permissions

### DIFF
--- a/postgresql/config/functions.sh
+++ b/postgresql/config/functions.sh
@@ -68,4 +68,5 @@ ensure_dir_ownership() {
   chown -RL hab:hab {{pkg.svc_var_path}}
   chown -RL hab:hab {{pkg.svc_config_path}}
   chown -RL hab:hab {{pkg.svc_data_path}}
+  chmod 0700 {{pkg.svc_data_path}}
 }


### PR DESCRIPTION
habitat-sh/habitat@c61953650b (released in 0.52.0) changed the default
data directory permissions from 0700 to 0770. While postgresql can
initially start up because initdb will set the correct permissions on
the data directory, subsequent restarts of the service will fail
because the supervisor will change the directory permissions, leading
to the following postgresql error:

    FATAL:  data directory "/hab/svc/postgresql/data" has group or world access
    DETAIL:  Permissions should be u=rwx (0700).

Setting the data directory permissions explicitly resolves this issue

Signed-off-by: Steven Danna <steve@chef.io>