### PR TITLE
[gdb] Relax gcc options to compile with gcc7

### DIFF
--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -34,7 +34,7 @@ pkg_lib_dirs=(lib)
 
 do_prepare() {
   export CFLAGS="${CFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
-  export CXXFLAGS="${CXXFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
+  export CXXFLAGS="${CXXFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security -fpermissive "
   export CPPFLAGS="${CPPFLAGS} -Wdate-time"
   export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic-functions -Wl,-z,relro"
 }


### PR DESCRIPTION
This allows gdb to build fine in the latest base package refresh.

It builds fine with current base packages too, and can be merged today :)