### PR TITLE
[erlang] Fix erroneous RUNPATH on crypto.so

### DIFF
--- a/erlang/plan.sh
+++ b/erlang/plan.sh
@@ -29,6 +29,8 @@ do_prepare() {
 }
 
 do_build() {
+  sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure.in
+  sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure
   ./configure --prefix="${pkg_prefix}" \
               --enable-threads \
               --enable-smp-support \
@@ -36,7 +38,7 @@ do_build() {
               --enable-dynamic-ssl-lib \
               --enable-shared-zlib \
               --enable-hipe \
-              --with-ssl="$(pkg_path_for openssl)/lib" \
+              --with-ssl="$(pkg_path_for openssl)" \
               --with-ssl-include="$(pkg_path_for openssl)/include" \
               --without-javac
   make


### PR DESCRIPTION
Previously, this plan built the crypto.so file shipped in the
crypto package with the following RUNPATH:

```
Library runpath: [/hab/pkgs/core/openssl/1.0.2l/20171014213633/lib/lib:/usr/local/lib64:/usr/sfw/lib64:/usr/lib64:/opt/local/lib64:/usr/pkg/lib64:/usr/local/openssl/lib64:/usr/lib/openssl/lib64:/usr/openssl/lib64:/usr/local/ssl/lib64:/usr/lib/ssl/lib64:/usr/ssl/lib64://lib64:/usr/local/lib:/usr/sfw/lib:/usr/lib:/opt/local/lib:/usr/pkg/lib:/usr/local/openssl/lib:/usr/lib/openssl/lib:/usr/openssl/lib:/usr/local/ssl/lib:/usr/lib/ssl/lib:/usr/ssl/lib://lib:/hab/pkgs/core/erlang/20.0/20171014214153/lib:/hab/pkgs/core/glibc/2.22/20170513201042/lib:/hab/pkgs/core/zlib/1.2.8/20170513201911/lib:/hab/pkgs/core/ncurses/6.0/20170513213009/lib:/hab/pkgs/core/openssl/1.0.2l/20171014213633/lib]
```

As you can see, this includes a large number of system paths. This is
problematic since the libraries in those paths are not built by
habitat and thus may be the incorrect versions. This could produce
errors in erlang applications built by this plan. For example,

    Failed to load NIF library:
    '/hab/pkgs/chef/cool-service/1.0.0/20180430234433/lib/crypto-4.0/priv/lib/crypto.so:
    undefined symbol: EC_GROUP_new_curve_GF2m'"

With this patch, the RUNPATH is limited to habitat packages:

```
Library runpath:
[/hab/pkgs/core/openssl/1.0.2l/20171014213633/lib/lib:/hab/pkgs/ssd/erlang/20.0/20180510232405/lib:/hab/pkgs/core/glibc/2.22/20170513201042/lib:/hab/pkgs/core/zlib/1.2.8/20170513201911/lib:/hab/pkgs/core/ncurses/6.0/20170513213009/lib:/hab/pkgs/core/openssl/1.0.2l/20171014213633/lib]
```

Signed-off-by: Steven Danna <steve@chef.io>