### PR TITLE
[curl-static-musl] Fixes package

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source ../curl/plan.sh
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.51.0
+pkg_version=7.54.1
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/


### PR DESCRIPTION
The package sources `core/curl` but curl was updated without this one. Thus it failed to build.

Signed-off-by: Romain Sertelon <romain@sertelon.fr>