### PR TITLE
[dbdpg] add dbdpg plan for DBD::Pg

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -151,6 +151,8 @@ plan_path = "cyrus-sasl"
 plan_path = "damageproto"
 [db]
 plan_path = "db"
+[dbdpg]
+plan_path = "dbdpg"
 [dbus]
 plan_path = "dbus"
 [dd-agent]

--- a/dbdpg/README.md
+++ b/dbdpg/README.md
@@ -1,0 +1,5 @@
+# Habitat Package: dbdpg
+The Habitat Maintainers humans@habitat.sh
+
+## Description
+This is a Habitat plan for [DBD-Pg](http://search.cpan.org/dist/DBD-Pg/) which is used to do Sqitch deploys to PostgreSQL.

--- a/dbdpg/plan.sh
+++ b/dbdpg/plan.sh
@@ -1,0 +1,35 @@
+pkg_name=dbdpg
+pkg_origin=core
+pkg_version="3.7.4"
+pkg_maintainer="The Habitat Maintainers humans@habitat.sh"
+pkg_license=('Artistic-1.0-Perl' 'GPL-2.0')
+pkg_deps=(
+  core/glibc
+  core/perl
+  core/postgresql
+  core/zlib
+)
+pkg_build_deps=(
+  core/cpanminus
+  core/local-lib
+  core/gcc
+  core/make
+)
+pkg_description="DBD::Pg is a Perl module that works with the DBI module to provide access to PostgreSQL databases."
+pkg_upstream_url="http://search.cpan.org/dist/DBD-Pg/"
+
+do_setup_environment() {
+  push_buildtime_env PERL5LIB "${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+  push_runtime_env PERL5LIB "${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  source <(perl -I"$(pkg_path_for core/local-lib)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/local-lib)")
+  source <(perl -I"$(pkg_path_for core/cpanminus)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/cpanminus)")
+  source <(perl -Mlocal::lib="$pkg_prefix")
+  cpanm "DBD::Pg@$pkg_version" --local-lib "$pkg_prefix"
+}


### PR DESCRIPTION
This is a Habitat plan for [DBD-Pg](http://search.cpan.org/dist/DBD-Pg/) which is used to do Sqitch deploys to PostgreSQL.

Signed-off-by: Irving Popovetsky <irving@chef.io>