### PR TITLE
[gperftools] fix tests

### DIFF
--- a/gperftools/plan.sh
+++ b/gperftools/plan.sh
@@ -7,16 +7,16 @@ pkg_license=('BSDv3')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/gperftools/gperftools/releases/download/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_shasum=2f8ec5129701e6c68c75009db5303761b65b51867c63e49ec19b946930cfef1f
-pkg_deps=(core/glibc core/graphviz core/coreutils core/grep core/perl core/binutils)
+pkg_deps=(core/glibc core/gcc-libs core/graphviz core/coreutils core/grep core/perl core/binutils)
 pkg_build_deps=(core/gcc core/make core/automake)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
-do_install() {
-  do_default_install
+do_build() {
+  do_default_build
 
-  fix_interpreter "$pkg_prefix/bin/pprof" core/coreutils bin/env
+  fix_interpreter "src/pprof" core/coreutils bin/env
   sed -e "s#\"objdump\",#\"$(pkg_path_for core/binutils)/bin/objdump\",#" \
       -e "s#\"nm\",#\"$(pkg_path_for core/binutils)/bin/nm\",#" \
       -e "s#\"addr2line\",#\"$(pkg_path_for core/binutils)/bin/addr2line\",#" \
@@ -24,5 +24,9 @@ do_install() {
       -e "s#ShellEscape(\"grep\"#ShellEscape(\"$(pkg_path_for core/grep)/bin/grep\"#" \
       -e "s#ShellEscape(\"tail\"#ShellEscape(\"$(pkg_path_for core/coreutils)/bin/tail\"#" \
       -e "s#(\"dot\")#(\"$(pkg_path_for core/graphviz)/bin/dot\")#" \
-      -i "$pkg_prefix/bin/pprof"
+      -i "src/pprof"
+}
+
+do_check() {
+  make check
 }


### PR DESCRIPTION
This change allows `do_check` to run correctly.  Because of this change, it highlighted a few runtime errors that also got corrected.  Thanks to @rsertelon for pointing out that I was using the wrong `make` target. 

Signed-off-by: Ben Dang <me@bdang.it>