### PR TITLE
[hugo] Version up to 0.43

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,17 +1,17 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.42"
+pkg_version="0.43"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_source="https://github.com/gohugoio/hugo/releases/download/v${pkg_version}/hugo_${pkg_version}_Linux-64bit.tar.gz"
-pkg_shasum="788d733a98c6a59ac1584e4ea66ee8329fd66973b7bbfd4835e150175022a2d0"
+pkg_shasum="1be61308911461acfeb51d1858b46ed0b45d8bf78d06c0ac9779b5ee68c843a3"
 pkg_build_deps=(core/go)
 pkg_bin_dirs=(bin)
 pkg_upstream_url="https://gohugo.io"
 
 do_prepare() {
-  export GOPATH=$HAB_CACHE_SRC_PATH
+  export GOPATH="${HAB_CACHE_SRC_PATH}"
 }
 
 do_build() {
@@ -19,5 +19,5 @@ do_build() {
 }
 
 do_install() {
-  cp "$HAB_CACHE_SRC_PATH/hugo" "$pkg_prefix/bin/"
+  cp "${HAB_CACHE_SRC_PATH}/hugo" "${pkg_prefix}/bin/"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build and Install
build; source results/last_build.env; hab pkg install results/${pkg_artifact} --binlink

# Confirm version / running
hugo version
```

### Sample output

```
# hugo version
Hugo Static Site Generator v0.43 linux/amd64 BuildDate: 2018-07-09T10:00:08Z
```