### PR TITLE
fixes flex for base plans refresh

### DIFF
--- a/flex/plan.sh
+++ b/flex/plan.sh
@@ -2,7 +2,9 @@ pkg_name=flex
 pkg_origin=core
 pkg_version=2.6.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Flex is a fast lexical analyser generator. It is a tool for generating programs that perform pattern-matching on text. Flex is a free (but non-GNU) implementation of the original Unix lex program."
 pkg_license=('custom')
+pkg_upstream_url="https://www.gnu.org/software/flex/"
 pkg_source=https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=d39b15a856906997ced252d76e9bfe2425d7503c6ed811669665627b248e4c73
 pkg_deps=(core/glibc)
@@ -16,12 +18,18 @@ do_check() {
   make check LDFLAGS="$LDFLAGS -lstdc++"
 }
 
+do_build() {
+  CFLAGS="${CFLAGS} -D_GNU_SOURCE"
+
+  do_default_build
+}
+
 do_install() {
   do_default_install
 
   # A few programs do not know about `flex` yet and try to run its predecessor,
   # `lex`
-  ln -sv flex $pkg_prefix/bin/lex
+  ln -sv flex "$pkg_prefix/bin/lex"
 }
 
 


### PR DESCRIPTION
This sets a C flag for flex, which makes doxygen able to build successfully with it in the core plans refresh.

This still builds fine with the base plans in master.

Fixes #1437 

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>