### PR TITLE
[glib] Fixes python requirement at runtime

### DIFF
--- a/glib/plan.sh
+++ b/glib/plan.sh
@@ -20,6 +20,7 @@ pkg_deps=(
   core/libffi
   core/libiconv
   core/pcre
+  core/python
   core/util-linux
   core/zlib
 )
@@ -33,7 +34,6 @@ pkg_build_deps=(
   core/make
   core/perl
   core/pkg-config
-  core/python
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Python is used in `${pkg_prefix}/bin/gdbus-codegen` as an interpreter. As it was rightly put by the build, we never saw it. Until I tried to build gtk3 ;)

Signed-off-by: Romain Sertelon <romain@sertelon.fr>