### PR TITLE
Allow postgres to write logs to stderr

### DIFF
--- a/postgresql/config/postgresql.conf
+++ b/postgresql/config/postgresql.conf
@@ -7,7 +7,7 @@ authentication_timeout = 1min
 max_files_per_process = 1000
 max_locks_per_transaction = {{cfg.max_locks_per_transaction}}
 
-logging_collector = on
+logging_collector = {{cfg.logging_collector}}
 log_directory = '{{pkg.svc_var_path}}/pg_log'
 log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
 log_line_prefix = '{{cfg.log_line_prefix}}'

--- a/postgresql/default.toml
+++ b/postgresql/default.toml
@@ -4,6 +4,7 @@ max_connections = 100
 max_locks_per_transaction = 64
 log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d,client=%h %r (%x:%e)'
 log_level = 'ERROR'
+logging_collector = 'on'
 
 [superuser]
 name = 'admin'


### PR DESCRIPTION
This gives us the ability to turn off logging to a file which will cause
postgresql to log to stderr. This behavior is prefered when running in a
container and when running under systemd.

ref: https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html

Signed-off-by: Christopher Webber <cwebber@chef.io>