### PR TITLE
[sqitch_pg] Add the sqitch_pg core plan, which provides sqitch ready to use with PostgreSQL

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1016,6 +1016,8 @@ plan_path = "socat"
 plan_path = "spark"
 [sqitch]
 plan_path = "sqitch"
+[sqitch_pg]
+plan_path = "sqitch_pg"
 [sqlite]
 plan_path = "sqlite"
 [sshpass]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -154,6 +154,8 @@ protobuf-cpp @afiune
 rabbitmqadmin @predominant
 redis @irvingpop
 shared-mime-info @rsertelon
+sqitch @irvingpop
+sqitch_pg @irvingpop
 sqlserver @mwrock
 sqlserver-ha-ag @mwrock
 vault @defilan

--- a/sqitch_pg/README.md
+++ b/sqitch_pg/README.md
@@ -1,0 +1,24 @@
+# sqitch_pg
+This is a Habitat plan for [Sqitch](http://sqitch.org/) with [DBD-Pg](http://search.cpan.org/dist/DBD-Pg/) which is used to do database deploys to PostgreSQL.
+
+## Maintainers
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+This is a hybrid binary + library package, designed to make it easy to install Sqitch for PostgreSQL with a single package definition.
+
+## Usage
+
+Install this package by running:
+```
+hab pkg install -b core/sqitch_pg
+```
+
+Run this package like so:
+```
+cd your_schema_folder
+hab pkg exec core/sqitch_pg sqitch --engine pg deploy "db:pg://${USER}:${PASS}@${HOST}/$DB"
+```
+
+For a complete example, see [this db-migrations script](https://github.com/chef/chef-server/blob/master/src/bookshelf/habitat/config/database-migrations.sh)

--- a/sqitch_pg/plan.sh
+++ b/sqitch_pg/plan.sh
@@ -1,0 +1,36 @@
+pkg_name=sqitch_pg
+pkg_origin=core
+pkg_version="3.7.4"
+pkg_maintainer="The Habitat Maintainers humans@habitat.sh"
+pkg_license=('Artistic-1.0-Perl' 'GPL-2.0')
+pkg_deps=(
+  core/glibc
+  core/perl
+  core/postgresql-client
+  core/zlib
+  core/sqitch
+)
+pkg_build_deps=(
+  core/cpanminus
+  core/local-lib
+  core/gcc
+  core/make
+)
+pkg_description="Sqitch the database management application, bundled with the DBD::Pg Perl module for PostgreSQL"
+pkg_upstream_url="http://sqitch.org/" # Note: also http://search.cpan.org/dist/DBD-Pg/
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  push_runtime_env PERL5LIB "${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  source <(perl -I"$(pkg_path_for core/local-lib)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/local-lib)")
+  source <(perl -I"$(pkg_path_for core/cpanminus)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/cpanminus)")
+  source <(perl -Mlocal::lib="$pkg_prefix")
+  cpanm "DBD::Pg@$pkg_version" --local-lib "$pkg_prefix"
+}


### PR DESCRIPTION
The `core/sqitch` plan is valuable, but requires the inclusion of database-specific perl modules in order to provide a good user experience.  This PR solves that by providing a `core/sqitch_pg` package which wraps sqitch in all the Postgres love. 

Based on the discussion from #1510, supersedes that PR

![hitchin a ride](https://media.giphy.com/media/103GzauXuHnsiY/giphy.gif)

Signed-off-by: Irving Popovetsky <irving@chef.io>