### PR TITLE
[meson] Remove Meson's handling of rpath

### DIFF
--- a/meson/patches/000_fix_rpath.patch
+++ b/meson/patches/000_fix_rpath.patch
@@ -1,0 +1,17 @@
+--- mesonbuild/scripts/meson_install.py.orig	2018-05-21 13:48:15.860000000 +0000
++++ mesonbuild/scripts/meson_install.py		2018-05-21 13:48:30.330000000 +0000
+@@ -366,14 +366,6 @@
+                     print("Symlink creation does not work on this platform. "
+                           "Skipping all symlinking.")
+                     printed_symlink_error = True
+-        if os.path.isfile(outname):
+-            try:
+-                depfixer.fix_rpath(outname, install_rpath, False)
+-            except SystemExit as e:
+-                if isinstance(e.code, int) and e.code == 0:
+-                    pass
+-                else:
+-                    raise
+ 
+ def run(args):
+     global install_log_file

--- a/meson/plan.sh
+++ b/meson/plan.sh
@@ -1,15 +1,18 @@
 pkg_name=meson
 pkg_origin=core
-pkg_version=0.43.0
+pkg_version=0.46.1
 pkg_description="The Meson Build System"
 pkg_upstream_url="http://mesonbuild.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/mesonbuild/${pkg_name}/archive/${pkg_version}.tar.gz"
-pkg_shasum=324894427dcd29f6156fe06b046c6ad1b998470714debd7c5705902f21aaaa73
+pkg_shasum=2d917692d2cc194e12295f00469fbdf3c045e85d0295e5e59ced69115920ffa0
 pkg_deps=(
   core/python
   core/ninja
+)
+pkg_build_deps=(
+  core/patch
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
@@ -21,6 +24,7 @@ do_setup_environment() {
 
 do_prepare() {
   mkdir -p "${pkg_prefix}/lib/python3.6/site-packages"
+  patch -p0 < "$PLAN_CONTEXT/patches/000_fix_rpath.patch"
 }
 
 do_build() {


### PR DESCRIPTION
Meson manipulates the rpath of binaries/libraries post-build and doesn't currently take into account LD_RUN_PATH.  This prevents software built with Meson in Habitat from being able to find the libraries needed after the artifact is generated. 

I first considered modifying the Meson source to handle our use case, but decided against it as I don't have much Python experience and modifying the code that is patching binaries and libraries felt very risky. It would have the upside of _just working_ from both Habitats and Mesons perspective

The next solution I considered, and the one I chose, is to patch out the code that modifies the rpath. I chose this since it allows builds to behave like all other Habitat builds. It has the downside of requiring plan authors to be aware of this, if the package they are building uses the `install_rpath` feature Meson provides. 

I also considered that plan authors would either need to patch `meson.build` to set the `install_rpath` correctly for their software, or utilize `patchelf` to set the rpath correctly for their software, but I feel  both of these put too much burden on plan developers.  

Unfortunately, the solution I chose results in the following remaining in the RUNPATH as reported by readelf: `Library runpath: [$ORIGIN/src/shared:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:` .   I think this is safe to leave, and it unblocks the  base plans refresh (stage3: systemd , which uses meson), but we would want to revisit in the future. 

Reference:
https://github.com/mesonbuild/meson/issues/314
https://github.com/mesonbuild/meson/issues/2567

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>