### PR TITLE
[jenkins] Upgrade to 2.121.1

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,19 +1,18 @@
-# Habitat Package: core/jenkins
+# Jenkins
 
-## Description
+[Jenkins][jenkins] is a self-contained, open source automation server which can be used to automate all sorts of tasks such as building, testing, and deploying software.
 
-- [Jenkins Website](https://jenkins.io)
-- [Jenkins Documentation](https://jenkins.io/doc/)
+## Maintainers
 
-> Jenkins is a self-contained, open source automation server which can
-> be used to automate all sorts of tasks such as building, testing,
-> and deploying software. Jenkins can be installed through native
-> system packages, Docker, or even run standalone by any machine with
-> the Java Runtime Environment installed.
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
 
 ## Usage
 
-### Starting
+Start the service with Habitat:
 
 ```
 hab sup start core/jenkins
@@ -21,12 +20,18 @@ hab sup start core/jenkins
 
 ### Initial Password
 
-On first login, you will be asked for an initial admin password. This is
-generated automatically, and output in the supervisor log (check with
-`sup-log`), and is also available on disk at
-`/hab/svc/jenkins/data/secrets/initialAdminPassword`.
+On first login, you will be asked for an initial admin password. This is generated automatically, and output in the supervisor log (check with `sup-log`), and is also available on disk at `/hab/svc/jenkins/data/secrets/initialAdminPassword`.
+
+## Topologies
+
+Deploy Jenkins in a `standalone` topology, or leave it empty (default).
+
+## Update Strategies
+
+An `at-once` update strategy, or none work for Jenkins.
 
 ## Notes
 
-By default, this package is configured for plain HTTP and is intended
-for usage in secure environment.
+By default, this package is configured for plain HTTP and is intended for usage in secure environment.
+
+[jenkins]: https://jenkins.io

--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.107.1
+pkg_version=2.121.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('mit')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="cec74c80190ed1f6ce55d705d2f649ddb2eaf8aba3ae26796152921d46b31280"
+pkg_shasum="5bb075b81a3929ceada4e960049e37df5f15a1e3cfc9dc24d749858e70b48919"
 pkg_deps=(core/jre8 core/curl)
 pkg_exports=(
   [port]=jenkins.http.port


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Start studio with a port forward
HAB_DOCKER_OPTS="-p 10080:80" hab studio enter

# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Follow Logs - Confirm admin password is displayed
sl

# Extra tools
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static nc
hab pkg binlink core/busybox-static ifconfig

# Confirm 80 is listening
netstat -peanut

# Confirm listening (exit code 0)
IP_ADDRESS=$(ifconfig eth0 | grep 'inet addr' | awk -F'[: ]+' '{print $4}')
nc -z ${IP_ADDRESS} 80

# Browse to URL on local machine (port 10080) and confirm installer is displayed.
# It will show a page with heading: Getting Started / Unlock Jenkins
```

For reference, the admin password/unlock code in supervisor logs looks like this:
```
jenkins.default(O): *************************************************************
jenkins.default(O): *************************************************************
jenkins.default(O): *************************************************************
jenkins.default(O):
jenkins.default(O): Jenkins initial setup is required. An admin user has been created and a password generated.
jenkins.default(O): Please use the following password to proceed to installation:
jenkins.default(O):
jenkins.default(O): f0935859c11a42a59c8e6723cce748d4
jenkins.default(O):
jenkins.default(O): This may also be found at: /hab/svc/jenkins/data/secrets/initialAdminPassword
jenkins.default(O):
jenkins.default(O): *************************************************************
jenkins.default(O): *************************************************************
jenkins.default(O): *************************************************************
```