### PR TITLE
[memcached] Update memcached to 1.5.4

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.4.25
+pkg_version=1.5.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=f058437b3c224d321919a9a6bb4e3eedb2312ed718c0caf087ff2f04ab795dda
+pkg_shasum=e0c3cfa89fa4c2ffd8aa45df7825c6d1a2423ac89ab1a7c4f42bb9803f7403d4
 pkg_deps=(core/glibc core/libevent)
 pkg_build_deps=(core/git core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
1.4.25 is about 2 years old. 1.5.4 is the latest

Signed-off-by: Tim Smith <tsmith@chef.io>