### PR TITLE
[scaffolding-node] Copy over .npmrc if defined by the project

### DIFF
--- a/scaffolding-node/CHANGELOG.md
+++ b/scaffolding-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-node)
 
+## 0.6.13 (03-30-2018)
+
+- Copy over .npmrc if defined by the user project.
+
 ## 0.6.12 (03-29-2018)
 
 - Add support for tsoa module

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -114,7 +114,7 @@ scaffolding_modules_install() {
       if [[ ! -f "$CACHE_PATH/package.json" ]]; then
         cp -av package.json "$CACHE_PATH/"
       fi
-      if [[ ! -f "$CACHE_PATH/.npmrc" ]]; then
+      if [[ -f ".npmrc" ]]; then
         cp -av .npmrc "$CACHE_PATH/"
       fi
       if [[ -f "npm-shrinkwrap.json" ]]; then

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -114,7 +114,7 @@ scaffolding_modules_install() {
       if [[ ! -f "$CACHE_PATH/package.json" ]]; then
         cp -av package.json "$CACHE_PATH/"
       fi
-      if [[ -f ".npmrc" ]]; then
+      if [[ -c ".npmrc" ]]; then
         cp -av .npmrc "$CACHE_PATH/"
       fi
       if [[ -f "npm-shrinkwrap.json" ]]; then

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -114,6 +114,9 @@ scaffolding_modules_install() {
       if [[ ! -f "$CACHE_PATH/package.json" ]]; then
         cp -av package.json "$CACHE_PATH/"
       fi
+      if [[ ! -f "$CACHE_PATH/.npmrc" ]]; then
+        cp -av .npmrc "$CACHE_PATH/"
+      fi
       if [[ -f "npm-shrinkwrap.json" ]]; then
         cp -av npm-shrinkwrap.json "$CACHE_PATH/"
       fi

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.12"
+pkg_version="0.6.13"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
This is referenced later in the build process, and is important when using custom NPM repos.