### PR TITLE
WIP: Upgrade CMake to latest version and use system libs

### DIFF
--- a/RHash/plan.sh
+++ b/RHash/plan.sh
@@ -1,0 +1,24 @@
+pkg_origin=core
+pkg_name=RHash
+pkg_version="1.3.6"
+pkg_description="Great utility for computing hash sums"
+pkg_upstream_url="https://sf.net/p/rhash/"
+pkg_license=('MIT')
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_source="https://github.com/rhash/${pkg_name}/archive/v${pkg_version}.tar.gz"
+pkg_shasum=964df972b60569b5cb35ec989ced195ab8ea514fc46a74eab98e86569ffbcf92
+pkg_deps=(core/glibc core/gcc-libs core/openssl)
+pkg_build_deps=(core/gcc core/make core/which)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}" --extra-cflags="$CFLAGS" --extra-ldflags="$LDFLAGS"
+  make
+}
+
+do_install() {
+  make install
+  make -C librhash install-headers install-lib-shared install-so-link
+}

--- a/cmake/plan.sh
+++ b/cmake/plan.sh
@@ -1,25 +1,25 @@
 pkg_name=cmake
 pkg_origin=core
-_base_version=3.10
-pkg_version=${_base_version}.2
+_base_version=3.11
+pkg_version=${_base_version}.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('BSD-3-Clause')
 pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 pkg_upstream_url="https://cmake.org/"
 pkg_source="https://cmake.org/files/v${_base_version}/cmake-${pkg_version}.tar.gz"
-pkg_shasum=80d0faad4ab56de07aa21a7fc692c88c4ce6156d42b0579c6962004a70a3218b
+pkg_shasum=c313bee371d4d255be2b4e96fd59b11d58bc550a7c78c021444ae565709a656b
 pkg_deps=(
   core/glibc
   core/gcc-libs
+  core/curl
+  core/libarchive
+  edavis/libuv
 )
 pkg_build_deps=(
   core/coreutils
   core/diffutils
   core/make
   core/gcc
-  core/curl
-  core/zlib
-  core/bzip2
 )
 
 pkg_lib_dirs=(lib)
@@ -27,8 +27,12 @@ pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
 do_build() {
-  ./bootstrap
-  ./configure --prefix="${pkg_prefix}"
+  ./bootstrap \
+    --system-libs \
+    --prefix="${pkg_prefix}" \
+    --no-system-jsoncpp \
+    --no-system-librhash \
+    --parallel="$(nproc)"
   make -j "$(nproc)"
 }
 

--- a/libuv/plan.sh
+++ b/libuv/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=libuv
 pkg_origin=core
-pkg_version="1.16.1"
+pkg_version="1.20.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="http://dist.${pkg_name}.org/dist/v${pkg_version}/${pkg_name}-v${pkg_version}.tar.gz"
 pkg_dirname="${pkg_name}-v${pkg_version}"
-pkg_shasum="d64aafa9ad969391248a2dc7ef14b7da128be0b3f2d6ca5c18e13a93d64c785d"
+pkg_shasum="d19334d8db40cc92ace4b77bd0317d1c878e1a321afa2b7974f084dd3ed8b5e6"
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/autoconf


### PR DESCRIPTION
Currently CMake relies on an internal version of curl and friends, which doesn't work in habitat.

For this to work, I believe we need an upgraded version of GCC.

Signed-off-by: Elliott Davis <elliott@excellent.io>