### PR TITLE
[clingo] Update to 5.2.2

### DIFF
--- a/clingo/plan.sh
+++ b/clingo/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=clingo
 pkg_origin=core
 pkg_description="A grounder and solver for logic programs."
-pkg_upstream_url="https://potassco.org/"
-pkg_version="5.2.0"
+pkg_upstream_url="https://potassco.org/clingo"
+pkg_version="5.2.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/potassco/clingo/archive/v${pkg_version}.tar.gz"
-pkg_shasum="57d8979b0972a091e1921309ca9ba9c18dd0cf83afcfb1586a8c0bff54ed8b9b"
+pkg_shasum="da1ef8142e75c5a6f23c9403b90d4f40b9f862969ba71e2aaee9a257d058bfcf"
 pkg_deps=(core/gcc-libs core/glibc)
 pkg_build_deps=(core/doxygen core/cmake core/make core/gcc)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
This fixes clingo build in stage3 environment.

It should build without problem in current builder (not tested).

Signed-off-by: Romain Sertelon <romain@sertelon.fr>