### PR TITLE
fix postgresql chown assumptions

### DIFF
--- a/postgresql/config/functions.sh
+++ b/postgresql/config/functions.sh
@@ -67,10 +67,17 @@ bootstrap_replica_via_pg_basebackup() {
 }
 
 ensure_dir_ownership() {
-  echo 'Making sure hab user owns var and data paths'
-  chown -RL hab:hab {{pkg.svc_var_path}}
-  chown -RL hab:hab {{pkg.svc_data_path}}
-  chmod 0700 {{pkg.svc_data_path}}/pgdata
+  paths="{{pkg.svc_var_path}} {{pkg.svc_data_path}}"
+  if [[ $EUID -eq 0 ]]; then
+    # if EUID is root, so we should chown to pkg_svc_user:pkg_svc_group
+    ownership_command="chown -RL {{pkg.svc_user}}:{{pkg.svc_group}} $paths"
+  else
+    # not root, so at best we can only chgrp to the effective user's primary group
+    ownership_command="chgrp -RL $(id -g) $paths"
+  fi
+  echo "Ensuring proper ownership: $ownership_command"
+  $ownership_command  || true
+  chmod 0700 {{pkg.svc_data_path}}/pgdata || true
 }
 
 promote_to_leader() {

--- a/postgresql/config/functions.sh
+++ b/postgresql/config/functions.sh
@@ -76,8 +76,8 @@ ensure_dir_ownership() {
     ownership_command="chgrp -RL $(id -g) $paths"
   fi
   echo "Ensuring proper ownership: $ownership_command"
-  $ownership_command  || true
-  chmod 0700 {{pkg.svc_data_path}}/pgdata || true
+  $ownership_command
+  chmod 0700 {{pkg.svc_data_path}}/pgdata
 }
 
 promote_to_leader() {


### PR DESCRIPTION
![happy-pooh](https://user-images.githubusercontent.com/1991696/36452179-16b792c8-1659-11e8-8f2e-f095cfc0e1a2.gif)


This PR extends the current functionality to allow for non-root services by detecting the effective user id and primary group and accounting for those to ensure proper path ownership.

