### PR TITLE
[rethinkdb] Removes pinned node dependency

### DIFF
--- a/rethinkdb/plan.sh
+++ b/rethinkdb/plan.sh
@@ -13,7 +13,6 @@ pkg_build_deps=(
   core/python2
   core/boost
   core/coreutils
-  core/node/4.2.6
   core/jemalloc
   core/m4
 )


### PR DESCRIPTION
Linked to #1423 

This still builds fine, as the source package includes a v8 distribution (the dependency was not used).

Signed-off-by: Romain Sertelon <romain@sertelon.fr>