### PR TITLE
[popt] Update source_url & fix variable name

### DIFF
--- a/popt/plan.sh
+++ b/popt/plan.sh
@@ -2,11 +2,11 @@
 pkg_name=popt
 pkg_origin=core
 pkg_version=1.16
-pkg_descriptyon="Popt is a C library for parsing command line parameters"
+pkg_description="Popt is a C library for parsing command line parameters"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
 pkg_upstream_url=http://rpm5.org
-pkg_source=http://rpm5.org/files/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_source=ftp://anduin.linuxfromscratch.org/BLFS/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make)


### PR DESCRIPTION
The DNS registration for the specified `pkg_source` has expired, blocking builds.  This changes the source_url to the Linux From Scratch mirror of popt. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>