### PR TITLE
[scaffolding-node] Update scaffolding-node to handle double-digit version constraints.

### DIFF
--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -644,9 +644,9 @@ _extracted_version_number() {
 }
 
 _full_version_digits() {
-    if [[ $1 =~ ([0-9]\.[0-9]\.[0-9]$) ]]; then
+    if [[ $1 =~ ([0-9]+\.[0-9]+\.[0-9]+$) ]]; then
         echo "$1"
-    elif [[ $1 =~ ([0-9]\.[0-9]$) ]]; then
+    elif [[ $1 =~ ([0-9]+\.[0-9]+$) ]]; then
         echo "$1.0"
     else
         echo "$1.0.0"
@@ -658,7 +658,9 @@ remove_single_chars() {
 }
 
 stable_versions_list() {
-	versions_list=$($_jq '.data[].version' < "${1}")
+  local filter=".data[] | select(.platforms[] | contains(\"$pkg_target\")) | .version"
+
+	versions_list=$($_jq "${filter}" < "${1}")
 	versions_str=${versions_list[0]}
 
 	versions_array=()

--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -666,7 +666,7 @@ stable_versions_list() {
 	versions_array=()
 
 	versions_array=($versions_str)
-	sorted_versions_array=($(for l in "${versions_array[@]}"; do echo "$l"; done | sort))
+	sorted_versions_array=($(for l in "${versions_array[@]}"; do echo "$l"; done | sort -V))
 	echo "${sorted_versions_array[@]}"
 }
 

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.13"
+pkg_version="0.6.14"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
Fixes #1613 

Also addresses issue where windows node packages are taken into account on Linux, and can result in a "Package Not Found" error if the latest Windows package is newer than latest Linux package. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>