### PR TITLE
[less] Update less to 487

### DIFF
--- a/less/plan.sh
+++ b/less/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=less
 pkg_origin=core
-pkg_version=481
+pkg_version=487
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('gplv3+')
 pkg_source=http://www.greenwoodsoftware.com/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=3fa38f2cf5e9e040bb44fffaa6c76a84506e379e47f5a04686ab78102090dda5
+pkg_shasum=f3dc8455cb0b2b66e0c6b816c00197a71bf6d1787078adeee0bcf2aea4b12706
 pkg_deps=(core/glibc core/ncurses core/pcre)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)

--- a/less/plan.sh
+++ b/less/plan.sh
@@ -1,4 +1,5 @@
 pkg_name=less
+pkg_description="a terminal pager program used to view (but not change) the contents of a text file"
 pkg_origin=core
 pkg_version=487
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -11,7 +12,7 @@ pkg_bin_dirs=(bin)
 
 do_build() {
   ./configure \
-    --prefix=$pkg_prefix \
+    --prefix="$pkg_prefix" \
     --sysconfdir=/etc \
     --with-regex=pcre
   make

--- a/less/plan.sh
+++ b/less/plan.sh
@@ -1,5 +1,6 @@
 pkg_name=less
 pkg_description="a terminal pager program used to view (but not change) the contents of a text file"
+pkg_upstream_url="http://www.greenwoodsoftware.com/less/index.html"
 pkg_origin=core
 pkg_version=487
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
* New commands ESC-{ and ESC-} to shift to start/end of displayed lines.

* Make search highlights work correctly when changing caselessness with -i.

* New option -Da in Windows version to enable SGR mode.

* Fix "nothing to search" error when top or bottom line on screen is empty.

* Fix bug when terminal has no "cm" termcap entry.

* Fix incorrect display when entering double-width chars in search string.

* Fix bug in Unicode handling that missed some double width characters.

* Update Unicode database to 9.0.0.

Signed-off-by: Tim Smith <tsmith@chef.io>