### PR TITLE
[postgresql-client] Fix sqitch_pg and dbdpg building against postgresql-client, they depend on pg_config.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,7 +102,6 @@ lessmsi @mwrock
 visual-cpp-build-tools-2015 @mwrock
 visual-cpp-redist-2013 @mwrock
 wix @mwrock
-postgresql-client @joshbrand @irvingpop
 
 # # Community Plans
 #
@@ -155,6 +154,7 @@ nuget @mwrock
 optipng @predominant
 pango @rsertelon
 pngquant @predominant
+postgresql-client @joshbrand @irvingpop
 protobuf-cpp @afiune
 rabbitmqadmin @predominant
 redis @irvingpop

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@ lessmsi @mwrock
 visual-cpp-build-tools-2015 @mwrock
 visual-cpp-redist-2013 @mwrock
 wix @mwrock
+postgresql-client @joshbrand @irvingpop
 
 # # Community Plans
 #

--- a/postgresql-client/plan.sh
+++ b/postgresql-client/plan.sh
@@ -24,7 +24,6 @@ server_execs=(
     ecpg
     initdb
     pg_archivecleanup
-    pg_config
     pg_controldata
     pg_resetxlog
     pg_rewind

--- a/sqitch/plan.sh
+++ b/sqitch/plan.sh
@@ -14,10 +14,14 @@ pkg_build_deps=(core/gcc core/make core/coreutils core/perl core/local-lib core/
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)
 
+do_setup_environment() {
+  push_runtime_env PERL5LIB "${pkg_prefix}/lib/perl5:${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+}
+
 do_prepare() {
-  eval "$(perl -I$(pkg_path_for core/local-lib)/lib/perl5 -Mlocal::lib=$(pkg_path_for core/local-lib))"
+  eval "$(perl -I"$(pkg_path_for core/local-lib)"/lib/perl5 -Mlocal::lib="$(pkg_path_for core/local-lib)")"
   # Create a new lib dir in our pacakge for cpanm to house all of its libs
-  eval $(perl -Mlocal::lib=${pkg_prefix})
+  eval "$(perl -Mlocal::lib="${pkg_prefix}")"
 
   cpanm Module::Build
 }
@@ -32,8 +36,8 @@ do_install() {
   ./Build
   ./Build install
 
-  for file in ${pkg_prefix}/bin/*; do
-    sed -i "1 s,.*,& -I${pkg_prefix}/lib/perl5," $file
+  for file in "${pkg_prefix}"/bin/*; do
+    sed -i "1 s,.*,& -I${pkg_prefix}/lib/perl5," "$file"
   done
 }
 


### PR DESCRIPTION
The `postgresql-client` package stripped out the `pg_config` binary, which impacts Sqitch's ability to determine information about the version and location of Postgres it is talking to.  This PR corrects that, while also improving the sqitch plan to push PERL5LIB to the runtime_env.

also adds this plan to CODEOWNERS

Fixes #1572 

Signed-off-by: Irving Popovetsky <irving@chef.io>