### PR TITLE
[nginx] bump: 1.12.2 -> 1.13.10

### DIFF
--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.12.2
+pkg_version=1.13.10
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd')
 pkg_source=https://nginx.org/download/nginx-${pkg_version}.tar.gz
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416
+pkg_shasum=336182104d90be3c40c874f7f06f87dbb357da1dc74ea573ad081a0f29a94885
 pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Changelog is here: http://nginx.org/en/CHANGES

Quite a bit of stuff. Verified that the built binary doesn't go up in smoke
like this:

    [11][default:/src:0]# /hab/pkgs/srenatus/nginx/1.13.10/20180328103646/bin/nginx -V
    nginx version: nginx/1.13.10
    built with OpenSSL 1.0.2l  25 May 2017
    TLS SNI support enabled
    configure arguments: --prefix=/hab/pkgs/srenatus/nginx/1.13.10/20180328103646 --conf-path=/hab/svc/nginx/config/nginx.conf --sbin-path=/hab/pkgs/srenatus/nginx/1.13.10/20180328103646/bin/nginx --pid-path=/hab/svc/nginx/var/nginx.pid --lock-path=/hab/svc/nginx/var/nginx.lock --user=hab --group=hab --http-log-path=/dev/stdout --error-log-path=stderr --http-client-body-temp-path=/hab/svc/nginx/var/client-body --http-proxy-temp-path=/hab/svc/nginx/var/proxy --http-fastcgi-temp-path=/hab/svc/nginx/var/fastcgi --http-scgi-temp-path=/hab/svc/nginx/var/scgi --http-uwsgi-temp-path=/hab/svc/nginx/var/uwsgi --with-ipv6 --with-pcre --with-pcre-jit --with-file-aio --with-stream=dynamic --with-mail=dynamic --with-http_gunzip_module --with-http_gzip_static_module --with-http_realip_module --with-http_v2_module --with-http_ssl_module --with-http_stub_status_module --with-http_addition_module --with-http_degradation_module --with-http_flv_module --with-http_mp4_module --with-http_secure_link_module --with-http_sub_module --with-http_slice_module --with-cc-opt='-I/hab/pkgs/core/glibc/2.22/20170513201042/include -I/hab/pkgs/core/libedit/3.1.20150325/20170514030323/include -I/hab/pkgs/core/ncurses/6.0/20170513213009/include -I/hab/pkgs/core/zlib/1.2.8/20170513201911/include -I/hab/pkgs/core/bzip2/1.0.6/20170513212938/include -I/hab/pkgs/core/openssl/1.0.2l/20171014213633/include -I/hab/pkgs/core/pcre/8.38/20170513213423/include -I/hab/pkgs/core/gcc/5.2.0/20170513202244/include -I/hab/pkgs/core/make/4.2.1/20170513214620/include' --with-ld-opt='-L/hab/pkgs/core/glibc/2.22/20170513201042/lib -L/hab/pkgs/core/libedit/3.1.20150325/20170514030323/lib -L/hab/pkgs/core/ncurses/6.0/20170513213009/lib -L/hab/pkgs/core/zlib/1.2.8/20170513201911/lib -L/hab/pkgs/core/bzip2/1.0.6/20170513212938/lib -L/hab/pkgs/core/openssl/1.0.2l/20171014213633/lib -L/hab/pkgs/core/pcre/8.38/20170513213423/lib -L/hab/pkgs/core/gcc/5.2.0/20170513202244/lib'