### PR TITLE
Updating node to latest LTS release

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="8.9.0"
+$pkg_version="8.11.1"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="cd37ff1fb455f7e6e6fe566cffcea06bbde392501fd7b5be5ec4174b762af523"
+$pkg_shasum="86678028f13b26ceed08efc4b838921ca1bf514c0b7e8151bfec8ba15c5e66ad"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=8.9.4
+pkg_version=8.11.1
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=729b44b32b2f82ecd5befac4f7518de0c4e3add34e8fe878f745740a66cbbc01
+pkg_shasum=86678028f13b26ceed08efc4b838921ca1bf514c0b7e8151bfec8ba15c5e66ad
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This PR updates node to the latest supported LTS release of Node. Version 6 of node went into maintenance on April 30th.

I verified the builds on my local machines.

![image](https://user-images.githubusercontent.com/3253989/39635488-840c573a-4f72-11e8-8530-1be5d07ff695.png)

If our policy is to always be on the latest LTS release, then we should also plan to move to 10.x in October 2018.


![img_7476](https://user-images.githubusercontent.com/3253989/39636132-357195de-4f74-11e8-995d-f0c767d8ec03.JPG)

