### PR TITLE
New core-plan 'grpcurl' 

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -324,6 +324,8 @@ plan_path = "graphviz"
 plan_path = "grep"
 [groff]
 plan_path = "groff"
+[grpcurl]
+plan_path = "grpcurl"
 [grub]
 plan_path = "grub"
 [gsl]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -118,6 +118,7 @@ consul @defilan
 elasticsearch @joshbrand @predominant
 gdk-pixbuf @rsertelon
 glib @rsertelon
+grpcurl @afiune
 gtk2 @rsertelon
 harfbuzz @rsertelon
 jdk7 @predominant @rsertelon

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -115,12 +115,20 @@ artifactory-pro @defilan
 atk @rsertelon
 cairo @rsertelon
 consul @defilan
+dep @afiune @nellshamrell
+dotnet-47-dev-pack @mwrock
+dotnet-core-lts @mwrock
+dotnet-core-sdk-lts @mwrock
+dotnet-core-sdk-preview @mwrock
+dotnet-core-sdkdotnet-core @mwrock
 elasticsearch @joshbrand @predominant
 gdk-pixbuf @rsertelon
 glib @rsertelon
+go @afiune @nellshamrell
 grpcurl @afiune
 gtk2 @rsertelon
 harfbuzz @rsertelon
+innounp @mwrock
 jdk7 @predominant @rsertelon
 jdk8 @predominant @rsertelon
 jdk9 @predominant @rsertelon
@@ -133,22 +141,14 @@ logstash @joshbrand @predominant
 libtalloc @defilan
 monit @rsertelon
 mosquitto @rsertelon
+mssql @mwrock
 nmap @defilan
+nuget @mwrock
 pango @rsertelon
+protobuf-cpp @afiune
 rabbitmqadmin @predominant
 redis @irvingpop
 shared-mime-info @rsertelon
-wrk @afiune
-protobuf-cpp @afiune
-go @afiune @nellshamrell
-dep @afiune @nellshamrell
-dotnet-47-dev-pack @mwrock
-dotnet-core-lts @mwrock
-dotnet-core-sdk-lts @mwrock
-dotnet-core-sdk-preview @mwrock
-dotnet-core-sdkdotnet-core @mwrock
-innounp @mwrock
-mssql @mwrock
-nuget @mwrock
 vault @defilan
 visual-build-tools-2017 @mwrock
+wrk @afiune

--- a/grpcurl/README.md
+++ b/grpcurl/README.md
@@ -1,0 +1,16 @@
+# grpcurl
+
+Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
+
+## Maintainers
+
+The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+The usage of this tool can be found [here](https://github.com/fullstorydev/grpcurl#example-usage)
+

--- a/grpcurl/README.md
+++ b/grpcurl/README.md
@@ -14,3 +14,4 @@ Binary package
 
 The usage of this tool can be found [here](https://github.com/fullstorydev/grpcurl#example-usage)
 
+

--- a/grpcurl/README.md
+++ b/grpcurl/README.md
@@ -13,5 +13,3 @@ Binary package
 ## Usage
 
 The usage of this tool can be found [here](https://github.com/fullstorydev/grpcurl#example-usage)
-
-

--- a/grpcurl/plan.sh
+++ b/grpcurl/plan.sh
@@ -1,0 +1,10 @@
+pkg_name=grpcurl
+pkg_origin=core
+pkg_description="Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/fullstorydev/grpcurl/cmd/grpcurl"
+pkg_upstream_url="https://github.com/fullstorydev/grpcurl"
+pkg_version="0.1.0"
+pkg_license=('custom')
+pkg_bin_dirs=(bin)
+pkg_scaffolding=core/scaffolding-go


### PR DESCRIPTION
The `grpcurl` binary is just like cURL, but for gRPC. A Command-line tool for interacting with gRPC servers. 

Code base lives at https://github.com/fullstorydev/grpcurl

Extra: Ordered `CODEOWNERS` packages alphabetically
