### PR TITLE
Jenkins upgrade to 2.89.4 (Security update), and readme update

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,10 +1,9 @@
 # Habitat Package: core/jenkins
-The Habitat Maintainers <humans@habitat.sh>
 
 ## Description
 
-- [www](https://jenkins.io)
-- [Docs](https://jenkins.io/doc/)
+- [Jenkins Website](https://jenkins.io)
+- [Jenkins Documentation](https://jenkins.io/doc/)
 
 > Jenkins is a self-contained, open source automation server which can
 > be used to automate all sorts of tasks such as building, testing,
@@ -13,14 +12,21 @@ The Habitat Maintainers <humans@habitat.sh>
 > the Java Runtime Environment installed.
 
 ## Usage
+
 ### Starting
+
 ```
 hab sup start core/jenkins
 ```
 
+### Initial Password
+
+On first login, you will be asked for an initial admin password. This is
+generated automatically, and output in the supervisor log (check with
+`sup-log`), and is also available on disk at
+`/hab/svc/jenkins/data/secrets/initialAdminPassword`.
+
 ## Notes
 
-- By default, this package is configured for plain HTTP and is
-  intended for usage in secure environment.
-  - On first run, you will be asked for an initial admin password. Run
-  `slog` inside the studio to obtain this.
+By default, this package is configured for plain HTTP and is intended
+for usage in secure environment.

--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.89.2
+pkg_version=2.89.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('mit')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="014f669f32bc6e925e926e260503670b32662f006799b133a031a70a794c8a14"
+pkg_shasum="1d893aa30e49a3130e4f90268044dafb34f7c32b573970f2acca8c2c821f9b53"
 pkg_deps=(core/jre8 core/curl)
 pkg_exports=(
   [port]=jenkins.http.port


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-135762032](https://user-images.githubusercontent.com/24568/36458335-a8df6cbe-16f1-11e8-850b-f73328276bb8.gif)

Addresses security advisory: https://jenkins.io/security/advisory/2018-02-14/