### PR TITLE
[kubernetes] Fixes build with go >= 1.10

### DIFF
--- a/kubernetes/golang_detection.patch
+++ b/kubernetes/golang_detection.patch
@@ -1,0 +1,11 @@
+--- hack/lib/golang.sh	2018-04-14 14:13:55.209257922 +0000
++++ hack/lib/golang.sh	2018-04-14 14:15:05.272683732 +0000
+@@ -339,7 +339,7 @@
+   go_version=($(go version))
+   local minimum_go_version
+   minimum_go_version=go1.8.3
+-  if [[ "${go_version[2]}" < "${minimum_go_version}" && "${go_version[2]}" != "devel" ]]; then
++  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
+     kube::log::usage_from_stdin <<EOF
+ Detected go version: ${go_version[*]}.
+ Kubernetes requires ${minimum_go_version} or greater.

--- a/kubernetes/plan.sh
+++ b/kubernetes/plan.sh
@@ -16,6 +16,7 @@ pkg_build_deps=(
   core/gcc
   core/go
   core/diffutils
+  core/patch
   core/which
   core/rsync
 )
@@ -23,6 +24,10 @@ pkg_build_deps=(
 pkg_deps=(
   core/glibc
 )
+
+do_prepare() {
+  patch hack/lib/golang.sh "${PLAN_CONTEXT}/golang_detection.patch"
+}
 
 do_build() {
   make


### PR DESCRIPTION
If you try to build kubernetes today, it'll fail due to wrong check of go version (lexicographic sort FTW).

This PR addresses that.

Signed-off-by: Romain Sertelon <romain@sertelon.fr>