### PR TITLE
[xlib] Fixes dependencies

### DIFF
--- a/xlib/README.md
+++ b/xlib/README.md
@@ -12,4 +12,7 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/xlib)

--- a/xlib/plan.sh
+++ b/xlib/plan.sh
@@ -9,18 +9,43 @@ pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/lib/${pkg_distname}-${pkg_version}.tar.bz2"
 pkg_shasum="4d3890db2ba225ba8c55ca63c6409c1ebb078a2806de59fb16342768ae63435d"
 pkg_dirname="${pkg_distname}-${pkg_version}"
-pkg_deps=(core/glibc
-          core/xproto
-	  core/xextproto
-	  core/xtrans
-          core/libxau
-          core/libxdmcp
-          core/libxcb)
-pkg_build_deps=(core/gcc core/make core/pkg-config core/diffutils core/libpthread-stubs core/inputproto core/kbproto)
+pkg_deps=(
+  core/glibc
+  core/libxau
+  core/libxcb
+  core/libxdmcp
+)
+pkg_build_deps=(
+  core/diffutils
+  core/file
+  core/gcc
+  core/inputproto
+  core/kbproto
+  core/libpthread-stubs
+  core/make
+  core/perl
+  core/pkg-config
+  core/util-macros
+  core/xextproto
+  core/xproto
+  core/xtrans
+)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)
 
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
 do_check() {
     make check
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
 }


### PR DESCRIPTION
`core/xproto` triggered a lot of rebuilds, which is not normal.

I tracked down how `core/xproto` was used, only `core/xlib` used it as a `pkg_deps`. This PR fixes that.

Signed-off-by: Romain Sertelon <romain@sertelon.fr>