### PR TITLE
[iproute2] Update to 4.16.0

### DIFF
--- a/iproute2/plan.sh
+++ b/iproute2/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=iproute2
 pkg_origin=core
-pkg_version=4.8.0
-pkg_source=https://www.kernel.org/pub/linux/utils/net/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
-pkg_shasum=a30959c8421bc8ef42719bed41d14e1d7cfdbad80d7d70c5c42ad31f2c2cb389
+pkg_version=4.16.0
+pkg_source="https://www.kernel.org/pub/linux/utils/net/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="0c5c24020fd7349fe25728c5edee9fb6a1bc8a38f08e23be5c57a6301e55ee0a"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Collection of utilities for controlling TCP/IP networking"
-pkg_upstream_url=https://wiki.linuxfoundation.org/networking/iproute2
+pkg_upstream_url="https://wiki.linuxfoundation.org/networking/iproute2"
 pkg_license=('GPL-2.0')
 pkg_bin_dirs=(sbin)
 pkg_lib_dirs=(lib)
@@ -19,15 +19,6 @@ pkg_build_deps=(
   core/pkg-config
 )
 pkg_deps=(core/glibc)
-
-do_prepare() {
-  # http://www.linuxfromscratch.org/lfs/view/development/chapter06/iproute2.html
-  sed -i /ARPD/d Makefile
-  sed -i 's/arpd.8//' man/man8/Makefile
-  rm doc/arpd.sgml
-
-  sed -i 's/m_ipt.o//' tc/Makefile
-}
 
 do_build() {
   SBINDIR="$pkg_prefix/sbin"


### PR DESCRIPTION
This fixes iproute2 build in stage3 environment.

It should build without problem in current builder (not tested).

Signed-off-by: Romain Sertelon <romain@sertelon.fr>