### PR TITLE
Add Envoy plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -221,6 +221,8 @@ plan_path = "elixir"
 plan_path = "envconsul"
 [envdir]
 plan_path = "envdir"
+[envoy]
+plan_path = "envoy"
 [erlang]
 plan_path = "erlang"
 [erlang16]

--- a/envoy/README.md
+++ b/envoy/README.md
@@ -1,0 +1,16 @@
+# Envoy
+
+C++ front/service proxy
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+This plan is intended to be extended with your own configuration.
+Please add it as a dependency for your own proxy service.

--- a/envoy/plan.sh
+++ b/envoy/plan.sh
@@ -1,0 +1,46 @@
+pkg_name=envoy
+pkg_origin=core
+pkg_version='e5f864a82d4f27110359daa2fbdcb12d99e415b9'
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('Apache-2.0')
+pkg_description="Build and test software of any size, quickly and reliably"
+pkg_upstream_url='https://www.envoyproxy.io/'
+pkg_source="https://github.com/envoyproxy/envoy/archive/v${pkg_version}.tar.gz"
+pkg_build_deps=(
+  core/curl
+  core/jq-static
+  core/patchelf
+  core/coreutils
+)
+pkg_deps=(core/glibc)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  curl "https://raw.githubusercontent.com/moby/moby/master/contrib/download-frozen-image-v2.sh" -o "${HAB_CACHE_SRC_PATH}/download-frozen-image-v2.sh"
+  sed -e "s#\#\!/usr/bin/env bash#\#\!/bin/bash#" -i "${HAB_CACHE_SRC_PATH}/download-frozen-image-v2.sh"
+  chmod +x "${HAB_CACHE_SRC_PATH}/download-frozen-image-v2.sh"
+  "${HAB_CACHE_SRC_PATH}/download-frozen-image-v2.sh" "${HAB_CACHE_SRC_PATH}/envoy" "envoyproxy/envoy:${pkg_version}"
+}
+
+do_unpack() {
+  mkdir -p "${CACHE_PATH}"
+  find "${HAB_CACHE_SRC_PATH}/envoy" -name "*.tar" -exec tar -xf {} -C "${CACHE_PATH}" \;
+}
+
+do_verify() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mkdir -p "${pkg_prefix}/bin/"
+  cp ./usr/local/bin/envoy "${pkg_prefix}/bin/envoy"
+  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" "${pkg_prefix}/bin/envoy"
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
Let me start out with apologizing for how gross this plan is.
Envoy doesn't publish binaries that I could find and the Bazel build proved too difficult for my mere mortal abilities.
So, that led me to download the dockerfile they publish to extract the envoy binary, then patch it.

![](https://media0.giphy.com/media/26Ff1cqEgwaOULKFi/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>