### PR TITLE
[git] Minor version bump for CVE-2018-11235

### DIFF
--- a/git/plan.sh
+++ b/git/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=git
-pkg_version=2.14.2
+pkg_version=2.14.4
 pkg_origin=core
 pkg_description="Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
@@ -9,7 +9,7 @@ pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.kernel.org/pub/software/scm/git/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=a03a12331d4f9b0f71733db9f47e1232d4ddce00e7f2a6e20f6ec9a19ce5ff61
+pkg_shasum=0556330e267dc968749619cd90ff6a815eda26f0c89faa5cfba56756e852202f
 pkg_deps=(
   core/cacerts
   core/curl


### PR DESCRIPTION
Reference:

* https://nvd.nist.gov/vuln/detail/CVE-2018-11235

Affected versions:

* 2.13.x before 2.13.7
* 2.14.x before 2.14.4
* 2.15.x before 2.15.2
* 2.16.x before 2.16.4
* 2.17.x before 2.17.1

Signed-off-by: Graham Weldon <graham@grahamweldon.com>