### PR TITLE
[zeromq] bump zeromq to 4.2.5

### DIFF
--- a/zeromq/README.md
+++ b/zeromq/README.md
@@ -1,6 +1,6 @@
 # zeromq
 
-ZeroMQ core engine in C++, implements ZMTP/3.0
+ZeroMQ core engine in C++, implements ZMTP/3.1
 
 ## Maintainers
 
@@ -12,4 +12,4 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Include `core/zeromq` in your `plan.sh` so that your apps can compile against the `libzmq`.

--- a/zeromq/plan.sh
+++ b/zeromq/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=zeromq
 pkg_origin=core
-pkg_version=4.2.2
+pkg_version=4.2.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_description="ZeroMQ core engine in C++, implements ZMTP/3.0"
+pkg_description="ZeroMQ core engine in C++, implements ZMTP/3.1"
 pkg_upstream_url=http://zeromq.org
 pkg_license=('LGPL')
 pkg_source=https://github.com/zeromq/libzmq/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b
+pkg_shasum=cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f
 pkg_deps=(core/glibc core/gcc-libs core/libsodium)
-pkg_build_deps=(core/gcc core/coreutils core/make core/pkg-config core/patchelf)
+pkg_build_deps=(core/gcc core/diffutils core/coreutils core/make core/pkg-config core/patchelf core/busybox-static core/shadow)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
@@ -16,4 +16,16 @@ do_install() {
   do_default_install
     # shellcheck disable=SC2038
   find "$pkg_prefix/lib" -name "*.so" | xargs -I '%' patchelf --set-rpath "$LD_RUN_PATH" %
+}
+
+do_check() {
+  # Note: tests/test_filter_ipc.cpp:144 runs a test against a user in another group. When running
+  # `id`, it shows that the `root` user belongs to `dialout`.  However the test still fails.
+  # Therefore we must ensure the `root` user really is part of dialout group.
+  gpasswd -a root dialout
+
+  make check
+
+  # clean this up by going back to default
+  gpasswd -d root dialout
 }


### PR DESCRIPTION
Bump to [4.2.5](https://github.com/zeromq/libzmq/releases/tag/v4.2.5) and also add in a `do_check`.

Signed-off-by: Ben Dang <me@bdang.it>