### PR TITLE
[docker] Bump docker-ce version to 18.01.0

### DIFF
--- a/docker/plan.sh
+++ b/docker/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=docker
 pkg_description="The Docker Engine"
 pkg_origin=core
-pkg_version=17.09.0
+pkg_version=18.01.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2')
-pkg_source=https://download.docker.com/linux/static/stable/x86_64/${pkg_name}-${pkg_version}-ce.tgz
+pkg_source=https://download.docker.com/linux/static/edge/x86_64/${pkg_name}-${pkg_version}-ce.tgz
 pkg_upstream_url=https://docs.docker.com/engine/installation/binaries/
-pkg_shasum=a9e90a73c3cdfbf238f148e1ec0eaff5eb181f92f35bdd938fd7dab18e1c4647
+pkg_shasum=c61ec5b86a721c65371a38e8fbf831e04b58c6e845289282dfa596790ccae8da
 pkg_dirname=docker
 pkg_deps=()
 pkg_build_deps=()


### PR DESCRIPTION
Note: This is tracking the edge distribution. It looks like this has not been promoted to stable as of yet.
Signed-off-by: John Jelinek <jjelinek@containerstore.com>