### PR TITLE
[memcached] Upgrade to 1.5.9, add readme

### DIFF
--- a/memcached/README.md
+++ b/memcached/README.md
@@ -1,0 +1,37 @@
+# Memcached
+
+Free & open source, high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+Simple usage:
+
+```
+hab pkg install core/memcached
+hab svc load core/memcached
+```
+
+Memcached is now available on port `11211` (default).
+
+## Topologies
+
+Memcached server nodes are not aware of each other.
+
+As such, `standalone` is the recommended topology.
+
+## Update Strategies
+
+Update strategies depend on how your application(s) depend on Memcached for operation. Both `at-once` and `rolling` would be appropriate, however the rolling requirement is that a leader-follower topology be used.
+
+## Monitoring
+
+Any network capable monitoring system can connect to the exposed port `11211` (by default) and issue the command `stats` to view basic system information for monitoring purposes.
+

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -34,4 +34,3 @@ Update strategies depend on how your application(s) depend on Memcached for oper
 ## Monitoring
 
 Any network capable monitoring system can connect to the exposed port `11211` (by default) and issue the command `stats` to view basic system information for monitoring purposes.
-

--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.4
+pkg_version=1.5.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=e0c3cfa89fa4c2ffd8aa45df7825c6d1a2423ac89ab1a7c4f42bb9803f7403d4
+pkg_shasum=4af3577dbf71cb0a748096dc6562ccd587cddb7565c720f1fdb23e8a34241d06
 pkg_deps=(core/glibc core/libevent)
 pkg_build_deps=(core/git core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Extra tools
hab pkg install core/busybox-static --binlink

# Confirm 11211 is listening
netstat -peanut

# Confirm exit code is 0
nc -z localhost 11211

# Confirm memcached is responding to simple commands
echo 'stats' | nc localhost 11211
```