### PR TITLE
Remove sha validation on boringssl

### DIFF
--- a/boringssl/plan.sh
+++ b/boringssl/plan.sh
@@ -6,7 +6,7 @@ pkg_version=3359
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('OpenSSL ISC')
 pkg_source="https://boringssl.googlesource.com/boringssl/+archive/${pkg_version}.tar.gz"
-pkg_shasum="aa57f96c8e34d44ec6e909faf181a5810229a745c6a331e1a99eebf645952b46"
+pkg_shasum="None"
 pkg_deps=(
   core/glibc
   core/go
@@ -22,6 +22,12 @@ pkg_build_deps=(
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
+
+
+# This feels bad but Google doesn't do releases and that branch is a moving target
+do_verify() {
+  return 0
+}
 
 do_build() {
   pushd .. >/dev/null


### PR DESCRIPTION
Since Google doesn't have a release of their openssl fork we are forced to pull from a branch. Unfortunately, there are commits going into the branches which causes shasum validation to fail.

Signed-off-by: Elliott Davis <elliott@excellent.io>