### PR TITLE
[dep] fix build version, bump version (v0.4.1)

### DIFF
--- a/dep/plan.sh
+++ b/dep/plan.sh
@@ -1,11 +1,28 @@
 pkg_name=dep
 pkg_origin=core
-pkg_version=0.3.0
+pkg_version=0.4.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Go dependency management tool"
 pkg_license="BSD-3-Clause"
-# pkg_source set per the Setup instructions: https://git.io/v5LpG
 pkg_source="https://github.com/golang/dep/cmd/dep"
 pkg_upstream_url="https://github.com/golang/dep"
 pkg_scaffolding="core/scaffolding-go"
 pkg_bin_dirs=(bin)
+
+do_download() {
+  scaffolding_go_download
+
+  pushd "${scaffolding_go_pkg_path}" >/dev/null
+  git reset --hard "v${pkg_version}"
+  popd >/dev/null
+}
+
+do_build() {
+  pushd "${scaffolding_go_pkg_path}/../.." >/dev/null
+  DEP_BUILD_ARCHS="amd64" DEP_BUILD_PLATFORMS="linux" bash -x hack/build-all.bash
+  popd >/dev/null
+}
+
+do_install() {
+  cp "${scaffolding_go_pkg_path}/../../release/dep-linux-amd64" "${pkg_prefix}/bin/dep"
+}


### PR DESCRIPTION
Our current `core/dep` package happens to be version 0.3.0 (I believe!),
however, rebuilding it would give us the latest version.

This change of plan.sh adds an explicit reset to the desired version of
dep to the download function.

Using the upstream-provided build script instead of the scaffolding lets
us build a dep binary that comes with proper version output:

    [18][default:/src:0]# dep version
    dep:
     version     : v0.4.1
     build date  : 2018-02-12
     git hash    : 37d9ea0a
     go version  : go1.9.4
     go compiler : gc
     platform    : linux/amd64

Also, this commit updates the version to the latest release of dep.