### PR TITLE
[dotnet-dev-pack] Addded plans for dotnet-471-dev-pack and dotnet-472-dev-pack

### DIFF
--- a/dotnet-47-dev-pack/plan.ps1
+++ b/dotnet-47-dev-pack/plan.ps1
@@ -2,7 +2,7 @@ $pkg_name="dotnet-47-dev-pack"
 $pkg_origin="core"
 $pkg_version="4.7"
 $pkg_description=".NET 4.7 Targeting Pack and the .NET 4.7 SDK."
-$pkg_upstream_url="https://www.microsoft.com/en-us/download/details.aspx?id=55168"
+$pkg_upstream_url="https://www.microsoft.com/net/download/all"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe"

--- a/dotnet-471-dev-pack/plan.ps1
+++ b/dotnet-471-dev-pack/plan.ps1
@@ -1,0 +1,7 @@
+. "..\dotnet-47-dev-pack\plan.ps1"
+
+$pkg_name="dotnet-471-dev-pack"
+$pkg_version="4.7.1"
+$pkg_description=".NET 4.7.1 Targeting Pack and the .NET 4.7.1 SDK."
+$pkg_source="https://download.microsoft.com/download/9/0/1/901B684B-659E-4CBD-BEC8-B3F06967C2E7/NDP471-DevPack-ENU.exe"
+$pkg_shasum="a615488d2c5229aff3b97c56f7e5519cc7ac4f58b638a8e159b19c5c3d455c7b"

--- a/dotnet-472-dev-pack/plan.ps1
+++ b/dotnet-472-dev-pack/plan.ps1
@@ -1,0 +1,7 @@
+. "..\dotnet-47-dev-pack\plan.ps1"
+
+$pkg_name="dotnet-472-dev-pack"
+$pkg_version="4.7.2"
+$pkg_description=".NET 4.7.2 Targeting Pack and the .NET 4.7.2 SDK."
+$pkg_source="https://download.microsoft.com/download/5/F/E/5FE505D0-E753-4F1A-B8D6-D9E73C0C28C7/NDP472-DevPack-ENU.exe"
+$pkg_shasum="15916f064a0ad061463ace80d9405f2d80d29655a13516f3676d421d0337d756"


### PR DESCRIPTION
New plans reference and override dotnet-47-dev-pack
Changed dotnet-47-dev-pack upstream URL to be more generic