### PR TITLE
[go] bump 1.10 -> 1.10.1

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.10
+pkg_version=1.10.1
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=f3de49289405fda5fd1483a8fe6bd2fa5469e005fd567df64485c4fa000c7f24
+pkg_shasum=589449ff6c3ccbff1d391d4e7ab5bb5d5643a5a41a04c99315e55c16bbf73ddc
 pkg_dirname=go
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)


### PR DESCRIPTION
Minor revisions: https://golang.org/doc/devel/release.html#go1.10.minor

> go1.10.1 (released 2018/03/28) includes fixes to the compiler, runtime,
> and the archive/zip, crypto/tls, crypto/x509, encoding/json, net, net/http,
> and net/http/pprof packages. See the Go 1.10.1 milestone on our issue tracker
> for details.

Done only minimal smoke tests: `build go` and
```
[4][default:/src:2]# /hab/pkgs/srenatus/go/1.10.1/20180403072002/bin/go version
go version go1.10.1 linux/amd64
```