### PR TITLE
[elfutils] Update to 0.170

### DIFF
--- a/elfutils/plan.sh
+++ b/elfutils/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=elfutils
 pkg_origin=core
-pkg_version=0.166
+pkg_version=0.170
 pkg_license=('GPL-3.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="elfutils is a collection of various binary tools such as
   eu-objdump, eu-readelf, and other utilities that allow you to inspect and
   manipulate ELF files."
-pkg_upstream_url=https://fedorahosted.org/elfutils/
-pkg_source=https://fedorahosted.org/releases/e/l/$pkg_name/$pkg_version/$pkg_name-$pkg_version.tar.bz2
-pkg_shasum=3c056914c8a438b210be0d790463b960fc79d234c3f05ce707cbff80e94cba30
+pkg_upstream_url=https://sourceware.org/elfutils/
+pkg_source=https://sourceware.org/${pkg_name}/ftp/${pkg_version}/$pkg_name-$pkg_version.tar.bz2
+pkg_shasum=1f844775576b79bdc9f9c717a50058d08620323c1e935458223a12f249c9e066
 pkg_deps=(
   core/glibc
   core/zlib


### PR DESCRIPTION
This updates elfutils to latest version. Current version does not build in base package refresh (but I don't have the details anymore)

Signed-off-by: Romain Sertelon <romain@sertelon.fr>