### PR TITLE
[pax-utils] Update to 1.2.3

### DIFF
--- a/pax-utils/plan.sh
+++ b/pax-utils/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=pax-utils
-pkg_version=1.1.7
+pkg_version=1.2.3
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL')
 pkg_description="ELF related utils for ELF 32/64 binaries that can check files
   for security relevant properties"
 pkg_upstream_url='http://hardened.gentoo.org/pax-utils.xml'
-pkg_source=http://distfiles.gentoo.org/distfiles/${pkg_name}-${pkg_version}.tar.xz
-pkg_shasum=bb9bdbf0888de9444b53b78f7b8069af9832bac7cef0588030b8ce49e8ebad10
+pkg_source="http://distfiles.gentoo.org/distfiles/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="d231b1a34aea2b9205c24fada79a8251d4c3fbcce49367fc055fe43e4c9783b2"
 pkg_deps=(
   core/bash
   core/glibc


### PR DESCRIPTION
Fixes #1494 by updating the package (upstream removed the source tarball)

Signed-off-by: Romain Sertelon <romain@sertelon.fr>