### PR TITLE
[rabbitmq] Fix reconfigure hook for sh

### DIFF
--- a/rabbitmq/hooks/reconfigure
+++ b/rabbitmq/hooks/reconfigure
@@ -16,4 +16,4 @@ rabbitmqctl start_app
 {{/if ~}}
 {{/if ~}}
 # sending TERM to ensure configuration is fully applied
-kill -SIGTERM `cat {{pkg.svc_pid_file}}`
+kill -TERM `cat {{pkg.svc_pid_file}}`


### PR DESCRIPTION
![tenor-219497348](https://user-images.githubusercontent.com/24568/42007362-a33aa27e-7aba-11e8-83bc-8bbb14949af1.gif)

bash will want `SIGTERM`, sh wants to see `TERM`.

Fixes #1583 

Signed-off-by: Graham Weldon <graham@grahamweldon.com>