### PR TITLE
[csvkit] Add plan for csvkit

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -140,6 +140,8 @@ plan_path = "cpio"
 plan_path = "cppunit"
 [cpputest]
 plan_path = "cpputest"
+[csvkit]
+plan_path = "csvkit"
 [curator]
 plan_path = "curator"
 [curator4]

--- a/csvkit/README.md
+++ b/csvkit/README.md
@@ -1,0 +1,17 @@
+# csvkit
+
+A suite of utilities for converting to and working with CSV, the king of tabular file formats.
+
+Full documentation for csvkit is available at [csvkit.readthedocs.io](https://csvkit.readthedocs.io)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Usage
+
+All the commands provided by the csvkit project are exported by this package via `pkg_bin_dirs`. They rely on a habitat-provided runtime environment though and so will not work via binlink. Use `hab pkg exec` for best results:
+
+```bash
+hab pkg exec core/csvkit in2csv data.xlsx > data.csv
+```

--- a/csvkit/plan.sh
+++ b/csvkit/plan.sh
@@ -1,0 +1,33 @@
+pkg_name="csvkit"
+pkg_origin="core"
+pkg_version="1.0.3"
+pkg_description="A suite of utilities for converting to and working with CSV, the king of tabular file formats."
+pkg_upstream_url="https://github.com/wireservice/csvkit"
+pkg_license=("MIT")
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_source="${pkg_upstream_url}/archive/${pkg_version}.tar.gz"
+pkg_shasum="4ca64988a648c845ad2f02a19d5736c3a2650a44b1dd8952b97b528c7f3e2a97"
+
+pkg_deps=(
+    core/python
+)
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+do_setup_environment() {
+  push_runtime_env PYTHONPATH "$(pkg_path_for core/python)/lib/python3.6/site-packages"
+  push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python3.6/site-packages"
+}
+
+do_prepare() {
+  mkdir -p "${pkg_prefix}/lib/python3.6/site-packages"
+}
+
+do_build() {
+  python setup.py build
+}
+
+do_install() {
+  python setup.py install --prefix="${pkg_prefix}" --optimize=1 --skip-build
+}


### PR DESCRIPTION
I've been using this for a while at `jarvus/csvkit` and it's been really handy to have installable via habitat. `hab pkg exec core/csvkit in2csv uploaded.xlsx` is magic