### PR TITLE
[go] bump 1.9.4 -> 1.10

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.9.4
+pkg_version=1.10
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=0573a8df33168977185aa44173305e5a0450f55213600e94541604b75d46dc06
+pkg_shasum=f3de49289405fda5fd1483a8fe6bd2fa5469e005fd567df64485c4fa000c7f24
 pkg_dirname=go
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)


### PR DESCRIPTION
https://blog.golang.org/go1.10

I'm a bit stuck with testing this for real -- I can't seem to get `build scaffolding-go` to pick up my locally-built go instead of `core/go/1.9.4` 🤔 