### PR TITLE
[rethinkdb] fixes rethinkdb for base plans refresh

### DIFF
--- a/rethinkdb/plan.sh
+++ b/rethinkdb/plan.sh
@@ -8,7 +8,7 @@ pkg_license=('Apache-2.0')
 pkg_source="https://download.${pkg_name}.com/dist/${pkg_name}-${pkg_version}.tgz"
 pkg_shasum=dd8aeee169b177179bfe080725f0560443e0f26dae875b32ae25d90cf2f8ee10
 pkg_build_deps=(
-  core/gcc
+  core/gcc/5.2.0
   core/make
   core/python2
   core/boost
@@ -17,12 +17,12 @@ pkg_build_deps=(
   core/m4
 )
 pkg_deps=(
-  core/openssl
-  core/gcc-libs
-  core/protobuf
-  core/zlib
-  core/curl
-  core/ncurses
+  core/openssl/1.0.2l
+  core/gcc-libs/5.2.0
+  core/protobuf/2.6.1/20170514031228
+  core/zlib/1.2.8
+  core/curl/7.54.1/20180329185356
+  core/ncurses/6.0
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>

Fixes #1452

According to [this Github issue](https://github.com/rethinkdb/rethinkdb/issues/6536) - rethinkdb only compiles with gcc 5.x or earlier.  As the base plans refresh updates gcc to 7.x, we need to pin rethinkdb to 5.x.  We also need to pin all dependencies built with gcc to the versions that were built with gcc 5.x.

I'm hoping that support for gcc5 will come in the near future.