### PR TITLE
[wal-e] Update to 1.1.0

### DIFF
--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=wal-e
-pkg_version=1.0.2
+pkg_version=1.1.0
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('wal-e license')
 pkg_description="Continuous Archiving for Postgres"
 pkg_upstream_url="https://github.com/wal-e/wal-e"
 pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
-pkg_shasum=f3bd4171917656fef3829c9d993684d26c86eef0038ac3da7f12bae9122c6fc3
-pkg_deps=(core/envdir core/lzop core/pv core/python/3.5.2)
+pkg_shasum=d3478e6eb4bfe00ac696af3e7ded4a91a0a2db6f9aa1a51ce780e43e4c12d6c7
+pkg_deps=(core/envdir core/lzop core/pv core/python)
 pkg_bin_dirs=(bin)
 
 do_download() {


### PR DESCRIPTION
Previously, the version of Python for `wal-e` was pinned to
3.5.2. Current `core/envdir`, however, depends on version 3.6.3,
creating a conflict.

Version 1.0.2 of wal-e does not appear to be officially supported on
Python 3.6, but the current 1.1.0 version is. Thus, we update to 1.1.0
and remove the version pin on `core/python` to march bravely forward
into the future.

Signed-off-by: Christopher Maier <cmaier@chef.io>