### PR TITLE
Add option to enable beta webui in consul plan

### DIFF
--- a/consul/default.toml
+++ b/consul/default.toml
@@ -11,6 +11,9 @@ bind = "127.0.0.1"
 data-dir = "/hab/svc/consul/data/consul"
 datacenter = "dc1"
 loglevel = "INFO"
+# Consul WebUI has been redesigned, switch this to true to use the new Beta UI
+# https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-new-ui
+beta_ui = false
 # switch this to false you want to start in DEVMODE
 # https://www.consul.io/docs/guides/bootstrapping.html
 mode = true

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -3,6 +3,7 @@
 exec 2>&1
 
 SERVERMODE={{cfg.server.mode}}
+export CONSUL_UI_BETA={{cfg.server.beta_ui}}
 
 if [ "$SERVERMODE" = true ] ; then
   exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json


### PR DESCRIPTION
Signed-off-by: qubitrenegade <qubitrenegade@gmail.com>

This commit adds an environment variable to easily toggle the new beta WebUI that ships with consul 1.1.0

Since this is a beta feature, defaults to off or the old WebUI.

See [Consul Docs](https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-new-ui) for complete details.