### PR TITLE
[ninja] bump to 1.8.2 and add do_check

### DIFF
--- a/ninja/README.md
+++ b/ninja/README.md
@@ -12,4 +12,4 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+To have `ninja` in your `PATH` just add `core/ninja` to `pkg_build_deps`.

--- a/ninja/plan.sh
+++ b/ninja/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ninja
 pkg_origin=core
-pkg_version=1.7.2
+pkg_version=1.8.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url=https://ninja-build.org/
 pkg_description="A small build system with a focus on speed"
 pkg_licenses=('Apache-2.0')
 pkg_source=https://github.com/ninja-build/${pkg_name}/archive/v${pkg_version}.tar.gz
-pkg_shasum=2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9
+pkg_shasum=86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/gcc core/python2 core/re2c)
 pkg_bin_dirs=(bin)
@@ -18,4 +18,10 @@ do_build() {
 do_install() {
   mkdir -p "$pkg_prefix/bin/"
   cp ninja "$pkg_prefix/bin/"
+}
+
+do_check() {
+  ./ninja all
+  ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
+  python ./misc/ninja_syntax_test.py
 }


### PR DESCRIPTION
The `do_check` copies what the source had placed here: https://github.com/ninja-build/ninja/blob/master/.travis.yml#L6

Signed-off-by: Ben Dang <me@bdang.it>