### PR TITLE
[wget] Updates to 1.19.4

### DIFF
--- a/wget/plan.sh
+++ b/wget/plan.sh
@@ -1,15 +1,32 @@
 pkg_name=wget
-pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=1.19.1
+pkg_version=1.19.4
 pkg_license=('GPL-3.0+')
-pkg_description="GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS the most widely-used Internet protocols."
-pkg_upstream_url=https://www.gnu.org/software/wget/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://ftp.gnu.org/gnu/$pkg_distname/${pkg_distname}-${pkg_version}.tar.xz
-pkg_shasum=0c950b9671881222a4d385b013c9604e98a8025d1988529dfca0e93617744cd2
-pkg_deps=(core/glibc core/libidn core/zlib core/openssl core/cacerts)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/grep core/pkg-config)
+pkg_description="GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS the most widely-used Internet protocols."
+pkg_upstream_url="https://www.gnu.org/software/wget/"
+pkg_source="https://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="93fb96b0f48a20ff5be0d9d9d3c4a986b469cb853131f9d5fe4cc9cecbc8b5b5"
+pkg_deps=(
+  core/cacerts
+  core/glibc
+  core/openssl
+  core/pcre
+  core/zlib
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/flex
+  core/gcc
+  core/gettext
+  core/grep
+  core/make
+  core/patch
+  core/perl
+  core/pkg-config
+  core/sed
+)
 pkg_bin_dirs=(bin)
 
 do_prepare() {
@@ -30,8 +47,13 @@ do_install() {
   cat <<EOF >> "$pkg_prefix/etc/wgetrc"
 
 # Default root CA certs location
-ca_certificate=$(pkg_path_for cacerts)/ssl/certs/cacert.pem
+ca_certificate=$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem
 EOF
+}
+
+do_check() {
+  PERL_MM_USE_DEFAULT=1 cpan HTTP:Daemon
+  make check
 }
 
 _wget_common_prepare() {


### PR DESCRIPTION
> Linked to #1151 

@fnichol I've removed the unused `core/libidn` dependency, if not used in other base packages, might not be part of them then.

The wget configure script tries to find `libidn2.so`. I currently have it underway (did the package while creating the `core/gtk(3)` one) and could push it if you need it for the refresh.