### PR TITLE
[packer] Update packer to 1.2.1

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,20 @@
+# Packer
+
+[Packer](https://packer.io) is a free and open source tool for creating golden images for multiple platforms from a single source configuration.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+[binary wrapper package](https://www.habitat.sh/docs/best-practices/#binary-wrapper-packages)
+
+## Usage
+
+```bash
+hab pkg install core/packer
+hab pkg binlink core/packer
+
+packer --version
+```

--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,19 +1,18 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=0.12.2
+pkg_version=1.2.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=035d0ea1fe785ab6b673bc2a79399125d4014f29151e106635fa818bb726bebf
+pkg_shasum=dd90f00b69c4d8f88a8d657fff0bb909c77ebb998afd1f77da110bc05e2ed9c3
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=packer.io
-pkg_dirname=$pkg_name
+pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)
 
 do_unpack() {
-  pushd "${HAB_CACHE_SRC_PATH}"
-    unzip "${pkg_filename}" -d "packer"
-  popd
+  cd "${HAB_CACHE_SRC_PATH}" || exit
+  unzip "${pkg_filename}" -d "${pkg_name}-${pkg_version}"
 }
 
 do_build() {
@@ -21,5 +20,5 @@ do_build() {
 }
 
 do_install() {
-  install -v "packer" "$pkg_prefix/bin/"
+  install -D packer "$pkg_prefix/bin/packer"
 }


### PR DESCRIPTION
As part of this change, I updated the `plan.sh` to match what other Hashicorp binary packages look like (e.g. terraform). 

Signed-off-by: Tom Duffield <tom@chef.io>