### PR TITLE
[logstash] update to 6.3.1

### DIFF
--- a/logstash/plan.sh
+++ b/logstash/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=logstash
-pkg_version=6.1.0
+pkg_version=6.3.1
 pkg_description="Logstash is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite 'stash.'"
 pkg_upstream_url=https://github.com/elastic/logstash
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=(Apache-2.0)
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=97186ab6e6780bc53ba57a380ad0d6c1c94aeec29ca6883c17cfe7a845435ce8
+pkg_shasum=7ee85ea0b01c4ff3330402b070dda1e1238cde80fcf771b01ec1d1b4dc61160d
 pkg_deps=(core/bash
   core/jre8
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
cd logstash
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

hab pkg install core/busybox-static --binlink
ps | grep logstash
netstat -peanut
```

Confirm logstash is running and port is open (owned by java).