### PR TITLE
[nghttp2] bump and add README

### DIFF
--- a/nghttp2/README.md
+++ b/nghttp2/README.md
@@ -1,0 +1,29 @@
+# nghttp2
+
+This package provides the nghttp2 library and headers.
+
+[nghttp2](http://nghttp2.org) is a C library for HTTP/2 (for example used by
+curl).
+
+The applications included in the nghttp2 sources, nghttpx, nghttpd, nghttp, and
+h2load, are *not included* in the habitat package.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+[binary wrapper package](https://www.habitat.sh/docs/best-practices/#binary-wrapper-packages)
+
+## Usage
+
+To use this library in your application, add `core/nghttp2` to its `pkg_deps`,
+and pass its location to your application's `./configure` call, for example:
+
+```
+do_build() {
+  ./configure --with-nghttp2="$(pkg_path_for nghttp2)"
+  make
+}
+```

--- a/nghttp2/plan.sh
+++ b/nghttp2/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nghttp2
 pkg_origin=core
-pkg_version=1.24.0
+pkg_version=1.31.0
 pkg_description="nghttp2 is an open source HTTP/2 C Library."
 pkg_upstream_url=https://nghttp2.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source=https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=5058da99c94764ff39f4a7046b9c8f0b6bafa10ec2fc096945a5d9d693654840
+pkg_shasum=6a2d02c441cf8d4279aea3c98d22763f8464808c3955db5c308291fe59d17cab
 pkg_dirname=${pkg_name}-${pkg_version}
 pkg_build_deps=(
   core/make


### PR DESCRIPTION
Release notes for 1.31.0 are here:

http://nghttp2.org/blog/2018/02/27/nghttp2-v1-31-0/

But we're skipping some versions in this bump.

I've built core/curl against this version locally; and it seemed to work fine:

    [5][default:/src:2]# /hab/pkgs/srenatus/curl/7.54.1/20180329122510/bin/curl -V
    curl 7.54.1 (x86_64-pc-linux-gnu) libcurl/7.54.1 OpenSSL/1.0.2l zlib/1.2.8 nghttp2/1.31.0
    Release-Date: 2017-06-14
    Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s smb smbs smtp smtps telnet tftp
    Features: IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy