### PR TITLE
[Vault] Updated plan to Vault 0.10.2

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.10.0
+pkg_version=0.10.2
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source=https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip
-pkg_shasum=a6b4b6db132f3bbe6fbb77f76228ffa45bd55a5a1ab83ff043c2c665c3f5a744
+pkg_shasum=f725be68316d10ef2e7779fdedd8eb5d4ed9975303c828466bb9a729e01392dd
 pkg_filename=${pkg_name}-${pkg_version}_linux_amd64.zip
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Another simple update, taking the plan to Vault version 0.10.2. 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>