### PR TITLE
updates ruby 2.2 to latest version and pins certain versions of dependencies

### DIFF
--- a/ruby22/plan.sh
+++ b/ruby22/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby22
 pkg_origin=core
-pkg_version=2.2.9
+pkg_version=2.2.10
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6
+pkg_shasum=cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358
 pkg_dirname="ruby-$pkg_version"
+pkg_deps=(core/glibc/2.22 core/ncurses/6.0 core/zlib/1.2.8 core/openssl/1.0.2l core/libyaml/0.1.6/20170514013335 core/libffi/3.2.1/20170514003538 core/readline/6.3.8)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc/5.2.0 core/sed)


### PR DESCRIPTION
 Updates Ruby 2.2 to 2.2.10.

Fixes #1436 

This also introduces pinning to make this plan build with the base plans refresh.  Unfortunately, Ruby 2.2 will not work with the latest version of gcc and glibc (which the base packages refresh updates those package to).  As it's an older version of Ruby, it requires older versions of gcc and glibc, so this introduces pinning to those older versions.

Additionally, every dependency that also depends on gcc and glibc must be built with the older versions of those two packages.  Often, when a dependency of a package is updated and the dependent package is rebuilt, the version number of the dependent package is not bumped.  Therefore, for some of the dependencies, I have had to pin to specific timestamps, in most cases the last stable timestamp currently in builder.

Ruby 2.2.x is no longer officially supported (that ended in March 2018) and we should consider deprecating it.  Deprecating a core plan, however, will require an RFC to establish the process.  While I will open this RFC, we must complete the base plans refresh as soon as possible, most likely sooner than it would take to go through the RFC process.  So, for now, I'm going with pinning to specific version/timestamps.  When/if an RFC around deprecating core plans for software that is no longer supported is adopted, we can revisit deprecating this package.

This builds fine with both the base plans currently in master and the refreshed base plans.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>