### PR TITLE
Fix mongodb

### DIFF
--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=mongodb
 pkg_origin=core
-pkg_version=3.2.10
+pkg_version=3.6.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="High-performance, schema-free, document-oriented database"
 pkg_license=('AGPL-3.0')
-pkg_source=http://downloads.mongodb.org/src/${pkg_name}-src-r${pkg_version}.tar.gz
-pkg_shasum=3bef44f50f302159c26194bcac9d51c81d98d57ea728f55400774850a70f5120
+pkg_source=https://fastdl.mongodb.org/src/mongodb-src-r3.6.4.tar.gz
+pkg_shasum=1a9697c3ad2f5545b5160d5e32d5f3c0f6f0a3371ceb9fa85961aec513acd7ac
 pkg_upstream_url=https://www.mongodb.com/
 pkg_filename=${pkg_name}-src-r${pkg_version}.tar.gz
 pkg_dirname=${pkg_name}-src-r${pkg_version}
@@ -15,7 +15,7 @@ pkg_build_deps=(
   core/gcc
   core/glibc
   core/python2
-  core/scons
+  core/scons/2.5.1
   core/openssl
 )
 pkg_bin_dirs=(bin)
@@ -50,13 +50,17 @@ do_prepare() {
 
     # because scons dislikes saving our variables, we will save our
     # variables within the construct ourselves
-    sed -i "840s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
+    sed -i "891s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
 }
 
 do_build() {
-    scons core --prefix="$pkg_prefix" --ssl -j"$(nproc)"
+    # This is currently necessary because MongoDB still uses Python 2.x
+    # When it supports Python 3.x, this line will be unnecessary
+    pip install typing pyyaml cheetah3
+
+    scons core --disable-warnings-as-errors --prefix="$pkg_prefix" --ssl -j"$(nproc)"
 }
 
 do_install() {
-    scons install --prefix="$pkg_prefix" --ssl
+    scons install --disable-warnings-as-errors --prefix="$pkg_prefix" --ssl
 }

--- a/scons/plan.sh
+++ b/scons/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=scons
 pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=2.5.0
+pkg_version=2.5.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_upstream_url=http://www.scons.org/
 pkg_description="Substitute for classic 'make' tool with autoconf/automake functionality"
 pkg_source=https://downloads.sourceforge.net/project/$pkg_distname/$pkg_distname/${pkg_version}/$pkg_distname-${pkg_version}.tar.gz
-pkg_shasum=eb296b47f23c20aec7d87d35cfa386d3508e01d1caa3040ea6f5bbab2292ace9
+pkg_shasum=0b25218ae7b46a967db42f2a53721645b3d42874a65f9552ad16ce26d30f51f2
 pkg_deps=(core/coreutils core/python2)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updates MongoDB and Scons so that they build with the newly refreshed base plans.  I am targeting this pull request at the refresh base packages branch (fnichol/teh-futur), rather than master, because these versions require the updated gcc.

Fixes #1426