### PR TITLE
[libfcgi] Add libfcgi

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -540,6 +540,8 @@ plan_path = "liberation-fonts-ttf"
 plan_path = "libev"
 [libevent]
 plan_path = "libevent"
+[libfcgi]
+plan_path = "libfcgi"
 [libffi]
 plan_path = "libffi"
 [libgcrypt]

--- a/libfcgi/README.md
+++ b/libfcgi/README.md
@@ -1,0 +1,22 @@
+# libfcgi
+
+FastCGI is a language independent, scalable, open extension to CGI that provides high performance without the limitations of server specific APIs.
+
+This package contains library and include files, as well as the `cgi-fcgi` binary that can be used on execute FastCGI requests via command line.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Usage
+
+Execute a FastCGI request directly against PHP-FPM:
+
+```bash
+SCRIPT_NAME="/status" \
+SCRIPT_FILENAME="/status" \
+REQUEST_METHOD="GET" \
+    cgi-fcgi \
+        -bind \
+        -connect 127.0.0.1:9000
+```

--- a/libfcgi/plan.sh
+++ b/libfcgi/plan.sh
@@ -1,0 +1,39 @@
+pkg_name=libfcgi
+pkg_origin=core
+pkg_version="2.4.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("custom")
+pkg_description="FastCGI is a language independent, scalable, open extension to CGI that provides high performance without the limitations of server specific APIs."
+pkg_upstream_url="https://directory.fsf.org/wiki/Libfcgi"
+pkg_source="http://ftp.debian.org/debian/pool/main/${pkg_name:0:4}/${pkg_name}/${pkg_name}_${pkg_version}.orig.tar.gz"
+pkg_shasum="c21f553f41141a847b2f1a568ec99a3068262821e4e30bc9d4b5d9091aa0b5f7"
+pkg_filename="${pkg_name}_${pkg_version}.orig.tar.gz"
+pkg_dirname="${pkg_name}-${pkg_version}.orig"
+
+pkg_build_deps=(
+  core/make
+  core/gcc
+  core/patch
+)
+
+pkg_deps=(
+  core/glibc
+)
+
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+
+do_build() {
+  patch -p0 -i "${PLAN_CONTEXT}/stdio.patch"
+
+  do_default_build
+}
+
+do_install() {
+  do_default_install
+
+  build_line "Copying LICENSE to build artifact"
+  cp -v ./LICENSE.TERMS "${pkg_prefix}/LICENSE"
+}

--- a/libfcgi/stdio.patch
+++ b/libfcgi/stdio.patch
@@ -1,0 +1,9 @@
+--- include/fcgio.h 2012-01-23 15:23:51.136063795 +0000
++++ include/fcgio.h 2012-01-23 15:22:19.057221383 +0000
+@@ -31,6 +31,7 @@
+ #define FCGIO_H
+
+ #include <iostream>
++#include <stdio.h>
+
+ #include "fcgiapp.h"


### PR DESCRIPTION
The binary is this package is useful for health checking a FastCGI application without a web server running: https://easyengine.io/tutorials/php/directly-connect-php-fpm/

Here's how you might use it in the `health_check` hook for a PHP-FPM application:

```bash
#!/bin/bash -e

{{#if cfg.path.ping}}
    SCRIPT_NAME="{{ cfg.path.ping }}" \
    SCRIPT_FILENAME="{{ cfg.path.ping }}" \
    REQUEST_METHOD="GET" \
        {{pkgPathFor "core/libfcgi"}}/bin/cgi-fcgi \
            -bind \
            -connect {{ sys.ip }}:{{ cfg.network.port }} \
        | grep pong
{{/if}}
```