### PR TITLE
Enable Consul to autodiscover peers based on service group

### DIFF
--- a/consul/config/basic_config.json
+++ b/consul/config/basic_config.json
@@ -5,6 +5,11 @@
   "bind_addr": "{{cfg.server.bind}}",
   "client_addr": "{{cfg.client.bind}}",
   "server": {{cfg.server.mode}},
+  "retry_join": [
+  {{#eachAlive svc.members as |member| ~}}
+    "{{member.sys.ip}}" {{~#unless @last}},{{/unless}}
+  {{/eachAlive ~}}
+  ],
   "ports": {
     "dns": {{cfg.ports.dns}},
     "http": {{cfg.ports.http}},

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -6,9 +6,16 @@ SERVERMODE={{cfg.server.mode}}
 
 if [ "$SERVERMODE" = true ] ; then
   exec consul agent {{~#if cfg.website}} -ui {{~/if}} \
-          {{#eachAlive svc.members as |member| ~}}
-              -retry-join {{member.sys.ip}} \
-          {{/eachAlive ~}}
+          {{#if svc.me.leader }}
+            {{#eachAlive svc.members as |member| ~}}
+              {{#unless member.leader}}
+                -retry-join {{member.sys.ip}} \
+              {{/unless}
+            {{/eachAlive ~}}
+          {{/if}
+          {{#if svc.me.follower }}
+            -retry-join {{svc.leader.sys.ip}}
+          {{/if}}
           -server -bootstrap-expect {{cfg.bootstrap.expect}} \
           -config-file={{pkg.svc_config_path}}/basic_config.json
 else

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -3,21 +3,10 @@
 exec 2>&1
 
 SERVERMODE={{cfg.server.mode}}
+export CONSUL_UI_BETA={{cfg.server.beta_ui}}
 
 if [ "$SERVERMODE" = true ] ; then
-  exec consul agent {{~#if cfg.website}} -ui {{~/if}} \
-          {{#if svc.me.leader }}
-            {{#eachAlive svc.members as |member| ~}}
-              {{#unless member.leader}}
-                -retry-join {{member.sys.ip}} \
-              {{/unless}
-            {{/eachAlive ~}}
-          {{/if}
-          {{#if svc.me.follower }}
-            -retry-join {{svc.leader.sys.ip}}
-          {{/if}}
-          -server -bootstrap-expect {{cfg.bootstrap.expect}} \
-          -config-file={{pkg.svc_config_path}}/basic_config.json
+  exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json
 else
   exec consul agent -dev
 fi

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -5,7 +5,12 @@ exec 2>&1
 SERVERMODE={{cfg.server.mode}}
 
 if [ "$SERVERMODE" = true ] ; then
-  exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json
+  exec consul agent {{~#if cfg.website}} -ui {{~/if}} \
+          {{#eachAlive svc.members as |member| ~}}
+              -retry-join {{member.sys.ip}} \
+          {{/eachAlive ~}}
+          -server -bootstrap-expect {{cfg.bootstrap.expect}} \
+          -config-file={{pkg.svc_config_path}}/basic_config.json
 else
   exec consul agent -dev
 fi


### PR DESCRIPTION
This change adds the `-retry-join` parameter to add each _alive_ member of the service pool to the run command to allow consul to discover its peers using the built-in habitat gossip layer.

This resolves #1524