### PR TITLE
[curl] upgrade to 7.58.0 to address CVE-2018-1000007

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source ../curl/plan.sh
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.51.0
+pkg_version=7.58.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/

--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.54.1
+pkg_version=7.58.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=cd404b808b253512dafec4fed0fb2cc98370d818a7991826c3021984fc27f9d0
+pkg_shasum=cc245bf9a1a42a45df491501d97d5593392a03f7b4f07b952793518d97666115
 pkg_deps=(
   core/cacerts
   core/glibc


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-1000007
https://curl.haxx.se/docs/adv_2018-b3bf.html

Exerpts from curl's write-up:

## VULNERABILITY

curl might leak authentication data to third parties.

When asked to send custom headers in its HTTP requests, curl will send that set of headers first to the host in the initial URL but also, if asked to follow redirects and a 30X HTTP response code is returned, to the host mentioned in URL in the Location: response header value.

Sending the same set of headers to subsequest hosts is in particular a problem for applications that pass on custom Authorization: headers, as this header often contains privacy sensitive information or data that could allow others to impersonate the curl-using client's request.

## THE SOLUTION

In curl version 7.58.0, custom Authorization: headers will be limited the same way other such headers is controlled within curl: they will only be sent to the host used in the original URL unless curl is told
that it is ok to pass on to others using the [CURLOPT_UNRESTRICTED_AUTH](https://curl.haxx.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html) option.

**NOTE:** this solution creates a slight change in behavior. Users who actually want to pass on the header to other hosts now need to give curl that specific permission. You do this with [--location-trusted](https://curl.haxx.se/docs/manpage.html#--location-trusted) with the curl command line tool.