### PR TITLE
[dejagnu] Updates to 1.6.1

### DIFF
--- a/dejagnu/plan.sh
+++ b/dejagnu/plan.sh
@@ -1,24 +1,28 @@
 pkg_name=dejagnu
 pkg_origin=core
-pkg_version=1.5.3
-pkg_license=('GPL-2.0')
+pkg_version=1.6.1
+pkg_license=('GPL-3.0-or-later')
 pkg_upstream_url="https://www.gnu.org/software/dejagnu/"
 pkg_description="A framework for testing other programs."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=099b8e364ca1d6248f8e1d32168c4b12677abff4253bbbb4a8ac8cdd321e3f19
-pkg_deps=(core/expect)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_source="https://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="bf5b28bb797e0ace4cfc0766a996339c795d8223bef54158be7887046bc01692"
+pkg_deps=(
+  core/expect
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 
 do_check() {
-  # The test-suite needs to have a non-empty stdin, see:
-  # http://lists.gnu.org/archive/html/bug-dejagnu/2003-06/msg00002.html
-  #
-  # Provide `runtest' with a log name, otherwise it tries to run `whoami`,
-  # which fails when in a chroot.
-  LOGNAME="dejagnu-logger" make check < /dev/zero
+  make check
 }
 
 do_install() {


### PR DESCRIPTION
> Linked to #1151 

Several notes:
* I think the license was wrong for 1.5.3. It's a GPL3+ (as stated in the `COPYING` file of the sources)
* Removed previous check's workarounds, they don't seem to be useful anymore (tests passed)