### PR TITLE
Add stream_ssl_module

### DIFF
--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -39,6 +39,7 @@ do_build() {
     --with-pcre-jit \
     --with-file-aio \
     --with-stream=dynamic \
+    --with-stream_ssl_module \
     --with-mail=dynamic \
     --with-http_gunzip_module \
     --with-http_gzip_static_module \


### PR DESCRIPTION
This change adds the stream_ssl_module to the nginx configuration, in order to support SSL reverse proxy out of the box - see https://docs.nginx.com/nginx/admin-guide/security-controls/securing-tcp-traffic-upstream/ 

Resolves issue: https://github.com/habitat-sh/core-plans/issues/1502

Signed-off-by: Salim Alam <salam@chef.io>

