### PR TITLE
[mc] Update to 4.8.21, prefer xz tarball

### DIFF
--- a/mc/plan.sh
+++ b/mc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=mc
 pkg_origin=core
-pkg_version=4.8.18
+pkg_version=4.8.21
 pkg_description="Midnight Commander."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-3.0')
-pkg_source=http://ftp.midnight-commander.org/mc-${pkg_version}.tar.bz2
+pkg_source=http://ftp.midnight-commander.org/mc-${pkg_version}.tar.xz
 pkg_upstream_url=https://www.midnight-commander.org
-pkg_shasum=5b591e10dcbea95233434da40cdad4663d360229adf89826576c319667c103cb
+pkg_shasum=8f37e546ac7c31c9c203a03b1c1d6cb2d2f623a300b86badfd367e5559fe148c
 pkg_deps=(
   core/glib
   core/glibc
@@ -26,11 +26,12 @@ pkg_build_deps=(
 pkg_bin_dirs=(bin)
 
 do_build() {
-  ./configure --prefix="$pkg_prefix" \
-              --with-screen=ncurses \
-              --with-ncurses-libs="$(pkg_path_for ncurses)/lib" \
-              --without-subshell \
-              --without-x \
-              --without-gpm-mouse
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --with-screen=ncurses \
+    --with-ncurses-libs="$(pkg_path_for ncurses)/lib" \
+    --without-subshell \
+    --without-x \
+    --without-gpm-mouse
   make
 }


### PR DESCRIPTION
![tenor-55588860](https://user-images.githubusercontent.com/24568/42311727-7f7213b2-8079-11e8-90fd-7e0a00fc1186.gif)

Testing:

```
hab studio enter
cd mc; build; source results/last_build.env; hab pkg install --binlink results/${pkg_artifact};
mc
```

You will see Midnight Commander open.

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

