### PR TITLE
[mysql] Exposing If bound to Localhost only

### DIFF
--- a/mysql/default.toml
+++ b/mysql/default.toml
@@ -1,5 +1,6 @@
 port = 3306
 bind = "127.0.0.1"
+local_only = true
 language = "english"
 root_password = ""
 app_username = false

--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -49,6 +49,7 @@ pkg_exports=(
   [port]=port
   [password]=app_password
   [username]=app_username
+  [bind]=bind
 )
 
 do_build() {

--- a/mysql/plan.sh
+++ b/mysql/plan.sh
@@ -49,7 +49,7 @@ pkg_exports=(
   [port]=port
   [password]=app_password
   [username]=app_username
-  [bind]=bind
+  [local_only]=local_only
 )
 
 do_build() {


### PR DESCRIPTION
This allows a dependent service to know if the database bound to localhost only. If the
service is started with 127.0.0.1 then another service can not connect to the database from the external IP address.

Signed-off-by: Lance Finfrock <lfinfrock@chef.io>