### PR TITLE
add concourse-fly plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -113,6 +113,8 @@ plan_path = "composer"
 plan_path = "compositeproto"
 [concourse]
 plan_path = "concourse"
+[concourse-fly]
+plan_path = "concourse-fly"
 [consul]
 plan_path = "consul"
 [coreutils]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -114,6 +114,8 @@ acbuild @rsertelon
 artifactory-pro @defilan
 atk @rsertelon
 cairo @rsertelon
+concourse @echohack
+concourse-fly @echohack
 consul @defilan
 dep @afiune @nellshamrell
 dotnet-47-dev-pack @mwrock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,10 @@ The supervisor dynamically invokes hooks at run-time, triggered by an applicatio
   - No one should ever edit anything in `/hab/` directly.
   - No one should write to anything in `/hab/` directly.
 
+### New Plans
+
+Adding a new plan to core-plans requires updating `.bldr.toml` with your new package plan. This is so that [Builder](https://bldr.habitat.sh/) can map all of the plans to their respective directories.
+
 ### README
 
 Check out the [core plans README template](https://github.com/habitat-sh/core-plans/blob/master/README_TEMPLATE_FOR_PLANS.md) for a quick start!

--- a/concourse-fly/README.md
+++ b/concourse-fly/README.md
@@ -1,0 +1,7 @@
+# Habitat package: concourse-fly
+
+## Usage
+Include this package in your `pkg_deps` like so:
+`pkg_deps="core/concourse-fly"`.
+
+Intended for distribution on worker nodes that need to interact with Concourse's API via Fly.

--- a/concourse-fly/plan.sh
+++ b/concourse-fly/plan.sh
@@ -1,0 +1,46 @@
+pkg_name=concourse-fly
+pkg_origin=core
+pkg_version="3.11.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Concourse CLI for interacting with the ATC API"
+pkg_license=('Apache-2.0')
+pkg_upstream_url="https://concourse.ci"
+
+pkg_source="https://github.com/concourse/concourse.git"
+pkg_build_deps=("core/cacerts" "core/gnupg" "core/go" "core/git")
+pkg_bin_dirs=(bin)
+
+do_download() {
+  GIT_SSL_CAINFO="$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem"
+  export GIT_SSL_CAINFO
+
+  REPO_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  rm -rf "$REPO_PATH"
+  git clone --recursive "$pkg_source" "$REPO_PATH"
+  pushd "$REPO_PATH" || return 1
+    git checkout "tags/v${pkg_version}"
+  popd || return 1
+}
+
+do_unpack() {
+  return 0
+}
+
+do_clean() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_build(){
+  cd "$HAB_CACHE_SRC_PATH/$pkg_dirname/" || return 1
+  source .envrc
+  cd "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/github.com/concourse/fly" || return 1
+  go build
+}
+
+do_install(){
+  cp "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/github.com/concourse/fly/fly" "${pkg_prefix}/bin/fly"
+}


### PR DESCRIPTION
This plan adds the concourse Fly CLI plan to core-plans.

Signed-off-by: echohack <echohack@users.noreply.github.com>

![image](https://user-images.githubusercontent.com/3253989/39208056-a5156eda-47b6-11e8-9e28-c6ad52bf55b1.png)
