### PR TITLE
[libidn2] Adds package

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -496,6 +496,8 @@ plan_path = "libice"
 plan_path = "libiconv"
 [libidn]
 plan_path = "libidn"
+[libidn2]
+plan_path = "libidn2"
 [libjpeg-turbo]
 plan_path = "libjpeg-turbo"
 [libksba]

--- a/libidn2/plan.sh
+++ b/libidn2/plan.sh
@@ -1,0 +1,30 @@
+pkg_name=libidn2
+pkg_origin=core
+pkg_version="2.0.4"
+pkg_description="Implementation of IDNA2008, Punycode and TR46 (Internationalized domain names)"
+pkg_upstream_url="https://www.gnu.org/software/libidn/#libidn2"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-2.0' 'LGPL-3.0')
+pkg_source="https://ftp.gnu.org/gnu/libidn/libidn2-2.0.4.tar.gz"
+pkg_shasum=644b6b03b285fb0ace02d241d59483d98bc462729d8bb3608d5cad5532f3d2f0
+pkg_deps=(
+  core/glibc
+  core/libiconv
+  core/libunistring
+)
+pkg_build_deps=(
+  core/diffutils
+  core/gcc
+  core/gettext
+  core/make
+  core/pkg-config
+)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+
+do_check() {
+  make check
+}


### PR DESCRIPTION
This should fix #1218 

As told on slack, I've already changed core/wget to include core/libidn2 as soon as base package refresh is merged and promoted.

Signed-off-by: Romain Sertelon <romain@sertelon.fr>