### PR TITLE
[cacerts] Fix the license for cacerts

### DIFF
--- a/cacerts/plan.ps1
+++ b/cacerts/plan.ps1
@@ -1,7 +1,7 @@
 $pkg_name="cacerts"
 $pkg_origin="core"
 $pkg_version="_set_from_downloaded_cacerts_file_"
-$pkg_license=@('mplv1.1', 'gplV2', 'lgplv2.1')
+$pkg_license=@('MPL-2.0')
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="http://curl.haxx.se/ca/cacert.pem"
 $pkg_shasum="nopenopebucketofnope"

--- a/cacerts/plan.sh
+++ b/cacerts/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cacerts
 pkg_origin=core
 pkg_version=_set_from_downloaded_cacerts_file_
-pkg_license=('mplv1.1' 'gplV2' 'lgplv2.1')
+pkg_license=('MPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://curl.haxx.se/ca/cacert.pem
 pkg_shasum=nopenopebucketofnope


### PR DESCRIPTION
Per https://curl.haxx.se/docs/caextract.html:

The PEM file is only a converted version of the original one and thus it
is licensed under the same license as the Mozilla source file: MPL 2.0

Signed-off-by: Tim Smith <tsmith@chef.io>