### PR TITLE
[Consul] Change user to hab (from root)

### DIFF
--- a/consul/hooks/reload
+++ b/consul/hooks/reload
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+exec 2>&1
 exec consul reload

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -1,12 +1,13 @@
-#!/bin/bash -xe
+#!/bin/sh
 
 exec 2>&1
 
 SERVERMODE={{cfg.server.mode}}
 export CONSUL_UI_BETA={{cfg.server.beta_ui}}
 
-if [ "$SERVERMODE" = true ] ; then
-  exec consul agent {{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json
-else
-  exec consul agent -dev
+CONSUL_OPTS="-dev"
+if [ "$SERVERMODE" = true ]; then
+  CONSUL_OPTS="{{~#if cfg.website}} -ui {{~/if}} -server -bootstrap-expect {{cfg.bootstrap.expect}} -config-file={{pkg.svc_config_path}}/basic_config.json"
 fi
+
+exec consul agent ${CONSUL_OPTS}

--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -20,8 +20,8 @@ pkg_exports=(
 )
 pkg_exposes=(port-dns port-http port-serf_lan port-serf_wan port-server)
 
-pkg_svc_user=root
-pkg_svc_group=root
+pkg_svc_user="hab"
+pkg_svc_group="${pkg_svc_user}"
 
 do_unpack() {
   cd "${HAB_CACHE_SRC_PATH}" || exit


### PR DESCRIPTION
Refs #1467 

- Change user to hab (from root)
- change bash to sh
- reload hook output redirection
- and some cleanup

Testing this change manually is simple.

```
hab svc load core/consul
```
Watch the log output, confirm its listening / started.

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-65143213](https://user-images.githubusercontent.com/24568/40513992-32de00ce-5f6d-11e8-8da4-25ac838b2fa6.gif)