### PR TITLE
[mysql-remote] Add proxy service for remote mysql

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -763,6 +763,8 @@ plan_path = "musl"
 plan_path = "mysql"
 [mysql-client]
 plan_path = "mysql-client"
+[mysql-remote]
+plan_path = "mysql-remote"
 [nasm]
 plan_path = "nasm"
 [nats-streaming-server]

--- a/mysql-remote/README.md
+++ b/mysql-remote/README.md
@@ -1,0 +1,69 @@
+# mysql-remote
+
+A dummy service that can be configured with an arbitrary MySQL connection to health check and provide in place of a mysql bind
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Usage
+
+Configuration options are identical to those of `core/mysql`, but with the addition of `host`:
+
+```yaml
+version: '2'
+
+services:
+  db:
+    image: core/mysql-remote
+    environment:
+      HAB_MYSQL_REMOTE: |
+        app_username = "myuser"
+        app_password = "mypassword"
+        host = "mysql.example.org"
+
+  app:
+    image: myorigin/myapp
+    depends_on:
+      - db
+    command: --peer db --bind database:mysql-remote.default
+```
+
+Consuming service need one change made to be able to accept both `mysql` and `mysql-remote` in the same slot.
+
+Where a config template for a consumer service might have look like this originally:
+
+```hbs
+{{~#eachAlive bind.database.members as |member|~}}
+{{~#if @first}}
+database
+  host: {{ member.sys.ip }}
+  port: {{ member.cfg.port }}
+  username: {{ member.cfg.username }}
+  password: {{ member.cfg.password }}
+  database: {{ ../cfg.database.name }}
+{{~/if~}}
+{{~/eachAlive}}
+```
+
+It should now use `member.cfg.host` in place of `member.sys.ip` if and only if it is available. This allows use of an explicitly-configured `host` while falling back to the peer IP determined by habitat for the bound service:
+
+```hbs
+{{~#eachAlive bind.database.members as |member|~}}
+{{~#if @first}}
+database
+  host: {{#if member.cfg.host}}{{ member.cfg.host }}{{else}}{{ member.sys.ip }}{{/if}}
+  port: {{ member.cfg.port }}
+  username: {{ member.cfg.username }}
+  password: {{ member.cfg.password }}
+  database: {{ ../cfg.database.name }}
+{{~/if~}}
+{{~/eachAlive}}
+```
+
+## Future considerations
+
+* socat or haproxy might be used to mirror the configured host:port to the local port so that `core/mysql-remote` could truly be a drop-in replacement for `core/mysql`
+  * modifying consumer services' config to use `host` would become an optional optimization
+  * relaying might be desirable for network security policies
+  * opening the relay or just sleeping like before could be controlled by a config option

--- a/mysql-remote/config/client.cnf
+++ b/mysql-remote/config/client.cnf
@@ -1,0 +1,5 @@
+[client]
+host = {{ cfg.host }}
+port = {{ cfg.port }}
+user = {{ cfg.app_username }}
+password = {{ cfg.app_password }}

--- a/mysql-remote/default.toml
+++ b/mysql-remote/default.toml
@@ -1,0 +1,5 @@
+host = "127.0.0.1"
+port = 3306
+app_username = false
+app_password = false
+server_id = 1

--- a/mysql-remote/hooks/health_check
+++ b/mysql-remote/hooks/health_check
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+
+echo "[mysql] status: CLIENT my_ip: {{sys.ip}} remote: {{cfg.host}}:{{cfg.port}}"
+mysqladmin --defaults-extra-file={{pkg.svc_config_path}}/client.cnf --wait=5 status

--- a/mysql-remote/hooks/run
+++ b/mysql-remote/hooks/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+while true; do sleep 86400; done

--- a/mysql-remote/plan.sh
+++ b/mysql-remote/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=mysql-remote
+pkg_origin=core
+pkg_version="1.0.0"
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('MIT')
+pkg_upstream_url='https://www.mysql.com/'
+pkg_description='A dummy service that can be configured with an arbitrary MySQL connection to health check and provide in place of a mysql bind'
+pkg_deps=(
+  core/mysql-client
+)
+
+
+pkg_exports=(
+  [host]=host
+  [port]=port
+  [password]=app_password
+  [username]=app_username
+  [server_id]=server_id
+)
+
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  return 0
+}


### PR DESCRIPTION
See original discussion on forum: https://forums.habitat.sh/t/binding-to-remote-services/531/2

I'm not sure if it's appropriate to merge a plan like this into core but want to at least kick off a broader discussion.

This package exposes a service that can take the place of `core/mysql` in a bind, but which is configured with full connection details to an external mysql instance. It runs a dummy sleep service and provides a `client.cnf` similar to `core/mysql`'s that is used for a connection health check