### PR TITLE
Revert "[scaffolding-go] separating build and run deps"

### DIFF
--- a/scaffolding-go/plan.sh
+++ b/scaffolding-go/plan.sh
@@ -7,10 +7,8 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/habitat-sh/core-plans"
 pkg_deps=(
-  core/go
-)
-pkg_build_deps=(
   ${pkg_deps[@]}
+  core/go
   core/git
   core/gcc
   core/make


### PR DESCRIPTION
Reverts habitat-sh/core-plans#1138

Unfortunately, this change caused plans that depended on the go scaffolding to break.  I tested this with core/dex, when it was pointing to this version of the plan (rather than the previous stable version), it broke with:

```
   dex: Layering buildtime environment on top of system environment
   dex: go get -d github.com/coreos/dex
/hab/cache/src/go/src/github.com/coreos/dex /src/dex
   dex: checking out v2.10.0
/src/dex/plan.sh: line 35: git: command not found
   dex: Build time: 0m2s
   dex: Exiting on error
```

I believe we need '${pkg_deps[@]}' under 'pkg_deps', rather than 'pkg_build_deps' for plans that depend upon git, etc being present in the go scaffolding.  While we could potentially change the plans depending on the go scaffolding to all require git, promoting this change to stable would be a breaking change, and one that I would prefer not to do at this time (especially as some of the habitat work around chef automate depends on the go scaffolding).