### PR TITLE
[libxcb] Fixes dependencies

### DIFF
--- a/libxcb/README.md
+++ b/libxcb/README.md
@@ -12,4 +12,7 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/libxcb)

--- a/libxcb/plan.sh
+++ b/libxcb/plan.sh
@@ -7,9 +7,22 @@ pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/xcb/${pkg_name}-${pkg_version}.tar.bz2"
 pkg_shasum="4adfb1b7c67e99bc9c2ccb110b2f175686576d2f792c8a71b9c8b19014057b5b"
-pkg_deps=(core/glibc core/libxau core/libxdmcp core/inputproto)
-pkg_build_deps=(core/gcc core/make core/pkg-config core/diffutils core/file core/python2 core/libxslt
-                core/xproto core/xcb-proto core/libpthread-stubs core/util-macros)
+pkg_deps=(
+  core/glibc
+  core/libxau
+  core/libxdmcp
+)
+pkg_build_deps=(
+  core/diffutils
+  core/gcc
+  core/libpthread-stubs
+  core/make
+  core/pkg-config
+  core/python2
+  core/util-macros
+  core/xproto
+  core/xcb-proto
+)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)


### PR DESCRIPTION
`core/inputproto` triggered a lot of rebuilds, which is not normal.

I tracked down how `core/inputproto` was used, only `core/libxcb` used it as `pkg_deps`. This PR fixes that.

Signed-off-by: Romain Sertelon <romain@sertelon.fr>