### PR TITLE
Make `sed -i` work on both linux and Mac OS

### DIFF
--- a/R/plan.sh
+++ b/R/plan.sh
@@ -43,7 +43,7 @@ pkg_include_dirs=(lib64/R/include)
 pkg_lib_dirs=(lib64/R/lib)
 
 do_build() {
-    sed -i '/#include.*<cairo-xlib.h>/d' ./configure
+    sed -i'' '/#include.*<cairo-xlib.h>/d' ./configure
     ./configure --prefix="${pkg_prefix}" \
 		 --with-x=no \
                 --disable-java \

--- a/acl/plan.sh
+++ b/acl/plan.sh
@@ -15,7 +15,7 @@ do_prepare() {
   # Fix a bug that causes `getfacl -e` to segfault on overly long group name.
   #
   # Thanks to: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/acl.html
-  sed -i -e "/TABS-1;/a if (x > (TABS-1)) x = (TABS-1);" \
+  sed -i'' -e "/TABS-1;/a if (x > (TABS-1)) x = (TABS-1);" \
     libacl/__acl_to_any_text.c
 }
 

--- a/binutils/plan.sh
+++ b/binutils/plan.sh
@@ -64,7 +64,7 @@ do_prepare() {
   # Use symlinks instead of hard links to save space (otherwise `strip(1)`
   # needs to process each hard link seperately)
   for f in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
-    sed -i "$f" -e 's|ln |ln -s |'
+    sed -i'' "$f" -e 's|ln |ln -s |'
   done
 }
 

--- a/bzip2/plan.sh
+++ b/bzip2/plan.sh
@@ -15,10 +15,10 @@ pkg_lib_dirs=(lib)
 
 _common_prepare() {
   # Makes the symbolic links in installation relative vs. absolute
-  sed -i 's@\(ln -s -f \)$(PREFIX)/bin/@\1@' Makefile
+  sed -i'' 's@\(ln -s -f \)$(PREFIX)/bin/@\1@' Makefile
 
   # Ensure that the man pages are installed under share/man
-  sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
+  sed -i'' "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
 }
 
 do_prepare() {

--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -28,7 +28,7 @@ pkg_lib_dirs=(lib)
 
 do_prepare() {
   # Patch the zsh-generating program to use our perl at build time
-  sed -i "s,/usr/bin/perl,$(pkg_path_for perl)/bin/perl,g" scripts/zsh.pl
+  sed -i'' "s,/usr/bin/perl,$(pkg_path_for perl)/bin/perl,g" scripts/zsh.pl
 }
 
 do_build() {

--- a/diffutils/plan.sh
+++ b/diffutils/plan.sh
@@ -14,7 +14,7 @@ do_check() {
   # FAIL: test-update-copyright.sh
   #
   # Thanks to: http://permalink.gmane.org/gmane.linux.lfs.devel/16285
-  sed -i 's/copyright{/copyright\\{/' build-aux/update-copyright
+  sed -i'' 's/copyright{/copyright\\{/' build-aux/update-copyright
 
   # Add ./src to PATH so that the test suite can use the just-build `cmp`
   # program. Seems pretty meta to me...

--- a/eudev/plan.sh
+++ b/eudev/plan.sh
@@ -17,7 +17,7 @@ pkg_upstream_url="https://wiki.gentoo.org/wiki/Project:Eudev"
 do_prepare() {
   # http://www.linuxfromscratch.org/lfs/view/stable/chapter06/eudev.html
   sed -r -i 's|/usr(/bin/test)|\1|' test/udev-test.pl
-  sed -i '/keyboard_lookup_key/d' src/udev/udev-builtin-keyboard.c
+  sed -i'' '/keyboard_lookup_key/d' src/udev/udev-builtin-keyboard.c
   cat > config.cache << "EOF"
 HAVE_BLKID=1
 BLKID_LIBS="-lblkid"

--- a/expect/plan.sh
+++ b/expect/plan.sh
@@ -18,7 +18,7 @@ do_prepare() {
   do_default_prepare
 
   # Make the path to `stty` absolute from `coreutils`
-  sed -i "s,/bin/stty,$(pkg_path_for coreutils)/bin/stty,g" configure
+  sed -i'' "s,/bin/stty,$(pkg_path_for coreutils)/bin/stty,g" configure
 }
 
 do_build() {

--- a/gcc/plan.sh
+++ b/gcc/plan.sh
@@ -65,7 +65,7 @@ do_prepare() {
   # Patch the configure script so it finds glibc headers
   #
   # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/builder.sh
-  sed -i \
+  sed -i'' \
     -e "s,glibc_header_dir=/usr/include,glibc_header_dir=${headers}," \
     gcc/configure
 
@@ -77,7 +77,7 @@ do_prepare() {
   for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h; do
     grep -q LIBC_DYNAMIC_LINKER "$header" || continue
     build_line "  Fixing $header"
-    sed -i "$header" \
+    sed -i'' "$header" \
       -e 's|define[[:blank:]]*\([UCG]\+\)LIBC_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define \1LIBC_DYNAMIC_LINKER\2 "'"${glibc}"'\3"|g' \
       -e 's|/lib64/ld-linux-|/lib/ld-linux-|g'
   done
@@ -85,7 +85,7 @@ do_prepare() {
   # Installs x86_64 libraries under `lib/` vs the default `lib64/`
   #
   # Thanks to: https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/gcc
-  sed -i '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
+  sed -i'' '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
 
   # Build up the build cflags that will be set for multiple environment
   # variables in the `make` command

--- a/glibc/plan.sh
+++ b/glibc/plan.sh
@@ -74,7 +74,7 @@ do_prepare() {
   patch -p1 < "$PLAN_CONTEXT/glibc-2.22-upstream_fixes-1.patch"
 
   # Adjust `scripts/test-installation.pl` to use our new dynamic linker
-  sed -i "s|libs -o|libs -L${pkg_prefix}/lib -Wl,-dynamic-linker=${dynamic_linker} -o|" \
+  sed -i'' "s|libs -o|libs -L${pkg_prefix}/lib -Wl,-dynamic-linker=${dynamic_linker} -o|" \
     scripts/test-installation.pl
 }
 

--- a/go14/plan.sh
+++ b/go14/plan.sh
@@ -40,7 +40,7 @@ do_prepare() {
   # Set the dynamic linker from `glibc`
   dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   find src/cmd -name asm.c -exec \
-    sed -i "s,/lib/ld-linux.*\.so\.[0-9],$dynamic_linker," {} \;
+    sed -i'' "s,/lib/ld-linux.*\.so\.[0-9],$dynamic_linker," {} \;
 
   # Use the protocols database from `iana-etc`
   sed -e "s,/etc/protocols,$(pkg_path_for iana-etc)/etc/protocols," \

--- a/grub/plan.sh
+++ b/grub/plan.sh
@@ -38,7 +38,7 @@ do_setup() {
 }
 
 do_build() {
-  sed -i "s/#! \/usr\/bin\/env bash/#!\/bin\/bash/" ./autogen.sh
+  sed -i'' "s/#! \/usr\/bin\/env bash/#!\/bin\/bash/" ./autogen.sh
 
   ./linguas.sh
   ./autogen.sh

--- a/gzip/plan.sh
+++ b/gzip/plan.sh
@@ -13,7 +13,7 @@ do_prepare() {
   do_default_prepare
 
   build_line "Patching 'zless' with the full path to 'less'"
-  sed -i \
+  sed -i'' \
     -e "s,less -V,$(pkg_path_for less)/bin/less -V,g" \
     -e "s,exec less,exec $(pkg_path_for less)/bin/less,g" \
     zless.in
@@ -32,7 +32,7 @@ do_build() {
 do_check() {
   # Skip help-version test for running zmore which requires `more` on PATH. We
   # don't yet have one built and will assume that it works well enough.
-  sed -i -e "s,zmore,,g" tests/Makefile
+  sed -i'' -e "s,zmore,,g" tests/Makefile
 
   make check
 }

--- a/iproute2/plan.sh
+++ b/iproute2/plan.sh
@@ -22,11 +22,11 @@ pkg_deps=(core/glibc)
 
 do_prepare() {
   # http://www.linuxfromscratch.org/lfs/view/development/chapter06/iproute2.html
-  sed -i /ARPD/d Makefile
-  sed -i 's/arpd.8//' man/man8/Makefile
+  sed -i'' /ARPD/d Makefile
+  sed -i'' 's/arpd.8//' man/man8/Makefile
   rm doc/arpd.sgml
 
-  sed -i 's/m_ipt.o//' tc/Makefile
+  sed -i'' 's/m_ipt.o//' tc/Makefile
 }
 
 do_build() {

--- a/jffi/plan.sh
+++ b/jffi/plan.sh
@@ -21,7 +21,7 @@ pkg_build_deps=(
 
 do_prepare() {
   build_line "replacing /usr/bin/file with $(pkg_path_for core/file)/bin/file"
-  sed -i "s,/usr/bin/file,$(pkg_path_for core/file)/bin/file,g" "jni/libffi/configure"
+  sed -i'' "s,/usr/bin/file,$(pkg_path_for core/file)/bin/file,g" "jni/libffi/configure"
 
   export USE_SYSTEM_LIBFFI=1
   export JAVA_HOME

--- a/leiningen/plan.sh
+++ b/leiningen/plan.sh
@@ -36,7 +36,7 @@ do_build() {
 do_install() {
   mkdir -p "${pkg_prefix}/share/java"
   cd "${HAB_CACHE_SRC_PATH}" || exit
-  sed -i "s|^LEIN_JAR=.*|LEIN_JAR=${pkg_prefix}/share/java/${pkg_filename%.*}.jar|" lein
+  sed -i'' "s|^LEIN_JAR=.*|LEIN_JAR=${pkg_prefix}/share/java/${pkg_filename%.*}.jar|" lein
   chmod +x lein
   install -D lein "${pkg_prefix}/bin/lein"
   install -D "${pkg_filename%.*}.jar" "${pkg_prefix}/share/java/${pkg_filename%.*}.jar"

--- a/libcap/plan.sh
+++ b/libcap/plan.sh
@@ -15,7 +15,7 @@ do_prepare() {
   do_default_prepare
 
   # Install binaries under `bin/` vs. `sbin/`
-  sed -i "/SBINDIR/s#sbin#bin#" Make.Rules
+  sed -i'' "/SBINDIR/s#sbin#bin#" Make.Rules
 }
 
 do_build() {

--- a/linux/plan.sh
+++ b/linux/plan.sh
@@ -44,13 +44,13 @@ do_build() {
   #  builds that have CONFIG_ options set that require building scripts/ or tools/
 
   # Let the inline test build (CONFIG_STACK_VALIDATION) know where libelf lives
-  sed -i "932s|-xc|$LDFLAGS -xc|" Makefile
+  sed -i'' "932s|-xc|$LDFLAGS -xc|" Makefile
 
   # Override the defaults for building scripts and tools.
   #  scripts/sign-file and tools/objtool need openssl and elfutils.
-  sed -i "306s|$| $LDFLAGS|" Makefile
-  sed -i "98s|\$(hostc_flags)|\$(hostc_flags) \$(HOSTLDFLAGS)|" scripts/Makefile.host
-  sed -i "55s|\$(LDFLAGS)|\$(LDFLAGS) \$(HOSTLDFLAGS)|" tools/objtool/Makefile
+  sed -i'' "306s|$| $LDFLAGS|" Makefile
+  sed -i'' "98s|\$(hostc_flags)|\$(hostc_flags) \$(HOSTLDFLAGS)|" scripts/Makefile.host
+  sed -i'' "55s|\$(LDFLAGS)|\$(LDFLAGS) \$(HOSTLDFLAGS)|" tools/objtool/Makefile
 
   HOST_EXTRACFLAGS="${CFLAGS}" make -j "$(nproc)" bzImage modules
 

--- a/m4/plan.sh
+++ b/m4/plan.sh
@@ -26,7 +26,7 @@ do_check() {
   # FAIL: test-update-copyright.sh
   #
   # Thanks to: http://permalink.gmane.org/gmane.linux.lfs.devel/16285
-  sed -i 's/copyright{/copyright\\{/' build-aux/update-copyright
+  sed -i'' 's/copyright{/copyright\\{/' build-aux/update-copyright
 
   make check
 }

--- a/man-db/plan.sh
+++ b/man-db/plan.sh
@@ -63,7 +63,7 @@ do_prepare() {
   #
   # The file that gets generated here gets written to
   # $pkg_prefix/etc/man_db.conf.
-  sed -i -e "s#/var/#$pkg_svc_var_path/#g" "$CACHE_PATH/src/man_db.conf.in"
+  sed -i'' -e "s#/var/#$pkg_svc_var_path/#g" "$CACHE_PATH/src/man_db.conf.in"
 }
 
 do_check() {
@@ -75,5 +75,5 @@ do_install() {
 
   # Removing reference to non-existent user(--disable-setuid), inspired from Linux From Scratch:
   # http://www.linuxfromscratch.org/lfs/view/development/chapter06/man-db.html
-  sed -i "s:man root:root root:g" "${pkg_svc_config_path}/tmpfiles.d/man-db.conf"
+  sed -i'' "s:man root:root root:g" "${pkg_svc_config_path}/tmpfiles.d/man-db.conf"
 }

--- a/mariadb/plan.sh
+++ b/mariadb/plan.sh
@@ -22,8 +22,8 @@ do_prepare() {
       rm CMakeCache.txt
     fi
 
-    sed -i 's/^.*abi_check.*$/#/' CMakeLists.txt
-    sed -i "s@data/test@\${INSTALL_MYSQLTESTDIR}@g" sql/CMakeLists.txt
+    sed -i'' 's/^.*abi_check.*$/#/' CMakeLists.txt
+    sed -i'' "s@data/test@\${INSTALL_MYSQLTESTDIR}@g" sql/CMakeLists.txt
     export CXXFLAGS="$CFLAGS"
 }
 

--- a/mawk/plan.sh
+++ b/mawk/plan.sh
@@ -17,7 +17,7 @@ pkg_bin_dirs=(bin)
 
 do_check() {
   for file in test/mawktest test/fpe_test; do
-    sed -i "s|PATH=/bin:/usr/bin|PATH=/bin:/usr/bin:$PATH|g" $file
+    sed -i'' "s|PATH=/bin:/usr/bin|PATH=/bin:/usr/bin:$PATH|g" $file
   done
   make check
 }

--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -50,7 +50,7 @@ do_prepare() {
 
     # because scons dislikes saving our variables, we will save our
     # variables within the construct ourselves
-    sed -i "840s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
+    sed -i'' "840s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
 }
 
 do_build() {

--- a/mosquitto/plan.sh
+++ b/mosquitto/plan.sh
@@ -25,7 +25,7 @@ pkg_lib_dirs=(lib)
 pkg_svc_run="mosquitto -c $pkg_svc_config_path/mosquitto.conf"
 
 do_prepare() {
-    sed -i "s#prefix=/usr/local#prefix=#" config.mk
+    sed -i'' "s#prefix=/usr/local#prefix=#" config.mk
     export DESTDIR="${pkg_prefix}"
 }
 

--- a/mssql/plan.sh
+++ b/mssql/plan.sh
@@ -45,7 +45,7 @@ do_install() {
   cp -a opt/mssql/lib "$pkg_prefix"
 
   PYTHONPATH="$(pkg_path_for core/python2)"
-  sed -i "s#/usr/bin/python#$PYTHONPATH/bin/python#" "$pkg_prefix/lib/mssql-conf/mssql-conf.py"
+  sed -i'' "s#/usr/bin/python#$PYTHONPATH/bin/python#" "$pkg_prefix/lib/mssql-conf/mssql-conf.py"
 
   find "$pkg_prefix/bin" -type f -name '*' \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "$LD_RUN_PATH" {} \;

--- a/musl/plan.sh
+++ b/musl/plan.sh
@@ -23,7 +23,7 @@ pkg_lib_dirs=(lib)
 do_prepare() {
   stack_size="2097152"
   build_line "Setting default stack size to '$stack_size' from default of '81920'"
-  sed -i "s/#define DEFAULT_STACK_SIZE .*/#define DEFAULT_STACK_SIZE $stack_size/" \
+  sed -i'' "s/#define DEFAULT_STACK_SIZE .*/#define DEFAULT_STACK_SIZE $stack_size/" \
     src/internal/pthread_impl.h
 }
 

--- a/percona-xtrabackup/plan.sh
+++ b/percona-xtrabackup/plan.sh
@@ -19,7 +19,7 @@ do_prepare() {
   if [ -f CMakeCache.txt ]; then
     rm CMakeCache.txt
   fi
-  sed -i 's/^.*abi_check.*$/#/' CMakeLists.txt
+  sed -i'' 's/^.*abi_check.*$/#/' CMakeLists.txt
   export CXXFLAGS="$CFLAGS"
 }
 

--- a/perl/plan.sh
+++ b/perl/plan.sh
@@ -24,7 +24,7 @@ do_prepare() {
 
   #  Make Cwd work with the `pwd` command from `coreutils` (we cannot rely
   #  on `/bin/pwd` exisiting in an environment)
-  sed -i "s,'/bin/pwd','$(pkg_path_for coreutils)/bin/pwd',g" \
+  sed -i'' "s,'/bin/pwd','$(pkg_path_for coreutils)/bin/pwd',g" \
     dist/PathTools/Cwd.pm
 
   # Build the `-Dlocincpth` configure flag, which is collection of all

--- a/php5/plan.sh
+++ b/php5/plan.sh
@@ -53,7 +53,7 @@ do_install() {
   # --fpm-config <file>.
   mv "$pkg_prefix/etc/php-fpm.conf.default" "$pkg_prefix/etc/php-fpm.conf"
   # Run as the hab user by default, as it's more likely to exist than nobody.
-  sed -i "s/nobody/hab/g" "$pkg_prefix/etc/php-fpm.conf"
+  sed -i'' "s/nobody/hab/g" "$pkg_prefix/etc/php-fpm.conf"
 }
 
 do_check() {

--- a/python/plan.sh
+++ b/python/plan.sh
@@ -36,7 +36,7 @@ pkg_interpreters=(bin/python bin/python3 bin/python3.5)
 
 do_prepare() {
   sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
-  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+  sed -i'' -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
 }
 
 do_build() {

--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -37,12 +37,12 @@ pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 
 do_prepare() {
   sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
-  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+  sed -i'' -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
 
   # Allow embedded sqlite to load extensions
   # Uncertain if this is absolutely required, leaving commented for now.
   # https://docs.python.org/2/library/sqlite3.html#f1
-  # sed -i 's/sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))//g' setup.py
+  # sed -i'' 's/sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))//g' setup.py
 }
 
 do_build() {

--- a/repo/plan.sh
+++ b/repo/plan.sh
@@ -50,5 +50,5 @@ do_install() {
 
   # fix shebang in `repo`
   PYTHONPATH="$(pkg_path_for core/python2)"
-  sed -i "s#/usr/bin/env python#$PYTHONPATH/bin/python#" "$pkg_prefix"/bin/"$pkg_name"
+  sed -i'' "s#/usr/bin/env python#$PYTHONPATH/bin/python#" "$pkg_prefix"/bin/"$pkg_name"
 }

--- a/shadow/plan.sh
+++ b/shadow/plan.sh
@@ -22,15 +22,15 @@ do_prepare() {
   #
   # Thanks to: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/shadow.html
   # shellcheck disable=SC2016
-  sed -i 's/groups$(EXEEXT) //' src/Makefile.in
-  find man -name Makefile.in -exec sed -i 's/groups\.1 / /' {} \;
+  sed -i'' 's/groups$(EXEEXT) //' src/Makefile.in
+  find man -name Makefile.in -exec sed -i'' 's/groups\.1 / /' {} \;
 
   # Instead of using the default crypt method, use the more secure SHA-512
   # method of password encryption, which also allows passwords longer than 8
   # characters.
   #
   # Thanks to: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/shadow.html
-  sed -i -e 's@#ENCRYPT_METHOD DES@ENCRYPT_METHOD SHA512@' etc/login.defs
+  sed -i'' -e 's@#ENCRYPT_METHOD DES@ENCRYPT_METHOD SHA512@' etc/login.defs
 }
 
 do_build() {

--- a/sqitch/plan.sh
+++ b/sqitch/plan.sh
@@ -33,7 +33,7 @@ do_install() {
   ./Build install
 
   for file in ${pkg_prefix}/bin/*; do
-    sed -i "1 s,.*,& -I${pkg_prefix}/lib/perl5," $file
+    sed -i'' "1 s,.*,& -I${pkg_prefix}/lib/perl5," $file
   done
 }
 

--- a/tree/plan.sh
+++ b/tree/plan.sh
@@ -16,6 +16,6 @@ do_build() {
 }
 
 do_install() {
-  sed -i "s#prefix = /usr#prefix = ${pkg_prefix}#" Makefile
+  sed -i'' "s#prefix = /usr#prefix = ${pkg_prefix}#" Makefile
   make install
 }

--- a/virtualenv/plan.sh
+++ b/virtualenv/plan.sh
@@ -22,5 +22,5 @@ do_install() {
   python setup.py install --prefix="$pkg_prefix"
 
   # Modify the command to have the correct PYTHONPATH
-  sed -i "2iimport sys; sys.path.append(\"$PYTHONPATH\")" "$pkg_prefix/bin/virtualenv"
+  sed -i'' "2iimport sys; sys.path.append(\"$PYTHONPATH\")" "$pkg_prefix/bin/virtualenv"
 }


### PR DESCRIPTION
Because the Mac OS version of sed's -i option requires an argument but linux's
does not, the way to get inline ovewrite behavior on both is to supply a zero-
length argument with no spaces after the -i.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>