### PR TITLE
[wal-e] Unpin Python dependency

### DIFF
--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -7,7 +7,7 @@ pkg_description="Continuous Archiving for Postgres"
 pkg_upstream_url="https://github.com/wal-e/wal-e"
 pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
 pkg_shasum=f3bd4171917656fef3829c9d993684d26c86eef0038ac3da7f12bae9122c6fc3
-pkg_deps=(core/envdir core/lzop core/pv core/python/3.5.2)
+pkg_deps=(core/envdir core/lzop core/pv core/python)
 pkg_bin_dirs=(bin)
 
 do_download() {


### PR DESCRIPTION
:warning: WARNING ⚠️ 
This _does_ build a package, but `wal-e` 1.0.2 does not explicitly test against Python 3.6.x (see https://github.com/wal-e/wal-e/blob/v1.0.2/tox.ini). I'm currently figuring out how to further validate this. An alternative is to update to `wal-e` 1.1.0, which _does_ test against Python 3.6.x (see https://github.com/wal-e/wal-e/blob/v1.1/tox.ini)

Input from wal-e experts appreciated!
:warning:

Previously, the version of Python for `wal-e` was pinned to
3.5.2. Current `core/envdir`, however, depends on version 3.6.3,
creating a conflict.

Removing the explicit version pin allows us to use 3.6.3, which allows
`wal-e` to build again.

Signed-off-by: Christopher Maier <cmaier@chef.io>