### PR TITLE
[ttyrc] pins ttyrec to older version of glibc

### DIFF
--- a/ttyrec/README.md
+++ b/ttyrec/README.md
@@ -1,5 +1,7 @@
 # ttyrec
 
+ttyrec is a tty recorder. Recorded data can be played back with the included ttyplay command. ttyrec is just a derivative of script command for recording timing information with microsecond accuracy as well. It can record emacs -nw, vi, lynx, or any programs running on tty.
+
 ## Maintainers
 
 * The Habitat Maintainers: <humans@habitat.sh>
@@ -10,4 +12,9 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+```
+$ hab pkg install core/ttyrec
+$ hab pkg binlink core/ttyrec
+$ ttyrec -help
+usage: ttyrec [-u] [-e command] [-a] [file]
+```

--- a/ttyrec/plan.sh
+++ b/ttyrec/plan.sh
@@ -1,17 +1,19 @@
 pkg_name=ttyrec
+pkg_description="ttyrec is a tty recorder. Recorded data can be played back with the included ttyplay command. ttyrec is just a derivative of script command for recording timing information with microsecond accuracy as well. It can record emacs -nw, vi, lynx, or any programs running on tty."
 pkg_origin=core
 pkg_version=1.0.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd')
+pkg_upstream_url="http://0xcc.net/ttyrec/"
 pkg_source=http://0xcc.net/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=ef5e9bf276b65bb831f9c2554cd8784bd5b4ee65353808f82b7e2aef851587ec
-pkg_deps=(core/glibc)
+pkg_deps=(core/glibc/2.22)
 pkg_build_deps=(core/coreutils core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)
 
 do_prepare() {
   # Apply third party patch, originally designed for RHEL5
-  patch -p1 -i $PLAN_CONTEXT/ttyrec-1.0.8.RHEL5.patch
+  patch -p1 -i "$PLAN_CONTEXT/ttyrec-1.0.8.RHEL5.patch"
 }
 
 do_build() {
@@ -20,6 +22,6 @@ do_build() {
 
 do_install() {
   for bin in ttyplay ttyrec ttytime; do
-    install -v -D $bin $pkg_prefix/bin/$bin
+    install -v -D $bin "${pkg_prefix}/bin/$bin"
   done
 }


### PR DESCRIPTION
TTYREC appears to have not been updated since 2010, which means it needs an older version of glibc.  This pins it to that older version. 

Fixes #1434 

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>