### PR TITLE
Add Tasha to core-plans maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,6 +30,7 @@ To become a maintainer, open a pull request to this list.
 * [Josh Brand](https://github.com/joshbrand)
 * [Christopher P. Maher](https://github.com/defilan)
 * [Romain Sertelon](https://github.com/rsertelon)
+* [Tasha Drew](https://github.com/tashimi)
 
 ## Alumni
 


### PR DESCRIPTION
Signed-off-by: Tasha Drew <tasha.drew@gmail.com>