### PR TITLE
[postgres] updates postgres readme to use the readme template

### DIFF
--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,10 +1,80 @@
 # PostgreSQL
 
+This packages PostgreSQL in a Habitat package that can be run with the Habitat supervisor.
+
 This PostgreSQL plan supports standalone and clustered modes as well as continuous archiving via wal-e integration.
 
-*NOTE:* The current version of this plan is an intterim version of the package that cannot be considered production ready. It can be used however archiving (by default) copies data in `{{pkg.svc_path}}/archive` which cannot be guaranteed as persisted between failures. That being said, the archive location is tunable in the default.toml.
+*NOTE:* The current version of this plan is an interim version of the package that cannot be considered production ready. It can be used however archiving (by default) copies data in `{{pkg.svc_path}}/archive` which cannot be guaranteed as persisted between failures. That being said, the archive location is tunable in the default.toml.
 
-## Standalone
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+Service
+
+## Usage
+
+You can use this passage by adding core/postgresql to your package dependencies in your plan file:
+
+```
+pkg_deps=(
+  core/postgresql # for psql in hooks/init
+)
+```
+
+Or you can start the service with:
+
+```
+$ hab start core/postgresql
+```
+
+And bind another Habitat service to it - see "Binding" below for more details.
+
+## Bindings
+
+Consuming services can bind to PostgreSQL via:
+
+```
+hab start <origin>/<app> --bind database:postgresql.default --peer <pg-host>
+```
+
+Superuser access is exposed to consumers when binding and we advise that required databases, schemas and roles be created and migrations get run in the init hook of the consuming service. The created roles (with restricted access) should then be exposed to the application code that will get run.
+
+In the template of the consuming service, there is currently a difference between the binding syntax for binding to the leader in a clustered topology vs binding to any member.  A [future enhancement](https://github.com/habitat-sh/habitat/issues/4127) may improve upon that, but for now something like this could work if used in an interpreted script file:
+
+```
+# Use the eachAlive and @first helpers to bind to the oldest alive member of the bound service group
+#   - members are processed in the chronological order of when they joined the ring
+# If a later member comes along that is the leader of a cluster topology, override the environment variable definitions with that
+#   - if not, the second section is omitted
+{{~ #if bind.database}}
+  {{~ #eachAlive bind.database.members as |member|}}
+    {{~ #if @first}}
+# First alive member
+PGHOST="{{member.sys.ip}}"
+PGPORT="{{member.cfg.port}}"
+PGUSER="{{member.cfg.superuser_name}}"
+PGPASSWORD="{{member.cfg.superuser_password}}"
+    {{~ /if}}
+
+    {{~ #if member.leader}}
+# Leader node override
+PGHOST="{{member.sys.ip}}"
+PGPORT="{{member.cfg.port}}"
+PGUSER="{{member.cfg.superuser_name}}"
+PGPASSWORD="{{member.cfg.superuser_password}}"
+    {{~ /if}}
+  {{~ /eachAlive}}
+{{~ /if}}
+```
+
+However if you're using more of a rigid configuration file syntax then you still need to know and choose in advance whether or not you're expecting to connect to a leader topology or not.
+
+## Topologies
+
+### Standalone
 
 To run a standalone PostgreSQL instance simply run
 ```
@@ -16,7 +86,7 @@ docker run habitat/postgresql
 ```
 if you want to bring up the pre-exported docker image.
 
-## Cluster
+### Leader/Follower
 
 This plan supports running clustered PostgreSQL by utilizing Habitat's native leader election.
 
@@ -62,48 +132,17 @@ EOF
 docker-compose up
 ```
 
-## Binding
+## Update Strategies
 
-Consuming services can bind to PostgreSQL via:
+For more information on update strategies, see [this documentation](https://www.habitat.sh/docs/using-habitat/#update-strategy)
 
-```
-hab start <origin>/<app> --bind database:postgresql.default --peer <pg-host>
-```
+If you are running a standalone PostgreSQL instance and want to use an update strategy, you should use either "none" (which is the default update strategy) or "all-at-once".
 
-Superuser access is exposed to consumers when binding and we advise that required databases, schemas and roles be created and migrations get run in the init hook of the consuming service. The created roles (with restricted access) should then be exposed to the application code that will get run.
+If you are running a PostgreSQL cluster, you will likely want to use the Rolling strategy.
 
-In the template of the consuming service, there is currently a difference between the binding syntax for binding to the leader in a clustered topology vs binding to any member.  A [future enhancement](https://github.com/habitat-sh/habitat/issues/4127) may improve upon that, but for now something like this could work if used in an interpreted script file:
+## Notes
 
-```
-# Use the eachAlive and @first helpers to bind to the oldest alive member of the bound service group
-#   - members are processed in the chronological order of when they joined the ring
-# If a later member comes along that is the leader of a cluster topology, override the environment variable definitions with that
-#   - if not, the second section is omitted
-{{~ #if bind.database}}
-  {{~ #eachAlive bind.database.members as |member|}}
-    {{~ #if @first}}
-# First alive member
-PGHOST="{{member.sys.ip}}"
-PGPORT="{{member.cfg.port}}"
-PGUSER="{{member.cfg.superuser_name}}"
-PGPASSWORD="{{member.cfg.superuser_password}}"
-    {{~ /if}}
-
-    {{~ #if member.leader}}
-# Leader node override
-PGHOST="{{member.sys.ip}}"
-PGPORT="{{member.cfg.port}}"
-PGUSER="{{member.cfg.superuser_name}}"
-PGPASSWORD="{{member.cfg.superuser_password}}"
-    {{~ /if}}
-  {{~ /eachAlive}}
-{{~ /if}}
-```
-
-However if you're using more of a rigid configuration file syntax then you still need to know and choose in advance whether or not you're expecting to connect to a leader topology or not.
-
-
-# TODO (Potential improvements to this plan):
+### TODO (Potential improvements to this plan):
 - Upgrade logic (detect if the database engine is newer than the data on disk and perform pg_upgrade)
 - Full cluster restart logic (elect the previous leader)
   - add a `suitability` hook based on the existence of a `recovery.conf` file

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -140,6 +140,16 @@ If you are running a standalone PostgreSQL instance and want to use an update st
 
 If you are running a PostgreSQL cluster, you will likely want to use the Rolling strategy.
 
+## Scaling
+
+This plan can be run in a cluster, see the above section on "Leader/Follower" for more information.
+
+This plan has not been tested in a highly available architecture.
+
+## Monitoring
+
+If you wish to monitor this service directly, you can use [Datadog](https://www.datadoghq.com/) (there is also a [datadog agent plan](./dd-agent) in this repo), [Sumologic](https://www.sumologic.com/)(there is also a [sumlogic plan](./sumologic)), and other monitoring services.
+
 ## Notes
 
 ### TODO (Potential improvements to this plan):

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,10 +1,8 @@
 # PostgreSQL
 
-This packages PostgreSQL in a Habitat package that can be run with the Habitat supervisor.
+This packages PostgreSQL in a Habitat package that can be run with the Habitat Supervisor.
 
 This PostgreSQL plan supports standalone and clustered modes as well as continuous archiving via wal-e integration.
-
-*NOTE:* The current version of this plan is an interim version of the package that cannot be considered production ready. It can be used however archiving (by default) copies data in `{{pkg.svc_path}}/archive` which cannot be guaranteed as persisted between failures. That being said, the archive location is tunable in the default.toml.
 
 ## Maintainers
 
@@ -152,7 +150,9 @@ If you wish to monitor this service directly, you can use [Datadog](https://www.
 
 ## Notes
 
-### TODO (Potential improvements to this plan):
+# TODO (Potential improvements to this plan):
 - Upgrade logic (detect if the database engine is newer than the data on disk and perform pg_upgrade)
 - Full cluster restart logic (elect the previous leader)
   - add a `suitability` hook based on the existence of a `recovery.conf` file
+- Test for various high-availability and other operational optimizations (high writes, high reads)
+  - add configuration to the plan for people who wish to use those


### PR DESCRIPTION
Updates the PostgreSQL README to use the [README template](https://github.com/habitat-sh/core-plans/blob/master/README_TEMPLATE_FOR_PLANS.md).

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>