### PR TITLE
[php] core/php: Updated to run PHP-FPM as a service

### DIFF
--- a/php/config/php-fpm.conf
+++ b/php/config/php-fpm.conf
@@ -1,0 +1,17 @@
+[global]
+pid = {{pkg.svc_var_path}}/php-fpm-pid;
+daemonize = {{cfg.daemonize}}
+error_log = {{pkg.svc_var_path}}/log/php-fpm.log
+log_level = {{cfg.log_level}}
+
+[php]
+listen = {{pkg.svc_var_path}}/php-fpm.socket
+listen.owner = hab
+listen.group = hab
+listen.mode = 0666
+listen = {{cfg.listen}}:{{cfg.port}}
+
+pm = {{cfg.pm.mode}}
+pm.max_children = {{cfg.pm.max_children}}
+pm.process_idle_timeout = {{cfg.pm.timeout}}
+pm.max_requests = {{cfg.pm.requests}}

--- a/php/config/php-fpm.conf
+++ b/php/config/php-fpm.conf
@@ -9,7 +9,7 @@ listen = {{pkg.svc_var_path}}/php-fpm.socket
 listen.owner = hab
 listen.group = hab
 listen.mode = 0666
-listen = {{cfg.listen}}:{{cfg.port}}
+listen = {{cfg.bind}}:{{cfg.port}}
 
 pm = {{cfg.pm.mode}}
 pm.max_children = {{cfg.pm.max_children}}

--- a/php/default.toml
+++ b/php/default.toml
@@ -1,0 +1,10 @@
+listen = "0.0.0.0"
+port = 9000
+daemonize = "no"
+log_level = "notice"
+
+[pm]
+  mode = "ondemand"
+  max_children = 5
+  timeout = "10s"
+  requests = 500

--- a/php/default.toml
+++ b/php/default.toml
@@ -1,10 +1,11 @@
-listen = "127.0.0.1"
+bind = "127.0.0.1"
 port = 9000
+local_only = true
 daemonize = "no"
 log_level = "notice"
 
 [pm]
-  mode = "ondemand"
-  max_children = 5
-  timeout = "10s"
-  requests = 500
+mode = "ondemand"
+max_children = 5
+timeout = "10s"
+requests = 500

--- a/php/default.toml
+++ b/php/default.toml
@@ -1,4 +1,4 @@
-listen = "0.0.0.0"
+listen = "127.0.0.1"
 port = 9000
 daemonize = "no"
 log_level = "notice"

--- a/php/hooks/init
+++ b/php/hooks/init
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p "{{pkg.svc_var_path}}/log"
+chown -R hab:hab "{{pkg.svc_var_path}}/log"

--- a/php/plan.sh
+++ b/php/plan.sh
@@ -31,7 +31,10 @@ pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_interpreters=(bin/php)
-pkg_exports=([port]=port)
+pkg_exports=(
+  [port]=port
+  [listen]=listen
+)
 pkg_svc_run="php-fpm --fpm-config ${pkg_svc_config_path}/php-fpm.conf -c ${pkg_svc_config_path}"
 
 do_build() {

--- a/php/plan.sh
+++ b/php/plan.sh
@@ -18,6 +18,7 @@ pkg_deps=(
   core/libjpeg-turbo
   core/libpng
   core/openssl
+  core/readline
   core/zlib
 )
 pkg_build_deps=(
@@ -25,12 +26,13 @@ pkg_build_deps=(
   core/gcc
   core/make
   core/re2c
-  core/readline
 )
 pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_interpreters=(bin/php)
+pkg_exports=([port]=port)
+pkg_svc_run="php-fpm --fpm-config ${pkg_svc_config_path}/php-fpm.conf -c ${pkg_svc_config_path}"
 
 do_build() {
   ./configure --prefix="$pkg_prefix" \
@@ -53,15 +55,6 @@ do_build() {
     --with-xmlrpc \
     --with-zlib="$(pkg_path_for zlib)"
   make
-}
-
-do_install() {
-  do_default_install
-
-  # Modify PHP-FPM config so it will be able to run out of the box. To run a real
-  # PHP-FPM application you would want to supply your own config with
-  # --fpm-config <file>.
-  mv "$pkg_prefix/etc/php-fpm.conf.default" "$pkg_prefix/etc/php-fpm.conf"
 }
 
 do_check() {

--- a/php/plan.sh
+++ b/php/plan.sh
@@ -33,7 +33,7 @@ pkg_include_dirs=(include)
 pkg_interpreters=(bin/php)
 pkg_exports=(
   [port]=port
-  [listen]=listen
+  [local_only]=local_only
 )
 pkg_svc_run="php-fpm --fpm-config ${pkg_svc_config_path}/php-fpm.conf -c ${pkg_svc_config_path}"
 


### PR DESCRIPTION
Signed-off-by: Paul Adams <paul@baggerspion.net>

This update to the core/php package allows the user to optionally run php-fpm as a service to be bound to, and not simply as a library for import. This should not break any existing package that is based upon core/php, but open the door to building composite packages for PHP applications that deploy both nginx/apache + php-fpm. This is part of my overall mission to improve core/drupal.