### PR TITLE
[jre8] make the windows jre plan portable

### DIFF
--- a/jre8/plan.ps1
+++ b/jre8/plan.ps1
@@ -4,10 +4,11 @@ $pkg_version="8.172.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Apache-2.0")
 $pkg_upstream_version="8u172"
-$pkg_source="http://download.oracle.com/otn-pub/java/jdk/$pkg_upstream_version-b11/a58eab1ec242421181065cdc37240b08/jre-$pkg_upstream_version-windows-i586.exe"
+$pkg_source="http://download.oracle.com/otn-pub/java/jdk/$pkg_upstream_version-b11/a58eab1ec242421181065cdc37240b08/jre-$pkg_upstream_version-windows-x64.exe"
 $pkg_filename="$pkg_name-$pkg_version.exe"
-$pkg_shasum="434d7cbe88e2a28ee37c7345b5d93810c98112908f7dd5a273a0611482898928"
-$pkg_bin_dirs=@("bin")
+$pkg_shasum="580bd9a6da5640661c4dc6ebdb3eac451dbc49f23635728116d90a4d164d3a0f"
+$pkg_build_deps=@("core/7zip")
+$pkg_bin_dirs=@("java/bin")
 
 function Invoke-Download() {
      $Cookie  = New-Object -TypeName System.Net.Cookie
@@ -24,11 +25,23 @@ function Invoke-Download() {
      }
 }
 
-function Invoke-Unpack() { }
+function Invoke-Unpack() {
+    New-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname" -ItemType Directory | Out-Null
+    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    try {
+        7z x "$HAB_CACHE_SRC_PATH/$pkg_filename"
+        7z x data1.cab
+        7z x installerexe -ojava
+
+        Get-ChildItem java\lib -Include *.pack -Recurse | % {
+            Write-Host "Unpacking $_"
+            ."java\bin\unpack200.exe" $_.FullName $_.FullName.Replace(".pack", ".jar")
+            Remove-Item $_
+        }
+    }
+    finally { Pop-Location }
+}
 
 function Invoke-Install() {
-    Write-Host "Installing $HAB_CACHE_SRC_PATH/$pkg_filename to $pkg_prefix"
-    rm -Force $pkg_prefix/bin
-    Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/s INSTALL_SILENT=1 INSTALLDIR=$pkg_prefix /L $HAB_CACHE_SRC_PATH/jre.log"
-    cat $HAB_CACHE_SRC_PATH/jre.log
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/java" $pkg_prefix -Recurse -Force
 }


### PR DESCRIPTION
This ensures that the jre binaries are confined to `\hab\pkgs` and there are no OS side effects involved in installing the package.

Would love to know if this continues to work for @skylerto 

Signed-off-by: mwrock <matt@mattwrock.com>