### PR TITLE
[sqlserver-ha-ag] Impovements to sql HA plan based on customer engagement

### DIFF
--- a/sqlserver-ha-ag/hooks/init
+++ b/sqlserver-ha-ag/hooks/init
@@ -18,7 +18,7 @@ Invoke-Command -ComputerName localhost -EnableNetworkAccess {
     Write-Host "Checking for SqlServer PS module..."
     if(!(Get-Module SqlServer -ListAvailable)) {
         Write-Host "Installing SqlServer PS Module..."
-        Install-Module SqlServer -Force | Out-Null
+        Install-Module SqlServer -Force -AllowClobber | Out-Null
     }
     Write-Host "Checking for xNetworking PS module..."
     if(!(Get-Module xNetworking -ListAvailable)) {
@@ -41,8 +41,14 @@ Invoke-Command -ComputerName localhost -EnableNetworkAccess -ArgumentList (,($se
     param ($nodes)
     $ProgressPreference="SilentlyContinue"
 
+    $featureState = (Get-WindowsFeature Failover-Clustering).InstallState
+    if($featureState -eq "InstallPending") {
+        Restart-Computer # that's right
+    }
+
     $needToAddNode = $true
-    if(!(Get-Cluster -Name {{cfg.cluster_name}} -Domain $env:UserDomain)) {
+    $domain = (Get-ciminstance win32_computersystem).Domain.Split(".")[0]
+    if(!(Get-Cluster -Name {{cfg.cluster_name}} -Domain $domain)) {
         Write-Host "Creating new {{cfg.cluster_name}} cluster"
         $cluster = New-Cluster -Name {{cfg.cluster_name}} -Node $env:ComputerName -NoStorage -StaticAddress {{cfg.cluster_ip}} -ErrorAction SilentlyContinue
         if ($cluster) {

--- a/sqlserver-ha-ag/hooks/run
+++ b/sqlserver-ha-ag/hooks/run
@@ -17,7 +17,8 @@ if($(Get-Service 'MpsSvc').Status -eq "Running") {
 }
 
 if($env:ComputerName -eq $primary) {
-    $login = "${env:userdomain}\${env:ComputerName}`$"
+    $domain = (Get-ciminstance win32_computersystem).Domain.Split(".")[0]
+    $login = "$domain\${env:ComputerName}`$"
 
     Invoke-Command -ComputerName localhost -EnableNetworkAccess -ArgumentList $login, $secondary, $instance {
         param ($login, $secondary, $instance)
@@ -44,6 +45,16 @@ if($env:ComputerName -eq $primary) {
                 $svr = New-Object ('Microsoft.SqlServer.Management.Smo.Server') "$s\$instance"
                 $svrole = $svr.Roles | where {$_.Name -eq 'sysadmin'}
                 $svrole.AddMember($login)
+            }
+        }
+
+        # Create an empty database for each db if it does not already exist
+        $svr = New-Object ('Microsoft.SqlServer.Management.Smo.Server') "{{bind.database.first.sys.hostname}}\$instance"
+        $databases = @({{cfg.databases}})
+        foreach($db in $databases) {
+            if($db.Length -gt 0 -and (!$svr.Databases[$db])) {
+                Write-Host "Creating empty database for $db"
+                (New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database -argumentlist $svr, $db).Create()
             }
         }
     }


### PR DESCRIPTION
Found that on AWS, as opposed to azure, machines went into a pending reboot state after enabling failover clustering. Rebooting resolves this.

This also ensures that we use the domain of the computer and not the current user when adding the secondary node logins and it creates an empty database on the primary node if the configured db does not exist.

Signed-off-by: mwrock <matt@mattwrock.com>