### PR TITLE
[elasticsearch] Improvements to run hook and configuration

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,52 @@
+# Elasticsearch
+
+[Elasticsearch][elasticsearch] is an Open Source, Distributed, RESTful Search Engine
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+```
+hab pkg install core/elasticsearch
+hab svc load core/elasticsearch
+```
+
+## Bindings
+
+Consume an elasticsearch service like so:
+
+```
+hab start <origin>/<app> --bind elasticsearch:elasticsearch.default --peer <es_host>
+```
+
+Elasticsearch exposes a `http-port` and `transport-port`. The [transport protocol][transport-protocol] is for inter-node communication in the Elasticsearch cluster.
+
+No user credentials are exposed to the binding application. User credential setup and exposure is beyond the scope of this basic service package.
+
+## Topologies
+
+`standalone` topology is enough for Elasticsearch in a small or single node setup, as it handles its own master/leader election internally.
+
+However, if you want to take advantage of a `rolling` update strategy, the topology should be `leader`.
+
+## Update Strategies
+
+* `at-once` for a single node, or small number of nodes
+* `rolling` is more appropriate for production workloads, and requires a `leader` topology.
+
+## Monitoring
+
+Elasticsearch exposes cluster health information via HTTP(s). The [documentation][health-docs] details how to read and parse that data.
+
+Examples of this can be found in the `health_check` [hook][health-hook].
+
+[elasticsearch]: https://www.elastic.co/products/elasticsearch
+[transport-protocol]: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-transport.html
+[health-docs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+[health-hook]: hooks/health_check

--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -55,7 +55,7 @@
   # node.rack: r1
   #
   rack_id = ""
-  zone    = ""
+  zone = ""
   #
   # Disable starting multiple nodes on a single system:
   #
@@ -66,7 +66,7 @@
   # Default is master-eligible (master and data are both "true")
   #
   master = "true"
-  data   = "true"
+  data = "true"
 
 #
 # ----------------------------------- Paths ------------------------------------
@@ -75,49 +75,49 @@
   #
   # Path to directory where to store the data (separate multiple locations by comma):
   #
-  data =    ""
+  data = ""
   #
   # Path to log files:
   #
-  logs =    "logs"
+  logs = "logs"
 
 #
 # ----------------------------------- Indices ----------------------------------
 #
 [indices]
   [indices.recovery]
-    max_bytes_per_sec  =            "20mb"
+    max_bytes_per_sec = "20mb"
 
   [indices.fielddata]
     #
     # The max size of the field data cache, eg 30% of node heap space, or an absolute
     # value, eg 12GB. Defaults to unbounded.
     #
-    cache-size =                   ""
+    cache-size = ""
 
   [indices.breaker]
     #
     # Starting limit for overall parent breaker, defaults to 70% of JVM heap.
     #
-    total-limit =                    "70%"
+    total-limit = "70%"
     #
     # Limit for fielddata breaker, defaults to 60% of JVM heap.
     #
-    fielddata-limit =                "60%"
+    fielddata-limit = "60%"
     #
     # A constant that all field data estimations are multiplied with to determine a
     # final estimation. Defaults to 1.03
     #
-    fielddata-overhead =             "1.03"
+    fielddata-overhead = "1.03"
     #
     # Limit for request breaker, defaults to 40% of JVM heap.
     #
-    request-limit =                  "40%"
+    request-limit = "40%"
     #
     # A constant that all request estimations are multiplied with to determine a
     # final estimation. Defaults to 1.
     #
-    request-overhead =               "1"
+    request-overhead = "1"
 
 #
 # ----------------------------------- Memory -----------------------------------
@@ -141,7 +141,7 @@
   #
   # Set the bind address to a specific IP (IPv4 or IPv6):
   #
-  host =  "_site_"
+  host = "_site_"
   #
   # Set a custom port for HTTP:
   #
@@ -178,13 +178,13 @@
   #
   # Block initial recovery after a full cluster restart until N nodes are started:
   #
-  recover_after_nodes   = ""
+  recover_after_nodes = ""
   #
   # The number of (data or master) nodes that are expected to be in the cluster.
   # Recovery of local shards will start as soon as the expected number of nodes
   # have joined the cluster. Defaults to 0
   #
-  expected_nodes        = "0"
+  expected_nodes = "0"
   #
   # The number of master nodes that are expected to be in the cluster. Recovery
   # of local shards will start as soon as the expected number of master nodes
@@ -196,13 +196,13 @@
   # local shards will start as soon as the expected number of data nodes have
   # joined the cluster. Defaults to 0
   #
-  expected_data_nodes   = "0"
+  expected_data_nodes = "0"
   #
   # If the expected number of nodes is not achieved, the recovery process waits
   # for the configured amount of time before trying to recover regardless.
   # Defaults to 5m if one of the expected_nodes settings is configured.
   #
-  recover_after_time    = ""
+  recover_after_time = ""
   #
   # For more information, see the documentation at:
   # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
@@ -215,7 +215,7 @@
   #
   # Require explicit names when deleting indices:
   #
-  destructive_requires_name  = "true"
+  destructive_requires_name = "true"
 
 # ======================== Elasticsearch Logger Configuration =========================
 [logger]
@@ -227,8 +227,15 @@
 
 # ======================== Runtime Configuration =========================
 [runtime]
-  max_open_files = ""
+  user = "hab"
+  group = "hab"
+  max_open_files = 65536
   max_locked_memory = ""
   es_startup_sleep_time = ""
   es_java_opts = ""
   heapsize = "1g"
+  max_threads = 4096
+
+[sysctl]
+  [sysctl.vm]
+    max_map_count = 262144

--- a/elasticsearch/hooks/run
+++ b/elasticsearch/hooks/run
@@ -2,6 +2,9 @@
 
 exec 2>&1
 
+# Root needs to perform the below.
+sysctl -w vm.max_map_count={{cfg.sysctl.vm.max_map_count}}
+
 {{#if cfg.runtime.es_startup_sleep_time ~}}
 export ES_STARTUP_SLEEP_TIME={{cfg.runtime.es_startup_sleep_time}}
 {{/if ~}}
@@ -11,6 +14,15 @@ ulimit -l {{cfg.runtime.max_locked_memory}}
 {{#if cfg.runtime.max_open_files ~}}
 ulimit -n {{cfg.runtime.max_open_files}}
 {{/if ~}}
+{{#if cfg.runtime.max_threads ~}}
+ulimit -u {{cfg.runtime.max_threads}}
+{{/if ~}}
+
+mkdir -p "{{pkg.svc_var_path}}/tmp"
+chown -R {{cfg.runtime.user}}:{{cfg.runtime.group}} "{{pkg.svc_path}}"
 
 export ES_PATH_CONF="{{pkg.svc_config_path}}"
-exec elasticsearch
+export ES_TMPDIR="{{pkg.svc_var_path}}/tmp"
+
+# Service is executed as the runtime user.
+exec su -p {{cfg.runtime.user}} -c 'elasticsearch'

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -8,6 +8,7 @@ pkg_license=('Revised BSD')
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=0464127140820d82b24bd2830232131ea85bcd49267a8bc7365e4fa391dee2a3
 pkg_deps=(
+  core/busybox-static
   core/coreutils-static
   core/glibc
   core/jre8
@@ -23,6 +24,8 @@ pkg_exports=(
   [transport-port]=transport.port
 )
 pkg_exposes=(http-port transport-port)
+pkg_svc_user="root"
+pkg_svc_group="${pkg_svc_user}"
 
 do_build() {
   return 0

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=elasticsearch
 pkg_origin=core
-pkg_version=6.2.2
+pkg_version=6.3.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Open Source, Distributed, RESTful Search Engine"
 pkg_upstream_url="https://elastic.co"
 pkg_license=('Revised BSD')
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=b26e3546784b39ce3eacc10411e68ada427c5764bcda3064e9bb284eca907983
+pkg_shasum=0464127140820d82b24bd2830232131ea85bcd49267a8bc7365e4fa391dee2a3
 pkg_deps=(
   core/coreutils-static
   core/glibc


### PR DESCRIPTION
This rides on the back of #1642 and should not be merged before it is accepted.

### Changes

1) Run service as root, manually drop root privileges for running elasticseach (in run hook). This allows kernel parameter tweaking required by elasticsearch.

2) Add in default minimum values required by elastic search to configuration

3) Cleanup toml. It was inconsistent in spacing and formatting.

### Testing

I'm using a multinode Vagrant cluster to test small clusters of services, such as Elasticsearch. You can grab / use the Vagrantfile here: https://gist.github.com/predominant/7a05f5afd7b72bc0af05afd65f4883e1

Create the cluster:

```
vagrant destroy -f
vagrant up
```

The following is done on all 3 VMs, via synchronized panes in tmux:

```
sudo su -
hab pkg install core/elasticsearch
hab svc load core/elasticsearch --topology leader --strategy rolling --bind elasticsearch:elasticsearch.default
```

Observe the cluster health after startup (about 30 seconds?)

```
curl -vvv http://$(ifconfig -a | grep "10.0.2" | awk '{print $2}'):9200/_cluster/health
```

![tenor-221668541](https://user-images.githubusercontent.com/24568/42308075-7ab1adb0-806f-11e8-9fc9-529b02b4f023.gif)
