### PR TITLE
[git] Minor version bump for CVE-2018-11235

### DIFF
--- a/git/plan.ps1
+++ b/git/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name = "git"
 $pkg_origin = "core"
-$pkg_version = "2.13.3"
+$pkg_version = "2.13.7"
 $pkg_description = "Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
   speed and efficiency."

--- a/git/plan.sh
+++ b/git/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=git
-pkg_version=2.14.2
+pkg_version=2.14.4
 pkg_origin=core
 pkg_description="Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with


### PR DESCRIPTION
Reference:

* https://nvd.nist.gov/vuln/detail/CVE-2018-11235

Affected versions:

* 2.13.x before 2.13.7
* 2.14.x before 2.14.4
* 2.15.x before 2.15.2
* 2.16.x before 2.16.4
* 2.17.x before 2.17.1

Signed-off-by: Graham Weldon <graham@grahamweldon.com>