### PR TITLE
[mongodb] Fix mongodb linking

### DIFF
--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -9,58 +9,69 @@ pkg_shasum=1a9697c3ad2f5545b5160d5e32d5f3c0f6f0a3371ceb9fa85961aec513acd7ac
 pkg_upstream_url=https://www.mongodb.com/
 pkg_filename=${pkg_name}-src-r${pkg_version}.tar.gz
 pkg_dirname=${pkg_name}-src-r${pkg_version}
-pkg_deps=(core/gcc-libs core/glibc core/openssl)
-pkg_build_deps=(
+pkg_deps=(
   core/coreutils
+  core/gcc-libs
+  core/glibc
+  core/openssl
+)
+pkg_build_deps=(
   core/gcc
   core/glibc
   core/python2
   core/scons/2.5.1
   core/openssl
+  core/patchelf
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-pkg_svc_run="mongod --config $pkg_svc_config_path/mongod.conf"
-pkg_svc_user=hab
-pkg_svc_group=hab
+pkg_svc_run="mongod --config ${pkg_svc_config_path}/mongod.conf"
 pkg_exports=(
   [port]=mongod.net.port
 )
 pkg_exposes=(port)
 
 do_prepare() {
+  CC="$(pkg_path_for core/gcc)/bin/gcc"
+  CXX="$(pkg_path_for core/gcc)/bin/g++"
+  export CC
+  export CXX
 
-    CC="$(pkg_path_for core/gcc)/bin/gcc"
-    CXX="$(pkg_path_for core/gcc)/bin/g++"
-    export CC
-    export CXX
+  # create variables for our include and library pathes in a scons friendly format
+  # shellcheck disable=SC2001
+  INCPATH="$(echo "${CFLAGS}" | sed -e "s@-I@@g")"
+  # shellcheck disable=SC2001
+  INCPATH="$(echo "${INCPATH}" | sed -e "s@ @', '@g")"
+  # shellcheck disable=SC2001
+  LIBPATH="$(echo "${LDFLAGS}" | sed -e "s@-L@@g")"
+  # shellcheck disable=SC2001
+  LIBPATH="$(echo "${LIBPATH}" | sed -e "s@ @', '@g")"
+  export LIBPATH
+  export INCPATH
 
-    # create variables for our include and library pathes in a scons friendly format
-    # shellcheck disable=SC2001
-    INCPATH="$(echo "${CFLAGS}" | sed -e "s@-I@@g")"
-    # shellcheck disable=SC2001
-    INCPATH="$(echo "${INCPATH}" | sed -e "s@ @', '@g")"
-    # shellcheck disable=SC2001
-    LIBPATH="$(echo "${LDFLAGS}" | sed -e "s@-L@@g")"
-    # shellcheck disable=SC2001
-    LIBPATH="$(echo "${LIBPATH}" | sed -e "s@ @', '@g")"
-    export LIBPATH
-    export INCPATH
-
-    # because scons dislikes saving our variables, we will save our
-    # variables within the construct ourselves
-    sed -i "891s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
+  # because scons dislikes saving our variables, we will save our
+  # variables within the construct ourselves
+  sed -i "891s@**envDict@ENV = os.environ, CPPPATH = ['$INCPATH'], LIBPATH = ['$LIBPATH'], CFLAGS = os.environ['CFLAGS'], CXXFLAGS = os.environ['CXXFLAGS'], LINKFLAGS = os.environ['LDFLAGS'], CC = os.environ['CC'], CXX = os.environ['CXX'], PATH = os.environ['PATH'], **envDict@g" SConstruct
 }
 
 do_build() {
-    # This is currently necessary because MongoDB still uses Python 2.x
-    # When it supports Python 3.x, this line will be unnecessary
-    pip install typing pyyaml cheetah3
+  # This is currently necessary because MongoDB still uses Python 2.x
+  # When it supports Python 3.x, this line will be unnecessary
+  pip install typing pyyaml cheetah3
 
-    scons core --disable-warnings-as-errors --prefix="$pkg_prefix" --ssl -j"$(nproc)"
+  scons core --disable-warnings-as-errors --prefix="${pkg_prefix}" --ssl -j"$(nproc)"
 }
 
 do_install() {
-    scons install --disable-warnings-as-errors --prefix="$pkg_prefix" --ssl
+  scons install --disable-warnings-as-errors --prefix="${pkg_prefix}" --ssl
+  patchelf --set-rpath "${LD_RUN_PATH}" "${pkg_prefix}/bin/mongod"
+  patchelf --set-rpath "${LD_RUN_PATH}" "${pkg_prefix}/bin/mongo"
+  patchelf --set-rpath "${LD_RUN_PATH}" "${pkg_prefix}/bin/mongoperf"
+  patchelf --set-rpath "${LD_RUN_PATH}" "${pkg_prefix}/bin/mongos"
+  fix_interpreter "${pkg_prefix}/bin/install_compass" core/coreutils bin/env
+}
+
+do_strip() {
+  return 0
 }


### PR DESCRIPTION
![tenor-262492772](https://user-images.githubusercontent.com/24568/42453896-118d34b4-83c9-11e8-9def-85d00dd99348.gif)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fix mongodb linking. Fixes #1647 

cc: @scottvidmar @smacfarlane 

### Testing

```
# Build and install (Build takes A LONG TIME)
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Convenience
hab pkg binlink ${pkg_ident} mongos
hab pkg binlink ${pkg_ident} mongo
hab pkg binlink ${pkg_ident} mongod
hab pkg binlink ${pkg_ident} mongoperf

# Confirm can run:
mongod --version
mongos --version
mongo --version
mongoperf -h
```

### Sample output

```
[19][default:/src:130]# mongos --version
mongos version v3.6.4
git version: d0181a711f7e7f39e60b5aeb1dc7097bf6ae5856
OpenSSL version: OpenSSL 1.0.2n  7 Dec 2017
allocator: tcmalloc
modules: none
build environment:
    distarch: x86_64
    target_arch: x86_64


[20][default:/src:0]# mongo --version
MongoDB shell version v3.6.4
git version: d0181a711f7e7f39e60b5aeb1dc7097bf6ae5856
OpenSSL version: OpenSSL 1.0.2n  7 Dec 2017
allocator: tcmalloc
modules: none
build environment:
    distarch: x86_64
    target_arch: x86_64


[21][default:/src:0]# mongod --version
db version v3.6.4
git version: d0181a711f7e7f39e60b5aeb1dc7097bf6ae5856
OpenSSL version: OpenSSL 1.0.2n  7 Dec 2017
allocator: tcmalloc
modules: none
build environment:
    distarch: x86_64
    target_arch: x86_64


[22][default:/src:0]# mongoperf -h
mongoperf

usage:

  mongoperf < myjsonconfigfile

  {
    nThreads:<n>,     // number of threads (default 1)
    fileSizeMB:<n>,   // test file size (default 1MB)
    sleepMicros:<n>,  // pause for sleepMicros/nThreads between each operation (default 0)
    mmf:<bool>,       // if true do i/o's via memory mapped files (default false)
    r:<bool>,         // do reads (default false)
    w:<bool>,         // do writes (default false)
    recSizeKB:<n>,    // size of each write (default 4KB)
    syncDelay:<n>     // secs between fsyncs, like --syncdelay in mongod. (default 0/never)
  }

mongoperf is a performance testing tool. the initial tests are of disk subsystem performance; 
  tests of mongos and mongod will be added later.
most fields are optional.
non-mmf io is direct io (no caching). use a large file size to test making the heads
  move significantly and to avoid i/o coalescing
mmf io uses caching (the file system cache).
```

This package is strange. It has an init hook, but not a run hook. This ticket doesn't change the package behaviour, but just fixes the incorrect linking.