### PR TITLE
adding a dsc-core plan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -121,6 +121,7 @@ dotnet-core-lts @mwrock
 dotnet-core-sdk-lts @mwrock
 dotnet-core-sdk-preview @mwrock
 dotnet-core-sdkdotnet-core @mwrock
+dsc-core @mwrock
 elasticsearch @joshbrand @predominant
 gdk-pixbuf @rsertelon
 glib @rsertelon

--- a/dsc-core/DSCCore.psd1
+++ b/dsc-core/DSCCore.psd1
@@ -1,0 +1,11 @@
+@{
+    RootModule = 'DSCCore.psm1'
+    ModuleVersion = '0.1.0'
+    GUID = '56ecd704-4603-4790-a0c9-99f057027202'
+    Author = 'The Habitat Maintainers'
+    CompanyName = 'Chef Software Inc.'
+    Copyright = 'Copyright (c) 2018 Chef Software Inc. and/or applicable contributors'
+    Description = 'Module to apply DSC configurations in Powershell Core.'
+    PowerShellVersion = '6.0.0'
+    CmdletsToExport = 'Start-DscCore'
+}

--- a/dsc-core/DSCCore.psm1
+++ b/dsc-core/DSCCore.psm1
@@ -1,0 +1,60 @@
+<#
+    .SYNOPSIS
+        Applies a DSC configuration on Powershell Core
+
+    .PARAMETER Path
+        The path to the file containing the DSC configuration
+
+    .PARAMETER ConfigFunction
+        The function name of the configuration
+
+#>
+function Start-DscCore {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ConfigFunction
+    )
+
+    # We disable progress stream output since that tends to mangle the
+    # Supervisor output
+    $currentProgPref = $global:ProgressPreference
+    $global:ProgressPreference = "SilentlyContinue"
+
+    Write-Output "Compiling DSC mof for $ConfigFunction ..."
+
+    # Because the DSC configuration will be applied by the Local Configuration
+    # Manager in the context of a Windows Powershell session (not the same
+    # Powershell Core session of the hook), we want to compile the configuration
+    # in that same context. This is mainly som that Powershell Modules imported
+    # are discovered from the same PSModulePath. To do this we compile the mof
+    # in a local Windows Powershell session.
+    $mof = Invoke-Command -ComputerName localhost -EnableNetworkAccess -ArgumentList $Path, $ConfigFunction {
+        param ($confPath, $func)
+        $global:WarningPreference = "SilentlyContinue"
+        . $confPath
+        $tempDir = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+        & $func -OutputPath $tempDir
+    }
+
+    $configurationData = Get-Content $mof.FullName -AsByteStream -ReadCount 0
+    $totalSize = [System.BitConverter]::GetBytes($configurationData.Length + 4)
+    $configurationData = $totalSize + $configurationData
+
+    Write-Output "Applying DSC configuration for $Path ..."
+    Invoke-CimMethod    -ComputerName localhost `
+                        -Namespace "root/Microsoft/Windows/DesiredStateConfiguration" `
+                        -ClassName "MSFT_DSCLocalConfigurationManager" `
+                        -MethodName "SendConfigurationApply" `
+                        -Arguments @{ConfigurationData = $configurationData; Force = $true} `
+                        -ErrorAction Stop | Out-Null
+
+    $global:ProgressPreference = $currentProgPref
+    Remove-Item $mof.Directory -Recurse -Force | Out-Null
+}

--- a/dsc-core/README.md
+++ b/dsc-core/README.md
@@ -1,0 +1,67 @@
+# dsc-core
+
+The `dsc-core` plan applies Powershell DSC configurations on Powershell Core. Typically on Windows Powershell, one uses `Start-DscConfiguration` to apply a compiled DSC configuration mof. However, Powershell Core does not expose the `Start-DscConfiguration` cmdlet. It is possible to call a WMI method to invoke the Local Configuration manager but it incurs a bit of ceremony since it expects the `ConfigurationData` as a byte stream. this plan encapsulates the compilation and execution of a configuration into a simple "one liner."
+
+The plan puts its `psd1` and `psm1` files in the `PSModulePath` so that its function `Start-DscCore` is automatically discoverable.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+
+## Type of Package
+
+A Binary package containing a Powershell Module
+
+## Usage
+
+Note: This package can only be used if the Habitat Supervisor node has [WMF 5](https://www.microsoft.com/en-us/download/details.aspx?id=50395) installed. Otherwise, the DSC invocations will fail.
+
+Assuming you have the following configuration in a file `firewall.ps1` in your plan's `config` directory:
+
+```
+Configuration NewFirewallRule
+{
+    Import-DscResource -Module xNetworking
+    Node 'localhost' {
+        xFirewall "ag-endpoint"
+        {
+            Name   = "ag-endpoint"
+            DisplayName = "ag-endpoint"
+            Action = "Allow"
+            Direction = "InBound"
+            LocalPort = ("{{cfg.endpoint_port}}")
+            Protocol = "TCP"
+            Ensure = "Present"
+            Enabled  = "True"
+        }
+    }
+}
+```
+
+Your `hook` can apply this configuration using:
+
+```
+Start-DscCore (Join-Path {{pkg.svc_config_path}} firewall.ps1) NewFirewallRule
+```
+
+Note that the above configuration imports `xNetworking`. You will need to ensure that this module is installed prior to calling `Start-DscCore`. Because the configuration is applied by the Local Configuration Manager, it is not run inside of the current Powershell Core session but is run inside of a Windows Powershell session. Therefore you must install the `xNetworking` module inside of Windows Powershell. The easiest way to do this is to "remote" to a local `PSSession` and then run the install.
+
+```
+Invoke-Command -ComputerName localhost -EnableNetworkAccess {
+    if(!(Get-Module xNetworking -ListAvailable)) {
+        Install-Module xNetworking -Force | Out-Null
+    }
+}
+```
+
+### Problems using in a local Windows Studio
+
+The `PSModulePath` in a local Windows studio (one started with `hab studio enter -w`) will get assigned the wrong package path and thus simply calling `Start-DscCore` will not automatically import this module.
+
+You can work around this by explicitly importing the module before using the command:
+
+```
+Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
+Start-DscCore (Join-Path {{pkg.svc_config_path}} firewall.ps1) NewFirewallRule
+```

--- a/dsc-core/plan.ps1
+++ b/dsc-core/plan.ps1
@@ -1,0 +1,16 @@
+$pkg_name="dsc-core"
+$pkg_origin="core"
+$pkg_version="0.1.0"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@("Apache-2.0")
+$pkg_description="Compiles and applies DSC configurations in Powershell Core"
+
+function Invoke-SetupEnvironment {
+    Push-RuntimeEnv "PSModulePath" "\hab\pkgs\$pkg_origin\$pkg_name\$pkg_version\$pkg_release\Modules"
+}
+
+function Invoke-Install {
+    mkdir "$pkg_prefix/Modules/DSCCore"
+    Copy-Item "$PLAN_CONTEXT/DSCCore.psm1" "$pkg_prefix/Modules/DSCCore"
+    Copy-Item "$PLAN_CONTEXT/DSCCore.psd1" "$pkg_prefix/Modules/DSCCore"
+}


### PR DESCRIPTION
We have several example windows service plans that take advantage of DSC for initial setup. Applying a DSC configuration in a hook requires extra ceremony because they run in Powershell Core which lacks native cmdlets for applying dsc. This package wraps up that ceremony so that consuming plan authors can just use a single command to apply their DSC configs.

Signed-off-by: mwrock <matt@mattwrock.com>