### PR TITLE
READMEs for binary packages

### DIFF
--- a/7zip/README.md
+++ b/7zip/README.md
@@ -1,0 +1,15 @@
+# 7zip
+
+7-Zip is a file archiver with a high compression ratio
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/R/README.md
+++ b/R/README.md
@@ -1,0 +1,15 @@
+# R
+
+R is a free software environment for statistical computing and graphics.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/acbuild/README.md
+++ b/acbuild/README.md
@@ -1,0 +1,15 @@
+# acbuild
+
+A tool to build Application Container Images (ACI)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/acl/README.md
+++ b/acl/README.md
@@ -1,0 +1,13 @@
+# acl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/apr-util/README.md
+++ b/apr-util/README.md
@@ -1,0 +1,15 @@
+# apr-util
+
+Apache Portable Runtime util
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/apr/README.md
+++ b/apr/README.md
@@ -1,0 +1,15 @@
+# apr
+
+Apache Portable Runtime
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/aspcud/README.md
+++ b/aspcud/README.md
@@ -1,0 +1,15 @@
+# aspcud
+
+Aspcud is a solver for package dependencies
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/atk/README.md
+++ b/atk/README.md
@@ -1,0 +1,15 @@
+# atk
+
+Library for a set of interfaces providing accessibility. By supporting the ATK interfaces, an application or toolkit can be used with tools such as screen readers, magnifiers, and alternative input devices.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attr/README.md
+++ b/attr/README.md
@@ -1,0 +1,13 @@
+# attr
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/autoconf/README.md
+++ b/autoconf/README.md
@@ -1,0 +1,13 @@
+# autoconf
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -1,0 +1,15 @@
+# autogen
+
+A tool designed to simplify the creation and maintenance of programs that contain large amounts of repetitious text
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/automake/README.md
+++ b/automake/README.md
@@ -1,0 +1,13 @@
+# automake
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bash-completion/README.md
+++ b/bash-completion/README.md
@@ -1,0 +1,13 @@
+# bash-completion
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bash-static/README.md
+++ b/bash-static/README.md
@@ -1,0 +1,13 @@
+# bash-static
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,13 @@
+# bash
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bats/README.md
+++ b/bats/README.md
@@ -1,0 +1,15 @@
+# bats
+
+Bash Automated Testing System
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bc/README.md
+++ b/bc/README.md
@@ -1,0 +1,13 @@
+# bc
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bdwgc/README.md
+++ b/bdwgc/README.md
@@ -1,0 +1,15 @@
+# bdwgc
+
+A garbage collector for C and C++
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/binutils/README.md
+++ b/binutils/README.md
@@ -1,0 +1,13 @@
+# binutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bison/README.md
+++ b/bison/README.md
@@ -1,0 +1,15 @@
+# bison
+
+A parser generator that converts an annotated context-free grammar into a parser
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bison2/README.md
+++ b/bison2/README.md
@@ -1,0 +1,15 @@
+# bison2
+
+A parser generator that converts an annotated context-free grammar into a parser
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/boost/README.md
+++ b/boost/README.md
@@ -1,0 +1,15 @@
+# boost
+
+Boost provides free peer-reviewed portable C++ source libraries.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -1,0 +1,15 @@
+# bundler
+
+The Ruby language dependency manager
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/busybox-static/README.md
+++ b/busybox-static/README.md
@@ -1,0 +1,13 @@
+# busybox-static
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/busybox/README.md
+++ b/busybox/README.md
@@ -1,0 +1,13 @@
+# busybox
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bzip2-musl/README.md
+++ b/bzip2-musl/README.md
@@ -1,0 +1,13 @@
+# bzip2-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/bzip2/README.md
+++ b/bzip2/README.md
@@ -1,0 +1,13 @@
+# bzip2
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/c-ares/README.md
+++ b/c-ares/README.md
@@ -1,0 +1,15 @@
+# c-ares
+
+A C library for asynchronous DNS requests
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cacerts/README.md
+++ b/cacerts/README.md
@@ -1,0 +1,13 @@
+# cacerts
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -1,0 +1,15 @@
+# caddy
+
+Fast, cross-platform HTTP/2 web server with automatic HTTPS
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/camlp4/README.md
+++ b/camlp4/README.md
@@ -1,0 +1,15 @@
+# camlp4
+
+Camlp4 is a software system for writing extensible parsers for programming languages. It provides a set of OCaml libraries that are used to define grammars as well as loadable syntax extensions of such grammars.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cargo-nightly/README.md
+++ b/cargo-nightly/README.md
@@ -1,0 +1,15 @@
+# cargo-nightly
+
+The Rust package manager
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ccache/README.md
+++ b/ccache/README.md
@@ -1,0 +1,15 @@
+# ccache
+
+ccache is a compiler cache. It speeds up recompilation by caching previous compilations and detecting when the same compilation is being done again.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/certstrap/README.md
+++ b/certstrap/README.md
@@ -1,0 +1,15 @@
+# certstrap
+
+A simple certificate manager written in Go, to bootstrap your own certificate authority and public key infrastructure. Adapted from etcd-ca.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/check/README.md
+++ b/check/README.md
@@ -1,0 +1,13 @@
+# check
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/clens/README.md
+++ b/clens/README.md
@@ -1,0 +1,13 @@
+# clens
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/clingo/README.md
+++ b/clingo/README.md
@@ -1,0 +1,15 @@
+# clingo
+
+A grounder and solver for logic programs.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,15 @@
+# cmake
+
+CMake is an open-source, cross-platform family of tools designed to build, test and package software
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/composer/README.md
+++ b/composer/README.md
@@ -1,0 +1,15 @@
+# composer
+
+Dependency Manager for PHP
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/coreutils-static/README.md
+++ b/coreutils-static/README.md
@@ -1,0 +1,15 @@
+# coreutils-static
+
+Basic file, shell and text manipulation utilities of the GNU operating system.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/coreutils/README.md
+++ b/coreutils/README.md
@@ -1,0 +1,15 @@
+# coreutils
+
+Basic file, shell and text manipulation utilities of the GNU operating system.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cpanminus/README.md
+++ b/cpanminus/README.md
@@ -1,0 +1,15 @@
+# cpanminus
+
+cpanminus is a script to get, unpack, build and install modules from CPAN and does nothing else.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cpio/README.md
+++ b/cpio/README.md
@@ -1,0 +1,13 @@
+# cpio
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cppunit/README.md
+++ b/cppunit/README.md
@@ -1,0 +1,15 @@
+# cppunit
+
+CppUnit is the C++ port of the famous JUnit framework for unit testing. Test output is in XML for automatic testing and GUI based for supervised tests.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cpputest/README.md
+++ b/cpputest/README.md
@@ -1,0 +1,17 @@
+# cpputest
+
+  CppUTest is a C/C++ based unit xUnit test framework for unit testing and for test-driving your
+  code. It is written in C++ but is used in C and C++ projects and frequently used in embedded
+  systems but it works for any C/C++ project.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/curator/README.md
+++ b/curator/README.md
@@ -1,0 +1,15 @@
+# curator
+
+Elasticsearch Curator helps you curate, or manage your indices.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/curl-static-musl/README.md
+++ b/curl-static-musl/README.md
@@ -1,0 +1,16 @@
+# curl-static-musl
+
+curl is an open source command line tool and library for
+  transferring data with URL syntax.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/cyrus-sasl/README.md
+++ b/cyrus-sasl/README.md
@@ -1,0 +1,15 @@
+# cyrus-sasl
+
+Cyrus Simple Authentication Service Layer (SASL) library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,13 @@
+# db
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dbus/README.md
+++ b/dbus/README.md
@@ -1,0 +1,15 @@
+# dbus
+
+D-Bus is a message bus system, a simple way for applications to talk to one another.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dejagnu/README.md
+++ b/dejagnu/README.md
@@ -1,0 +1,15 @@
+# dejagnu
+
+A framework for testing other programs.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dep/README.md
+++ b/dep/README.md
@@ -1,0 +1,15 @@
+# dep
+
+Go dependency management tool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/devicemapper/README.md
+++ b/devicemapper/README.md
@@ -1,0 +1,13 @@
+# devicemapper
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/diffutils/README.md
+++ b/diffutils/README.md
@@ -1,0 +1,13 @@
+# diffutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/direnv/README.md
+++ b/direnv/README.md
@@ -1,0 +1,15 @@
+# direnv
+
+direnv is an environment switcher for the shell.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+# docker
+
+The Docker Engine
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/docutils/README.md
+++ b/docutils/README.md
@@ -1,0 +1,13 @@
+# docutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dosfstools/README.md
+++ b/dosfstools/README.md
@@ -1,0 +1,13 @@
+# dosfstools
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dotnet-core-lts/README.md
+++ b/dotnet-core-lts/README.md
@@ -1,0 +1,17 @@
+# dotnet-core-lts
+
+.NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac. LTS release channel.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dotnet-core-sdk-lts/README.md
+++ b/dotnet-core-sdk-lts/README.md
@@ -1,0 +1,17 @@
+# dotnet-core-sdk-lts
+
+.NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac. LTS release channel.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dotnet-core-sdk/README.md
+++ b/dotnet-core-sdk/README.md
@@ -1,0 +1,17 @@
+# dotnet-core-sdk
+
+.NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dotnet-core/README.md
+++ b/dotnet-core/README.md
@@ -1,0 +1,17 @@
+# dotnet-core
+
+.NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/doxygen/README.md
+++ b/doxygen/README.md
@@ -1,0 +1,15 @@
+# doxygen
+
+Generate documentation for several programming languages
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dpkg/README.md
+++ b/dpkg/README.md
@@ -1,0 +1,15 @@
+# dpkg
+
+Debian Package Manager
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/drush/README.md
+++ b/drush/README.md
@@ -1,0 +1,15 @@
+# drush
+
+Drush is a command line shell and Unix scripting interface for Drupal.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/e2fsprogs/README.md
+++ b/e2fsprogs/README.md
@@ -1,0 +1,13 @@
+# e2fsprogs
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/elfutils/README.md
+++ b/elfutils/README.md
@@ -1,0 +1,17 @@
+# elfutils
+
+elfutils is a collection of various binary tools such as
+  eu-objdump, eu-readelf, and other utilities that allow you to inspect and
+  manipulate ELF files.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,0 +1,15 @@
+# elixir
+
+A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/envdir/README.md
+++ b/envdir/README.md
@@ -1,0 +1,15 @@
+# envdir
+
+Envdir runs another program with a modified environment according to files in a specified directory.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -1,0 +1,15 @@
+# erlang
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/erlang16/README.md
+++ b/erlang16/README.md
@@ -1,0 +1,15 @@
+# erlang16
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/erlang18/README.md
+++ b/erlang18/README.md
@@ -1,0 +1,15 @@
+# erlang18
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/erlang19/README.md
+++ b/erlang19/README.md
@@ -1,0 +1,15 @@
+# erlang19
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/eudev/README.md
+++ b/eudev/README.md
@@ -1,0 +1,15 @@
+# eudev
+
+eudev is a device manager for the Linux kernel
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/exercism/README.md
+++ b/exercism/README.md
@@ -1,0 +1,15 @@
+# exercism
+
+A Go based command line tool for exercism.io.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/expat/README.md
+++ b/expat/README.md
@@ -1,0 +1,15 @@
+# expat
+
+Expat library: Fast XML parser in C
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/expect/README.md
+++ b/expect/README.md
@@ -1,0 +1,15 @@
+# expect
+
+A tool for automating interactive applications
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -1,0 +1,15 @@
+# ffmpeg
+
+A complete, cross-platform solution to record, convert and stream audio and video.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/file/README.md
+++ b/file/README.md
@@ -1,0 +1,13 @@
+# file
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/findutils/README.md
+++ b/findutils/README.md
@@ -1,0 +1,13 @@
+# findutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/fish/README.md
+++ b/fish/README.md
@@ -1,0 +1,15 @@
+# fish
+
+fish is a smart and user-friendly command line shell for macOS, Linux, and the rest of the family.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/fixesproto/README.md
+++ b/fixesproto/README.md
@@ -1,0 +1,15 @@
+# fixesproto
+
+X.Org Protocol Headers: fixesproto
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/flatbuffers/README.md
+++ b/flatbuffers/README.md
@@ -1,0 +1,17 @@
+# flatbuffers
+
+  FlatBuffers is an efficient cross platform serialization library for C++,
+  C#, C, Go, Java, JavaScript, PHP, and Python. It was originally created at
+  Google for game development and other performance-critical applications.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/flex/README.md
+++ b/flex/README.md
@@ -1,0 +1,13 @@
+# flex
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/fontconfig/README.md
+++ b/fontconfig/README.md
@@ -1,0 +1,16 @@
+# fontconfig
+
+Fontconfig is a library for configuring and
+  customizing font access.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/fping/README.md
+++ b/fping/README.md
@@ -1,0 +1,18 @@
+# fping
+
+  fping is a program to send ICMP echo probes to network hosts, similar to
+  ping, but much better performing when pinging multiple hosts. fping has a
+  long long story: Roland Schemers did publish a first version of it in 1992
+  and it has established itself since then as a standard tool.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/freetype/README.md
+++ b/freetype/README.md
@@ -1,0 +1,15 @@
+# freetype
+
+A software library to render fonts
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/galera/README.md
+++ b/galera/README.md
@@ -1,0 +1,15 @@
+# galera
+
+Galera WSREP plugin
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gamin/README.md
+++ b/gamin/README.md
@@ -1,0 +1,15 @@
+# gamin
+
+File Alteration Monitor
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gawk/README.md
+++ b/gawk/README.md
@@ -1,0 +1,13 @@
+# gawk
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gcc-libs/README.md
+++ b/gcc-libs/README.md
@@ -1,0 +1,15 @@
+# gcc-libs
+
+The GNU Compiler Collection
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gcc/README.md
+++ b/gcc/README.md
@@ -1,0 +1,15 @@
+# gcc
+
+The GNU Compiler Collection
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gdal/README.md
+++ b/gdal/README.md
@@ -1,0 +1,15 @@
+# gdal
+
+GDAL is a translator library for raster and vector geospatial data formats
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gdb/README.md
+++ b/gdb/README.md
@@ -1,0 +1,15 @@
+# gdb
+
+GDB, the GNU Project debugger, allows you to see what is going on 'inside' another program while it executes -- or what another program was doing at the moment it crashed.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gdbm/README.md
+++ b/gdbm/README.md
@@ -1,0 +1,13 @@
+# gdbm
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -1,0 +1,15 @@
+# gdk-pixbuf
+
+An image loading library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gecode/README.md
+++ b/gecode/README.md
@@ -1,0 +1,15 @@
+# gecode
+
+Gecode is a toolkit for developing constraint-based systems and applications
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/geoip/README.md
+++ b/geoip/README.md
@@ -1,0 +1,15 @@
+# geoip
+
+GeoIP Legacy C API
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/geos/README.md
+++ b/geos/README.md
@@ -1,0 +1,15 @@
+# geos
+
+GEOS (Geometry Engine - Open Source) is a C++ port of the ​Java Topology Suite (JTS).
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gettext/README.md
+++ b/gettext/README.md
@@ -1,0 +1,13 @@
+# gettext
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/giflib/README.md
+++ b/giflib/README.md
@@ -1,0 +1,16 @@
+# giflib
+
+GIFLIB is a package of portable tools and library routines for working with GIF images.
+Also commonly known as libgif.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gifsicle/README.md
+++ b/gifsicle/README.md
@@ -1,0 +1,13 @@
+# gifsicle
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/git/README.md
+++ b/git/README.md
@@ -1,0 +1,17 @@
+# git
+
+Git is a free and open source distributed version control
+  system designed to handle everything from small to very large projects with
+  speed and efficiency.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/github_changelog_generator/README.md
+++ b/github_changelog_generator/README.md
@@ -1,0 +1,15 @@
+# github_changelog_generator
+
+Changelog generation has never been so easy. Fully automate changelog generation -  this gem generate change log file based on tags, issues and merged pull requests from Github   issue tracker.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/glibc/README.md
+++ b/glibc/README.md
@@ -1,0 +1,19 @@
+# glibc
+
+  The GNU C Library project provides the core libraries for the GNU system and GNU/Linux systems,
+  as well as many other systems that use Linux as the kernel. These libraries provide critical
+  APIs including ISO C11, POSIX.1-2008, BSD, OS-specific APIs and more. These APIs include such
+  foundational facilities as open, read, write, malloc, printf, getaddrinfo, dlopen,
+  pthread_create, crypt, login, exit and more.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gmp/README.md
+++ b/gmp/README.md
@@ -1,0 +1,15 @@
+# gmp
+
+GMP is a free library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating-point numbers.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gnupg-static/README.md
+++ b/gnupg-static/README.md
@@ -1,0 +1,13 @@
+# gnupg-static
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gnupg/README.md
+++ b/gnupg/README.md
@@ -1,0 +1,13 @@
+# gnupg
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,16 @@
+# go
+
+Go is an open source programming language that makes it easy to
+  build simple, reliable, and efficient software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/go14/README.md
+++ b/go14/README.md
@@ -1,0 +1,15 @@
+# go14
+
+Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/go17/README.md
+++ b/go17/README.md
@@ -1,0 +1,16 @@
+# go17
+
+Go is an open source programming language that makes it easy to
+  build simple, reliable, and efficient software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/goreplay/README.md
+++ b/goreplay/README.md
@@ -1,0 +1,15 @@
+# goreplay
+
+GoReplay is an open-source tool for capturing and replaying live HTTP traffic into a test environment in order to continuously test your system with real data.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gox/README.md
+++ b/gox/README.md
@@ -1,0 +1,15 @@
+# gox
+
+A dead simple, no frills Go cross compile tool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gperf/README.md
+++ b/gperf/README.md
@@ -1,0 +1,15 @@
+# gperf
+
+GNU gperf is a perfect hash function generator.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gpgme/README.md
+++ b/gpgme/README.md
@@ -1,0 +1,13 @@
+# gpgme
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,0 +1,15 @@
+# gradle
+
+A powerful build system for the JVM
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/graphviz/README.md
+++ b/graphviz/README.md
@@ -1,0 +1,15 @@
+# graphviz
+
+Graphviz - Graph Visualization Software
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/grep/README.md
+++ b/grep/README.md
@@ -1,0 +1,13 @@
+# grep
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/groff/README.md
+++ b/groff/README.md
@@ -1,0 +1,15 @@
+# groff
+
+Groff (GNU troff) is a typesetting system that reads plain text mixed with formatting commands and produces formatted output. Output may be PostScript or PDF, html, or ASCII/UTF8 for display at the terminal. Formatting commands may be either low-level typesetting requests (“primitives”) or macros from a supplied set. Users may also write their own macros. All three may be combined.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/grub/README.md
+++ b/grub/README.md
@@ -1,0 +1,15 @@
+# grub
+
+GNU GRUB is a Multiboot boot loader.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gsl/README.md
+++ b/gsl/README.md
@@ -1,0 +1,15 @@
+# gsl
+
+GSL is a numerical library for C and C++
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gtk2/README.md
+++ b/gtk2/README.md
@@ -1,0 +1,15 @@
+# gtk2
+
+GTK+, or the GIMP Toolkit, is a multi-platform toolkit for creating graphical user interfaces.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/guile/README.md
+++ b/guile/README.md
@@ -1,0 +1,15 @@
+# guile
+
+An implementation of the Scheme programming language, used in many GNU programs as an extension language.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gzip/README.md
+++ b/gzip/README.md
@@ -1,0 +1,13 @@
+# gzip
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/handlebars-cmd/README.md
+++ b/handlebars-cmd/README.md
@@ -1,0 +1,15 @@
+# handlebars-cmd
+
+handlebars command-line tool.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/harfbuzz/README.md
+++ b/harfbuzz/README.md
@@ -1,0 +1,15 @@
+# harfbuzz
+
+HarfBuzz is an OpenType text shaping engine
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/htop/README.md
+++ b/htop/README.md
@@ -1,0 +1,15 @@
+# htop
+
+This is htop, an interactive process viewer for Unix systems. It is a text-mode application (for console or X terminals) and requires ncurses.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/iana-etc/README.md
+++ b/iana-etc/README.md
@@ -1,0 +1,13 @@
+# iana-etc
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/icu/README.md
+++ b/icu/README.md
@@ -1,0 +1,18 @@
+# icu
+
+  ICU is a mature, widely used set of C/C++ and Java libraries providing
+  Unicode and Globalization support for software applications. ICU is widely
+  portable and gives applications the same results on all platforms and
+  between C/C++ and Java software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/icu52/README.md
+++ b/icu52/README.md
@@ -1,0 +1,18 @@
+# icu52
+
+  ICU is a mature, widely used set of C/C++ and Java libraries providing
+  Unicode and Globalization support for software applications. ICU is widely
+  portable and gives applications the same results on all platforms and
+  between C/C++ and Java software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/icu56/README.md
+++ b/icu56/README.md
@@ -1,0 +1,18 @@
+# icu56
+
+  ICU is a mature, widely used set of C/C++ and Java libraries providing
+  Unicode and Globalization support for software applications. ICU is widely
+  portable and gives applications the same results on all platforms and
+  between C/C++ and Java software.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/imagemagick/README.md
+++ b/imagemagick/README.md
@@ -1,0 +1,15 @@
+# imagemagick
+
+A software suite to create, edit, compose, or convert bitmap images.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/inetutils/README.md
+++ b/inetutils/README.md
@@ -1,0 +1,13 @@
+# inetutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/inotify-tools/README.md
+++ b/inotify-tools/README.md
@@ -1,0 +1,15 @@
+# inotify-tools
+
+inotify-tools is a C library and a set of command-line programs for Linux providing a simple interface to inotify. These programs can be used to monitor and act upon filesystem events.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/inputproto/README.md
+++ b/inputproto/README.md
@@ -1,0 +1,15 @@
+# inputproto
+
+X11 input extension wire protocol
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/intltool/README.md
+++ b/intltool/README.md
@@ -1,0 +1,15 @@
+# intltool
+
+intltool is a set of tools to centralize translation of many different file formats using GNU gettext-compatible PO files.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/iproute2/README.md
+++ b/iproute2/README.md
@@ -1,0 +1,15 @@
+# iproute2
+
+Collection of utilities for controlling TCP/IP networking
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/iptables/README.md
+++ b/iptables/README.md
@@ -1,0 +1,13 @@
+# iptables
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jbigkit/README.md
+++ b/jbigkit/README.md
@@ -1,0 +1,15 @@
+# jbigkit
+
+An implementation of the JBIG1 data compression standard
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jdk7/README.md
+++ b/jdk7/README.md
@@ -1,0 +1,15 @@
+# jdk7
+
+Oracle Java Development Kit. This package is made available to you to allow you to run your applications as provided in and subject to the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jdk8/README.md
+++ b/jdk8/README.md
@@ -1,0 +1,15 @@
+# jdk8
+
+Oracle Java Development Kit. This package is made available to you to allow you to run your applications as provided in and subject to the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jemalloc/README.md
+++ b/jemalloc/README.md
@@ -1,0 +1,15 @@
+# jemalloc
+
+malloc implementation emphasizing fragmentation avoidance
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jffi/README.md
+++ b/jffi/README.md
@@ -1,0 +1,13 @@
+# jffi
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jfrog-cli/README.md
+++ b/jfrog-cli/README.md
@@ -1,0 +1,15 @@
+# jfrog-cli
+
+jfrog CLI
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jq-static/README.md
+++ b/jq-static/README.md
@@ -1,0 +1,13 @@
+# jq-static
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jre7/README.md
+++ b/jre7/README.md
@@ -1,0 +1,15 @@
+# jre7
+
+Oracle Java Runtime Environment. This package is made available to you to allow you to run your applications as provided in and subject to the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jre8/README.md
+++ b/jre8/README.md
@@ -1,0 +1,15 @@
+# jre8
+
+Oracle Java Runtime Environment. This package is made available to you to allow you to run your applications as provided in and subject to the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jruby/README.md
+++ b/jruby/README.md
@@ -1,0 +1,15 @@
+# jruby
+
+A high performance, stable, fully threaded Java implementation of the Ruby programming language.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/jruby1/README.md
+++ b/jruby1/README.md
@@ -1,0 +1,15 @@
+# jruby1
+
+A high performance, stable, fully threaded Java implementation of the Ruby programming language.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/kbproto/README.md
+++ b/kbproto/README.md
@@ -1,0 +1,15 @@
+# kbproto
+
+X11 XKB extension wire protocol
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -1,0 +1,15 @@
+# kmod
+
+Linux kernel module management tools and library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/krb5/README.md
+++ b/krb5/README.md
@@ -1,0 +1,17 @@
+# krb5
+
+Kerberos is a network authentication protocol. It is designed
+  to provide strong authentication for client/server applications by using
+  secret-key cryptography.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lcms2/README.md
+++ b/lcms2/README.md
@@ -1,0 +1,15 @@
+# lcms2
+
+Small-footprint color management engine, version 2
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/less/README.md
+++ b/less/README.md
@@ -1,0 +1,13 @@
+# less
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/leveldb/README.md
+++ b/leveldb/README.md
@@ -1,0 +1,15 @@
+# leveldb
+
+LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libaio/README.md
+++ b/libaio/README.md
@@ -1,0 +1,13 @@
+# libaio
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libarchive-musl/README.md
+++ b/libarchive-musl/README.md
@@ -1,0 +1,15 @@
+# libarchive-musl
+
+Multi-format archive and compression library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libarchive/README.md
+++ b/libarchive/README.md
@@ -1,0 +1,15 @@
+# libarchive
+
+Multi-format archive and compression library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libassuan/README.md
+++ b/libassuan/README.md
@@ -1,0 +1,13 @@
+# libassuan
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libatomic_ops/README.md
+++ b/libatomic_ops/README.md
@@ -1,0 +1,15 @@
+# libatomic_ops
+
+Atomic memory update operations
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libbsd/README.md
+++ b/libbsd/README.md
@@ -1,0 +1,13 @@
+# libbsd
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libcap-ng/README.md
+++ b/libcap-ng/README.md
@@ -1,0 +1,15 @@
+# libcap-ng
+
+The libcap-ng library is intended to make programming with posix capabilities much easier than the traditional libcap library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libcap/README.md
+++ b/libcap/README.md
@@ -1,0 +1,13 @@
+# libcap
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libcxx/README.md
+++ b/libcxx/README.md
@@ -1,0 +1,15 @@
+# libcxx
+
+A new implementation of the C++ standard library, targeting C++11
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libedit/README.md
+++ b/libedit/README.md
@@ -1,0 +1,13 @@
+# libedit
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/liberation-fonts-ttf/README.md
+++ b/liberation-fonts-ttf/README.md
@@ -1,0 +1,15 @@
+# liberation-fonts-ttf
+
+The Liberation Fonts are intended to be replacements for the three most commonly used fonts on Microsoft systems: Times New Roman, Arial, and Courier New.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libev/README.md
+++ b/libev/README.md
@@ -1,0 +1,15 @@
+# libev
+
+A full-featured and high-performance (see benchmark) event loop that is loosely modelled after libevent.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libevent/README.md
+++ b/libevent/README.md
@@ -1,0 +1,13 @@
+# libevent
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libffi/README.md
+++ b/libffi/README.md
@@ -1,0 +1,13 @@
+# libffi
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libgcrypt/README.md
+++ b/libgcrypt/README.md
@@ -1,0 +1,13 @@
+# libgcrypt
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libghthash/README.md
+++ b/libghthash/README.md
@@ -1,0 +1,15 @@
+# libghthash
+
+Generic Hash Table which is meant to be easy to extend, portable, clear in its code and easy to use.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libgpg-error/README.md
+++ b/libgpg-error/README.md
@@ -1,0 +1,13 @@
+# libgpg-error
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libice/README.md
+++ b/libice/README.md
@@ -1,0 +1,15 @@
+# libice
+
+X11 Inter-Client Exchange library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libiconv/README.md
+++ b/libiconv/README.md
@@ -1,0 +1,13 @@
+# libiconv
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libidn/README.md
+++ b/libidn/README.md
@@ -1,0 +1,13 @@
+# libidn
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libidn2/README.md
+++ b/libidn2/README.md
@@ -1,0 +1,15 @@
+# libidn2
+
+Implementation of IDNA2008, Punycode and TR46 (Internationalized domain names)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libjpeg-turbo/README.md
+++ b/libjpeg-turbo/README.md
@@ -1,0 +1,15 @@
+# libjpeg-turbo
+
+A faster (using SIMD) libjpeg implementation
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libksba/README.md
+++ b/libksba/README.md
@@ -1,0 +1,13 @@
+# libksba
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libmpc/README.md
+++ b/libmpc/README.md
@@ -1,0 +1,13 @@
+# libmpc
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libossp-uuid/README.md
+++ b/libossp-uuid/README.md
@@ -1,0 +1,15 @@
+# libossp-uuid
+
+OSSP uuid is a ISO-C:1999 application programming interface (API) and corresponding command line interface (CLI) for the generation of DCE 1.1
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libpcap/README.md
+++ b/libpcap/README.md
@@ -1,0 +1,15 @@
+# libpcap
+
+A portable C/C++ library for network traffic capture.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libpipeline/README.md
+++ b/libpipeline/README.md
@@ -1,0 +1,15 @@
+# libpipeline
+
+libpipeline is a C library for manipulating pipelines of subprocesses in a flexible and convenient way.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libpng/README.md
+++ b/libpng/README.md
@@ -1,0 +1,15 @@
+# libpng
+
+An Open, Extensible Image Format with Lossless Compression
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libpthread-stubs/README.md
+++ b/libpthread-stubs/README.md
@@ -1,0 +1,15 @@
+# libpthread-stubs
+
+Weak aliases for pthread functions
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libressl-musl/README.md
+++ b/libressl-musl/README.md
@@ -1,0 +1,15 @@
+# libressl-musl
+
+Version of the TLS/crypto stack forked from OpenSSL
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libressl/README.md
+++ b/libressl/README.md
@@ -1,0 +1,15 @@
+# libressl
+
+Version of the TLS/crypto stack forked from OpenSSL
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libscrypt/README.md
+++ b/libscrypt/README.md
@@ -1,0 +1,15 @@
+# libscrypt
+
+An implementation of Colin Percival's scrypt hash
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libseccomp/README.md
+++ b/libseccomp/README.md
@@ -1,0 +1,16 @@
+# libseccomp
+
+An easy to use, platform independent, interface
+to the Linux Kernel's syscall filtering mechanism.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libsm/README.md
+++ b/libsm/README.md
@@ -1,0 +1,15 @@
+# libsm
+
+X11 Session Management library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libsodium-musl/README.md
+++ b/libsodium-musl/README.md
@@ -1,0 +1,13 @@
+# libsodium-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libsodium/README.md
+++ b/libsodium/README.md
@@ -1,0 +1,13 @@
+# libsodium
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libtermkey/README.md
+++ b/libtermkey/README.md
@@ -1,0 +1,15 @@
+# libtermkey
+
+This library allows easy processing of keyboard entry from terminal-based programs.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libtiff/README.md
+++ b/libtiff/README.md
@@ -1,0 +1,15 @@
+# libtiff
+
+Library for reading and writting files in the Tag Image File Format (TIFF)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libtool/README.md
+++ b/libtool/README.md
@@ -1,0 +1,13 @@
+# libtool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libunistring/README.md
+++ b/libunistring/README.md
@@ -1,0 +1,15 @@
+# libunistring
+
+Library functions for manipulating Unicode strings
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libunwind/README.md
+++ b/libunwind/README.md
@@ -1,0 +1,15 @@
+# libunwind
+
+A C programming interface to determine the call-chain of a program.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libvterm/README.md
+++ b/libvterm/README.md
@@ -1,0 +1,15 @@
+# libvterm
+
+An abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libwebp/README.md
+++ b/libwebp/README.md
@@ -1,0 +1,15 @@
+# libwebp
+
+WebP codec: library to encode and decode images in WebP format.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxau/README.md
+++ b/libxau/README.md
@@ -1,0 +1,15 @@
+# libxau
+
+X11 authorization library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxcb/README.md
+++ b/libxcb/README.md
@@ -1,0 +1,15 @@
+# libxcb
+
+X11 C Bindings
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxdmcp/README.md
+++ b/libxdmcp/README.md
@@ -1,0 +1,15 @@
+# libxdmcp
+
+X11 Display Manager Control Protocol library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxext/README.md
+++ b/libxext/README.md
@@ -1,0 +1,15 @@
+# libxext
+
+X11 miscellaneous extensions library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxfixes/README.md
+++ b/libxfixes/README.md
@@ -1,0 +1,15 @@
+# libxfixes
+
+X.Org Libraries: libXfixes
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxi/README.md
+++ b/libxi/README.md
@@ -1,0 +1,15 @@
+# libxi
+
+X.Org Libraries: libXi
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxml2/README.md
+++ b/libxml2/README.md
@@ -1,0 +1,15 @@
+# libxml2
+
+Libxml2 is the XML C parser and toolkit developed for the Gnome project
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxmu/README.md
+++ b/libxmu/README.md
@@ -1,0 +1,15 @@
+# libxmu
+
+X11 miscellaneous utility library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxrender/README.md
+++ b/libxrender/README.md
@@ -1,0 +1,15 @@
+# libxrender
+
+X Rendering Extension client library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxslt/README.md
+++ b/libxslt/README.md
@@ -1,0 +1,15 @@
+# libxslt
+
+Libxslt is the XSLT C library developed for the GNOME project
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxt/README.md
+++ b/libxt/README.md
@@ -1,0 +1,15 @@
+# libxt
+
+X11 toolkit intrinsics library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libxtst/README.md
+++ b/libxtst/README.md
@@ -1,0 +1,15 @@
+# libxtst
+
+X.Org Libraries: libXtst
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libyajl2/README.md
+++ b/libyajl2/README.md
@@ -1,0 +1,15 @@
+# libyajl2
+
+Yet Another JSON Library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libyaml/README.md
+++ b/libyaml/README.md
@@ -1,0 +1,13 @@
+# libyaml
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/linux-headers-musl/README.md
+++ b/linux-headers-musl/README.md
@@ -1,0 +1,15 @@
+# linux-headers-musl
+
+Linux kernel headers (sanitized for use with musl)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/linux-headers/README.md
+++ b/linux-headers/README.md
@@ -1,0 +1,15 @@
+# linux-headers
+
+The Linux kernel headers
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/linux-pam/README.md
+++ b/linux-pam/README.md
@@ -1,0 +1,15 @@
+# linux-pam
+
+Linux-PAM is a free implementation of the following DCE-RFC from Sunsoft.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,0 +1,15 @@
+# linux
+
+The Linux kernel
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/local-lib/README.md
+++ b/local-lib/README.md
@@ -1,0 +1,15 @@
+# local-lib
+
+create and use a local lib/ for perl modules with PERL5LIB
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/logback/README.md
+++ b/logback/README.md
@@ -1,0 +1,15 @@
+# logback
+
+The reliable, generic, fast and flexible logging framework for Java.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lsof/README.md
+++ b/lsof/README.md
@@ -1,0 +1,15 @@
+# lsof
+
+lsof - list open files
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lsyncd/README.md
+++ b/lsyncd/README.md
@@ -1,0 +1,15 @@
+# lsyncd
+
+Lsyncd watches a local directory trees event monitor interface (inotify or fsevents)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lttng-ust/README.md
+++ b/lttng-ust/README.md
@@ -1,0 +1,15 @@
+# lttng-ust
+
+LTTng is an open source tracing framework for Linux.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lua/README.md
+++ b/lua/README.md
@@ -1,0 +1,15 @@
+# lua
+
+A powerful, efficient, lightweight, embeddable scripting language
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lynx/README.md
+++ b/lynx/README.md
@@ -1,0 +1,15 @@
+# lynx
+
+Lynx is the text web browser.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lz4/README.md
+++ b/lz4/README.md
@@ -1,0 +1,15 @@
+# lz4
+
+Extremely Fast Compression algorithm http://www.lz4.org
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lzip/README.md
+++ b/lzip/README.md
@@ -1,0 +1,15 @@
+# lzip
+
+A lossless data compressor with a user interface similar to the one of gzip or bzip2.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lzo/README.md
+++ b/lzo/README.md
@@ -1,0 +1,13 @@
+# lzo
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/lzop/README.md
+++ b/lzop/README.md
@@ -1,0 +1,15 @@
+# lzop
+
+lzop is a file compressor which is very similar to gzip. lzop uses the LZO data compression library for compression services, and its main advantages over gzip are much higher compression and decompression speed (at the cost of some compression ratio).
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/m4/README.md
+++ b/m4/README.md
@@ -1,0 +1,13 @@
+# m4
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/make/README.md
+++ b/make/README.md
@@ -1,0 +1,15 @@
+# make
+
+Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/man-db/README.md
+++ b/man-db/README.md
@@ -1,0 +1,15 @@
+# man-db
+
+man-db is an implementation of the standard Unix documentation system accessed using the man command.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/man-pages/README.md
+++ b/man-pages/README.md
@@ -1,0 +1,13 @@
+# man-pages
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mawk/README.md
+++ b/mawk/README.md
@@ -1,0 +1,15 @@
+# mawk
+
+An interpreter for the AWK Programming Language
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mc/README.md
+++ b/mc/README.md
@@ -1,0 +1,15 @@
+# mc
+
+Midnight Commander.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mercurial/README.md
+++ b/mercurial/README.md
@@ -1,0 +1,15 @@
+# mercurial
+
+A free, distributed source control management tool.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mg/README.md
+++ b/mg/README.md
@@ -1,0 +1,13 @@
+# mg
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mongo-tools/README.md
+++ b/mongo-tools/README.md
@@ -1,0 +1,15 @@
+# mongo-tools
+
+MongoDB Tools
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mpfr/README.md
+++ b/mpfr/README.md
@@ -1,0 +1,13 @@
+# mpfr
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/msgpack/README.md
+++ b/msgpack/README.md
@@ -1,0 +1,15 @@
+# msgpack
+
+MessagePack implementation for C and C++
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/musl/README.md
+++ b/musl/README.md
@@ -1,0 +1,15 @@
+# musl
+
+musl is a new standard library to power a new generation of Linux-based devices. musl is lightweight, fast, simple, free, and strives to be correct in the sense of standards-conformance and safety.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/mysql-client/README.md
+++ b/mysql-client/README.md
@@ -1,0 +1,15 @@
+# mysql-client
+
+MySQL Client Tools
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/nasm/README.md
+++ b/nasm/README.md
@@ -1,0 +1,15 @@
+# nasm
+
+The Netwide Assembler, NASM, is an 80x86 and x86-64 assembler designed for portability and modularity.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ncdu/README.md
+++ b/ncdu/README.md
@@ -1,0 +1,15 @@
+# ncdu
+
+Ncdu is a disk usage analyzer with an ncurses interface
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ncurses/README.md
+++ b/ncurses/README.md
@@ -1,0 +1,15 @@
+# ncurses
+
+The ncurses (new curses) library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/net-tools/README.md
+++ b/net-tools/README.md
@@ -1,0 +1,13 @@
+# net-tools
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/netcat-openbsd/README.md
+++ b/netcat-openbsd/README.md
@@ -1,0 +1,15 @@
+# netcat-openbsd
+
+TCP/IP swiss army knife, OpenBSD variant
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/netcat/README.md
+++ b/netcat/README.md
@@ -1,0 +1,15 @@
+# netcat
+
+GNU rewrite of the OpenBSD netcat/nc package
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ninja/README.md
+++ b/ninja/README.md
@@ -1,0 +1,15 @@
+# ninja
+
+A small build system with a focus on speed
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/nmap/README.md
+++ b/nmap/README.md
@@ -1,0 +1,15 @@
+# nmap
+
+nmap is a free security scanner for network exploration and security audits
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,15 @@
+# node
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node6/README.md
+++ b/node6/README.md
@@ -1,0 +1,15 @@
+# node6
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node9/README.md
+++ b/node9/README.md
@@ -1,0 +1,15 @@
+# node9
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/npth/README.md
+++ b/npth/README.md
@@ -1,0 +1,13 @@
+# npth
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/nspr/README.md
+++ b/nspr/README.md
@@ -1,0 +1,15 @@
+# nspr
+
+Netscape Portable Runtime
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/nss/README.md
+++ b/nss/README.md
@@ -1,0 +1,15 @@
+# nss
+
+Network Security Services
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/numactl/README.md
+++ b/numactl/README.md
@@ -1,0 +1,15 @@
+# numactl
+
+NUMA support for Linux http://oss.sgi.com/projects/libnuma/
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ocaml/README.md
+++ b/ocaml/README.md
@@ -1,0 +1,15 @@
+# ocaml
+
+The OCAML compiler
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ocamlbuild/README.md
+++ b/ocamlbuild/README.md
@@ -1,0 +1,15 @@
+# ocamlbuild
+
+OCamlbuild is a generic build tool, that has built-in rules for building OCaml library and programs.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/omniORB/README.md
+++ b/omniORB/README.md
@@ -1,0 +1,15 @@
+# omniORB
+
+A CORBA object request broker for C++ and Python.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/opam/README.md
+++ b/opam/README.md
@@ -1,0 +1,15 @@
+# opam
+
+opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/openjpeg/README.md
+++ b/openjpeg/README.md
@@ -1,0 +1,15 @@
+# openjpeg
+
+An open source JPEG 2000 codec
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/openssl-musl/README.md
+++ b/openssl-musl/README.md
@@ -1,0 +1,15 @@
+# openssl-musl
+
+OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,0 +1,15 @@
+# openssl
+
+OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pango/README.md
+++ b/pango/README.md
@@ -1,0 +1,15 @@
+# pango
+
+Pango is a library for laying out and rendering of text, with an emphasis on internationalization.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/patch/README.md
+++ b/patch/README.md
@@ -1,0 +1,13 @@
+# patch
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/patchelf/README.md
+++ b/patchelf/README.md
@@ -1,0 +1,15 @@
+# patchelf
+
+A small utility to modify the dynamic linker and RPATH of ELF executables
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pax-utils/README.md
+++ b/pax-utils/README.md
@@ -1,0 +1,16 @@
+# pax-utils
+
+ELF related utils for ELF 32/64 binaries that can check files
+  for security relevant properties
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pcre/README.md
+++ b/pcre/README.md
@@ -1,0 +1,15 @@
+# pcre
+
+A library that implements Perl 5-style regular expressions
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/percona-xtrabackup/README.md
+++ b/percona-xtrabackup/README.md
@@ -1,0 +1,15 @@
+# percona-xtrabackup
+
+Percona xtrabackup utilities
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,0 +1,13 @@
+# perl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/phantomjs/README.md
+++ b/phantomjs/README.md
@@ -1,0 +1,13 @@
+# phantomjs
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,15 @@
+# php
+
+PHP is a popular general-purpose scripting language that is especially suited to web development.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/php5/README.md
+++ b/php5/README.md
@@ -1,0 +1,15 @@
+# php5
+
+PHP is a popular general-purpose scripting language that is especially suited to web development.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pixman/README.md
+++ b/pixman/README.md
@@ -1,0 +1,15 @@
+# pixman
+
+A low-level software library for pixel manipulation
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pkg-config/README.md
+++ b/pkg-config/README.md
@@ -1,0 +1,13 @@
+# pkg-config
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ponysay/README.md
+++ b/ponysay/README.md
@@ -1,0 +1,15 @@
+# ponysay
+
+A cowsay reimplemention for ponies
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/popt/README.md
+++ b/popt/README.md
@@ -1,0 +1,13 @@
+# popt
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,0 +1,15 @@
+# powershell
+
+PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/procps-ng/README.md
+++ b/procps-ng/README.md
@@ -1,0 +1,13 @@
+# procps-ng
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/proj/README.md
+++ b/proj/README.md
@@ -1,0 +1,15 @@
+# proj
+
+Cartographic Projections Library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/protobuf-c/README.md
+++ b/protobuf-c/README.md
@@ -1,0 +1,15 @@
+# protobuf-c
+
+Protocol Buffers implementation in C
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/protobuf-cpp/README.md
+++ b/protobuf-cpp/README.md
@@ -1,0 +1,15 @@
+# protobuf-cpp
+
+Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/protobuf-rust/README.md
+++ b/protobuf-rust/README.md
@@ -1,0 +1,13 @@
+# protobuf-rust
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -1,0 +1,13 @@
+# protobuf
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/psmisc/README.md
+++ b/psmisc/README.md
@@ -1,0 +1,13 @@
+# psmisc
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/pv/README.md
+++ b/pv/README.md
@@ -1,0 +1,15 @@
+# pv
+
+Pipe Viewer - is a terminal-based tool for monitoring the progress of data through a pipeline.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,15 @@
+# python
+
+Python is a programming language that lets you work quickly   and integrate systems more effectively.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/python2/README.md
+++ b/python2/README.md
@@ -1,0 +1,16 @@
+# python2
+
+Python is a programming language that lets you work quickly
+  and integrate systems more effectively.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -1,0 +1,15 @@
+# qemu
+
+QEMU is a generic and open source machine emulator and virtualizer.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rabbitmqadmin/README.md
+++ b/rabbitmqadmin/README.md
@@ -1,0 +1,15 @@
+# rabbitmqadmin
+
+Open source multi-protocol messaging broker (Administration CLI)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/raml2html/README.md
+++ b/raml2html/README.md
@@ -1,0 +1,15 @@
+# raml2html
+
+RAML to HTML documentation generator.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/re2c/README.md
+++ b/re2c/README.md
@@ -1,0 +1,15 @@
+# re2c
+
+re2c is a lexer generator for C/C++.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/readline/README.md
+++ b/readline/README.md
@@ -1,0 +1,13 @@
+# readline
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rebar/README.md
+++ b/rebar/README.md
@@ -1,0 +1,15 @@
+# rebar
+
+rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rebar3/README.md
+++ b/rebar3/README.md
@@ -1,0 +1,13 @@
+# rebar3
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/recordproto/README.md
+++ b/recordproto/README.md
@@ -1,0 +1,15 @@
+# recordproto
+
+X.Org Protocol Headers: recordproto
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/relx/README.md
+++ b/relx/README.md
@@ -1,0 +1,13 @@
+# relx
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/renderproto/README.md
+++ b/renderproto/README.md
@@ -1,0 +1,15 @@
+# renderproto
+
+X11 Render extension wire protocol
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ripgrep/README.md
+++ b/ripgrep/README.md
@@ -1,0 +1,15 @@
+# ripgrep
+
+ripgrep combines the usability of The Silver Searcher with the raw speed of grep.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rlwrap/README.md
+++ b/rlwrap/README.md
@@ -1,0 +1,15 @@
+# rlwrap
+
+A readline wrapper
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,15 @@
+# rpm
+
+RPM Package Manager
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rq/README.md
+++ b/rq/README.md
@@ -1,0 +1,15 @@
+# rq
+
+Record Query - A tool for doing record analysis and transformation
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rsync/README.md
+++ b/rsync/README.md
@@ -1,0 +1,15 @@
+# rsync
+
+An open source utility that provides fast incremental file transfer
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,15 @@
+# ruby
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby22/README.md
+++ b/ruby22/README.md
@@ -1,0 +1,15 @@
+# ruby22
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby23/README.md
+++ b/ruby23/README.md
@@ -1,0 +1,15 @@
+# ruby23
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby24/README.md
+++ b/ruby24/README.md
@@ -1,0 +1,15 @@
+# ruby24
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby25/README.md
+++ b/ruby25/README.md
@@ -1,0 +1,15 @@
+# ruby25
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/runit/README.md
+++ b/runit/README.md
@@ -1,0 +1,13 @@
+# runit
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rust-nightly/README.md
+++ b/rust-nightly/README.md
@@ -1,0 +1,15 @@
+# rust-nightly
+
+Safe, concurrent, practical language
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,15 @@
+# rust
+
+Safe, concurrent, practical language
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sassc/README.md
+++ b/sassc/README.md
@@ -1,0 +1,15 @@
+# sassc
+
+libsass command line driver
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/scaffolding-base/README.md
+++ b/scaffolding-base/README.md
@@ -1,0 +1,13 @@
+# scaffolding-base
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/scons/README.md
+++ b/scons/README.md
@@ -1,0 +1,15 @@
+# scons
+
+Substitute for classic 'make' tool with autoconf/automake functionality
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/scowl/README.md
+++ b/scowl/README.md
@@ -1,0 +1,15 @@
+# scowl
+
+Spell Checking Oriented Word Lists (SCOWL)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sed/README.md
+++ b/sed/README.md
@@ -1,0 +1,13 @@
+# sed
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/serf/README.md
+++ b/serf/README.md
@@ -1,0 +1,15 @@
+# serf
+
+A high performance C-based HTTP client library built upon the Apache Portable Runtime (APR) library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/shadow/README.md
+++ b/shadow/README.md
@@ -1,0 +1,15 @@
+# shadow
+
+Password and account management tool suite
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/shared-mime-info/README.md
+++ b/shared-mime-info/README.md
@@ -1,0 +1,15 @@
+# shared-mime-info
+
+The shared-mime-info package contains the core database of common types and the update-mime-database command used to extend it
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/snappy/README.md
+++ b/snappy/README.md
@@ -1,0 +1,15 @@
+# snappy
+
+A fast compressor/decompressor http://google.github.io/snappy/
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sqitch/README.md
+++ b/sqitch/README.md
@@ -1,0 +1,15 @@
+# sqitch
+
+Sqitch is a database change management application.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -1,0 +1,15 @@
+# sqlite
+
+A software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/strace/README.md
+++ b/strace/README.md
@@ -1,0 +1,15 @@
+# strace
+
+strace is a system call tracer for Linux
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/stringencoders/README.md
+++ b/stringencoders/README.md
@@ -1,0 +1,15 @@
+# stringencoders
+
+Fast c-string transformations
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/subversion/README.md
+++ b/subversion/README.md
@@ -1,0 +1,15 @@
+# subversion
+
+Enterprise-class centralized version control for the masses
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sudo/README.md
+++ b/sudo/README.md
@@ -1,0 +1,15 @@
+# sudo
+
+Execute a command as another user
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/swig/README.md
+++ b/swig/README.md
@@ -1,0 +1,15 @@
+# swig
+
+Generate scripting interfaces to C/C++ code
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/sysstat/README.md
+++ b/sysstat/README.md
@@ -1,0 +1,15 @@
+# sysstat
+
+Sysstat and the utilities it provides: iostat, mpstat, pidstat, sar, sa1, sa2 and sadf
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,15 @@
+# systemd
+
+systemd is an init system used in Linux distributions to bootstrap the user space. Subsequently to booting, it is used to manage system processes.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tar/README.md
+++ b/tar/README.md
@@ -1,0 +1,15 @@
+# tar
+
+GNU Tar provides the ability to create tar archives, as well as various other kinds of manipulation.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tcl/README.md
+++ b/tcl/README.md
@@ -1,0 +1,15 @@
+# tcl
+
+Tool Command Language -- A dynamic programming language.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tcpdump/README.md
+++ b/tcpdump/README.md
@@ -1,0 +1,15 @@
+# tcpdump
+
+A powerful command-line packet analyzer.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,15 @@
+# terraform
+
+Terraform is a tool for building, changing, and combining infrastructure safely and efficiently
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/texinfo/README.md
+++ b/texinfo/README.md
@@ -1,0 +1,13 @@
+# texinfo
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -1,0 +1,15 @@
+# tmux
+
+A terminal multiplexer
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tomcat-native/README.md
+++ b/tomcat-native/README.md
@@ -1,0 +1,15 @@
+# tomcat-native
+
+The Apache Tomcat Native Library is an optional component for use with Apache Tomcat that allows Tomcat to use certain native resources for performance, compatibility, etc.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ttyrec/README.md
+++ b/ttyrec/README.md
@@ -1,0 +1,13 @@
+# ttyrec
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/tzdata/README.md
+++ b/tzdata/README.md
@@ -1,0 +1,15 @@
+# tzdata
+
+Sources for time zone and daylight saving time data
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/unibilium/README.md
+++ b/unibilium/README.md
@@ -1,0 +1,15 @@
+# unibilium
+
+A terminfo parsing library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/unzip/README.md
+++ b/unzip/README.md
@@ -1,0 +1,15 @@
+# unzip
+
+UnZip is an extraction utility for archives compressed in .zip format (also called 'zipfiles').
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/userspace-rcu/README.md
+++ b/userspace-rcu/README.md
@@ -1,0 +1,17 @@
+# userspace-rcu
+
+liburcu is a LGPLv2.1 userspace RCU (read-copy-update) library.
+  This data synchronization library provides read-side access which scales
+  linearly with the number of cores.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/util-linux/README.md
+++ b/util-linux/README.md
@@ -1,0 +1,15 @@
+# util-linux
+
+Miscellaneous system utilities for Linux
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/util-macros/README.md
+++ b/util-macros/README.md
@@ -1,0 +1,15 @@
+# util-macros
+
+X.Org X11 Autotools macros
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/valgrind/README.md
+++ b/valgrind/README.md
@@ -1,0 +1,15 @@
+# valgrind
+
+An instrumentation framework for building dynamic analysis tools
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/vde2/README.md
+++ b/vde2/README.md
@@ -1,0 +1,15 @@
+# vde2
+
+VDE is an ethernet compliant virtual network that can be spawned over a set of physical computer over the Internet.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/vim/README.md
+++ b/vim/README.md
@@ -1,0 +1,15 @@
+# vim
+
+Vim is a greatly improved version of the good old UNIX editor Vi
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/virtualenv/README.md
+++ b/virtualenv/README.md
@@ -1,0 +1,15 @@
+# virtualenv
+
+virtualenv is a tool to create isolated Python environments. This version is for python2. For python3 use the built-in 'pyvenv'
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/vmtouch/README.md
+++ b/vmtouch/README.md
@@ -1,0 +1,15 @@
+# vmtouch
+
+vmtouch is a tool for learning about and controlling the file system cache of unix and unix-like systems
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/wget-static/README.md
+++ b/wget-static/README.md
@@ -1,0 +1,15 @@
+# wget-static
+
+GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS the most widely-used Internet protocols.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/wget/README.md
+++ b/wget/README.md
@@ -1,0 +1,15 @@
+# wget
+
+GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS the most widely-used Internet protocols.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/which/README.md
+++ b/which/README.md
@@ -1,0 +1,13 @@
+# which
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/wrk/README.md
+++ b/wrk/README.md
@@ -1,0 +1,15 @@
+# wrk
+
+Modern HTTP benchmarking tool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xcb-proto/README.md
+++ b/xcb-proto/README.md
@@ -1,0 +1,15 @@
+# xcb-proto
+
+X11 client library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xextproto/README.md
+++ b/xextproto/README.md
@@ -1,0 +1,15 @@
+# xextproto
+
+X11 wire protocol extensions
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xeyes/README.md
+++ b/xeyes/README.md
@@ -1,0 +1,15 @@
+# xeyes
+
+xeyes
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xlib/README.md
+++ b/xlib/README.md
@@ -1,0 +1,15 @@
+# xlib
+
+X11 protocol client library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xproto/README.md
+++ b/xproto/README.md
@@ -1,0 +1,15 @@
+# xproto
+
+X11 wire protocol and auxillary headers
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xtrans/README.md
+++ b/xtrans/README.md
@@ -1,0 +1,15 @@
+# xtrans
+
+X11 transport library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xz-musl/README.md
+++ b/xz-musl/README.md
@@ -1,0 +1,13 @@
+# xz-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/xz/README.md
+++ b/xz/README.md
@@ -1,0 +1,13 @@
+# xz
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,0 +1,15 @@
+# yarn
+
+Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don’t ever have to worry.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/yasm/README.md
+++ b/yasm/README.md
@@ -1,0 +1,15 @@
+# yasm
+
+Yasm is a complete rewrite of the NASM assembler
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zeromq/README.md
+++ b/zeromq/README.md
@@ -1,0 +1,15 @@
+# zeromq
+
+ZeroMQ core engine in C++, implements ZMTP/3.0
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zip/README.md
+++ b/zip/README.md
@@ -1,0 +1,13 @@
+# zip
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zlib-musl/README.md
+++ b/zlib-musl/README.md
@@ -1,0 +1,13 @@
+# zlib-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zlib/README.md
+++ b/zlib/README.md
@@ -1,0 +1,13 @@
+# zlib
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -1,0 +1,15 @@
+# zsh
+
+Zsh is a shell designed for interactive use, although it is also a powerful scripting language.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/zstd/README.md
+++ b/zstd/README.md
@@ -1,0 +1,15 @@
+# zstd
+
+Zstandard is a real-time compression algorithm, providing high compression ratios. It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*


### PR DESCRIPTION
These are autogenerated, taking information from `pkg_description`,
where available.

Usage instructions remain a TODO, since that's not something that's
easily automatable. This'll still save a lot of typing.
