### PR TITLE
[Artifactory-Pro] Updating to 6.0.0

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=5.10.3
+pkg_version=6.0.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=7c7a39f8a0a0898300e0f548ee3b293ad0aa5e893871ecb453177dec2a09442f
+pkg_shasum=4c5fa3a86e3b1d07979ff011af3b58481e519faa6ee27eb23622a6fe00d89935
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hello! This is a version bump to the latest version of Artifactory Pro (6.0.0). This tests out locally and works like a champ, pretty simple bump. 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>