### PR TITLE
[lynx] Allows build in base refresh

### DIFF
--- a/lynx/ncurses.patch
+++ b/lynx/ncurses.patch
@@ -1,0 +1,73 @@
+commit f0b064b47bfa046da941f5029cdc1b4c851553ce
+Author: Thomas E. Dickey <dickey@invisible-island.net>
+Date:   Sat Mar 18 21:44:28 2017 +0000
+
+    snapshot of project "lynx", label v2-8-9dev_11m
+
+diff --git a/src/LYCurses.c b/src/LYCurses.c
+index 6b839c2..63b73ec 100644
+--- a/src/LYCurses.c
++++ b/src/LYCurses.c
+@@ -1696,7 +1696,7 @@ void lynx_enable_mouse(int state)
+ void lynx_nl2crlf(int normal GCC_UNUSED)
+ {
+ #if defined(NCURSES_VERSION_PATCH) && defined(SET_TTY) && defined(TERMIOS) && defined(ONLCR)
+-    static TTY saved_tty;
++    static struct termios saved_tty;
+     static int did_save = FALSE;
+     static int waiting = FALSE;
+     static int can_fix = TRUE;
+@@ -1705,8 +1705,10 @@ void lynx_nl2crlf(int normal GCC_UNUSED)
+ 	if (cur_term == 0) {
+ 	    can_fix = FALSE;
+ 	} else {
+-	    saved_tty = cur_term->Nttyb;
++	    tcgetattr(fileno(stdout), &saved_tty);
+ 	    did_save = TRUE;
++	    if ((saved_tty.c_oflag & ONLCR))
++		can_fix = FALSE;
+ #if NCURSES_VERSION_PATCH < 20010529
+ 	    /* workaround for optimizer bug with nonl() */
+ 	    if ((tigetstr("cud1") != 0 && *tigetstr("cud1") == '\n')
+@@ -1718,14 +1720,18 @@ void lynx_nl2crlf(int normal GCC_UNUSED)
+     if (can_fix) {
+ 	if (normal) {
+ 	    if (!waiting) {
+-		cur_term->Nttyb.c_oflag |= ONLCR;
++		struct termios alter_tty = saved_tty;
++
++		alter_tty.c_oflag |= ONLCR;
++		tcsetattr(fileno(stdout), TCSAFLUSH, &alter_tty);
++		def_prog_mode();
+ 		waiting = TRUE;
+ 		nonl();
+ 	    }
+ 	} else {
+ 	    if (waiting) {
+-		cur_term->Nttyb = saved_tty;
+-		SET_TTY(fileno(stdout), &saved_tty);
++		tcsetattr(fileno(stdout), TCSAFLUSH, &saved_tty);
++		def_prog_mode();
+ 		waiting = FALSE;
+ 		nl();
+ 		LYrefresh();
+diff --git a/src/LYStrings.c b/src/LYStrings.c
+index e97481c..02b1286 100644
+--- a/src/LYStrings.c
++++ b/src/LYStrings.c
+@@ -1004,12 +1004,13 @@ static const char *expand_tiname(const char *first, size_t len, char **result, c
+ {
+     char name[BUFSIZ];
+     int code;
++    TERMTYPE *tp = (TERMTYPE *) (cur_term);
+ 
+     LYStrNCpy(name, first, len);
+     if ((code = lookup_tiname(name, strnames)) >= 0
+ 	|| (code = lookup_tiname(name, strfnames)) >= 0) {
+-	if (cur_term->type.Strings[code] != 0) {
+-	    LYStrNCpy(*result, cur_term->type.Strings[code], (final - *result));
++	if (tp->Strings[code] != 0) {
++	    LYStrNCpy(*result, tp->Strings[code], (final - *result));
+ 	    (*result) += strlen(*result);
+ 	}
+     }

--- a/lynx/plan.sh
+++ b/lynx/plan.sh
@@ -15,8 +15,14 @@ pkg_deps=(
 pkg_build_deps=(
   core/gcc
   core/make
+  core/patch
 )
 pkg_bin_dirs=(bin)
+
+do_prepare() {
+  # http://lists.gnu.org/archive/html/bug-ncurses/2017-03/msg00009.html
+  patch -p1 < "${PLAN_CONTEXT}/ncurses.patch"
+}
 
 do_check() {
   make test


### PR DESCRIPTION
This is a backwards compatible change

This fixes #1432 

Signed-off-by: Romain Sertelon <romain@sertelon.fr>