### PR TITLE
elasticsearch: depend on wget for health_check

### DIFF
--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -11,6 +11,7 @@ pkg_deps=(
   core/coreutils-static
   core/glibc
   core/jre8
+  core/wget
 )
 pkg_bin_dirs=(es/bin)
 pkg_binds_optional=(


### PR DESCRIPTION
in #1209 we swapped out a dependency on `core/busybox-static` for
`core/coreutils-static` because of a behavior change in elasticsearch
that didn't support busybox. little did we know, `busybox-static` was
also providing the `wget` binary, so now we're relying on a binary in
the `health_check` that we don't have a hard dependency on

Signed-off-by: Stephen Delano <stephen@chef.io>