### PR TITLE
Add: Plan for lightweight rpm2cpio

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -851,6 +851,11 @@ plan_path = "rlwrap"
 plan_path = "rngd"
 [rpm]
 plan_path = "rpm"
+[rpm2cpio]
+plan_path = "rpm2cpio"
+paths = [
+  "rpm2cpio/*"
+]
 [rq]
 plan_path = "rq"
 [rsync]

--- a/rpm2cpio/README.md
+++ b/rpm2cpio/README.md
@@ -1,0 +1,17 @@
+# Habitat package: rpm2cpio
+
+## Description
+
+Why does the world need another rpm2cpio?  Because the existing one won't build unless you have half a ton of things that aren't really required for it, since it uses the same library used to extract RPM's.
+
+## Usage
+
+Dumps the contents of an RPM to stdout as a GNU cpio archive
+
+`hab pkg exec core/rpm2cpio rpm2cpio RPM_FILE | cpio`
+
+or
+
+`hab pkg exec core/rpm2cpio rpm2cpio < RPMFILE | cpio`
+
+If required, there is a `core/cpio` package available via `hab pkg install`.

--- a/rpm2cpio/hab-path.patch
+++ b/rpm2cpio/hab-path.patch
@@ -1,0 +1,29 @@
+--- rpm2cpio.orig	2018-03-05 20:06:39.742753467 +0000
++++ rpm2cpio	2018-03-05 20:25:07.926398170 +0000
+@@ -60,22 +60,22 @@
+ 	#	tell($f)-16, $magic, $sections, $bytes, $smagic);
+ 
+ 	if ($smagic == 0x1f8b) {
+-		$filter = "gzip -cd";
++		$filter = "%%gzip%% -cd";
+ 		last;
+ 	}
+ 	# BZh
+ 	if ($smagic == 0x425a and ($smagic2 & 0xff000000) == 0x68000000) {
+-		$filter = "bzip2 -cd";
++		$filter = "%%bzip2%% -cd";
+ 		last;
+ 	}
+ 	# 0xFD, '7zXZ', 0x0
+ 	if ($smagic == 0xfd37 and $smagic2 == 0x7a585a00) {
+-		$filter = "xz -cd";
++		$filter = "%%xz%% -cd";
+ 		last;
+ 	}
+ 	# assume lzma if there is no sig
+ 	if ($magic != 0x8eade801) {
+-		$filter = "lzma -cd";
++		$filter = "%%lzma%% -cd";
+ 		last;
+ 	}
+ 

--- a/rpm2cpio/plan.sh
+++ b/rpm2cpio/plan.sh
@@ -1,0 +1,37 @@
+pkg_name=rpm2cpio
+pkg_origin=core
+pkg_version="1.3"
+pkg_maintainer="Stephen Nelson-Smith <stephen@atalanta-systems.com>"
+pkg_license=("BSD")
+pkg_source="https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/files/rpm2cpio?revision=340851"
+pkg_filename="${pkg_name}-${pkg_version}.pl"
+pkg_shasum="09651201a34771774fc4feaf5b409717e4bc052b82a89f3fc17c0cf578f8e608"
+pkg_description="Simple Perl-based rpm2cpio utility"
+pkg_upstream_url="https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/"
+
+pkg_deps=(core/perl core/gzip core/xz core/bzip2)
+pkg_build_deps=(core/patch core/sed)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  cp ../"${pkg_filename}" rpm2cpio
+  sed -e "s,%%gzip%%,$(pkg_path_for gzip)/bin/gzip,g" \
+    -e "s,%%xz%%,$(pkg_path_for xz)/bin/xz,g" \
+    -e "s,%%bzip2%%,$(pkg_path_for bzip2)/bin/bzip2,g" \
+    -e "s,%%lzma%%,$(pkg_path_for xz)/bin/lzma,g" \
+    "$PLAN_CONTEXT/hab-path.patch" \
+    | patch -p0
+  fix_interpreter rpm2cpio core/perl bin/perl
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  install -v -D -m 0755 rpm2cpio "$pkg_prefix/bin/rpm2cpio"
+}


### PR DESCRIPTION
Although there is an rpm2cpio implementation in busybox-static, there is
value in a very lightweight rpm2cpio implementation that stands alone.

This uses perl and the appropriate decompression libary by inspecting
the file magic number.

You will need cpio on your path to do anything useful with this.

Signed-off-by: Stephen Nelson-Smith <stephen@atalanta-systems.com>