### PR TITLE
[zookeeper] Update to 3.4.12

### DIFF
--- a/zookeeper/plan.sh
+++ b/zookeeper/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=zookeeper
 pkg_origin=core
-pkg_version=3.4.11
+pkg_version=3.4.12
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications."
 pkg_upstream_url="https://zookeeper.apache.org"
 pkg_license=('Apache-2.0')
 pkg_source="http://apache.mirrors.ionfish.org/zookeeper/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84"
+pkg_shasum="c686f9319050565b58e642149cb9e4c9cc8c7207aacc2cb70c5c0672849594b9"
 pkg_build_deps=()
 pkg_deps=(
   core/bash-static


### PR DESCRIPTION
This fixes the build too. (older release removed from upstream)

Closes #1495 

Signed-off-by: Romain Sertelon <romain@sertelon.fr>