### PR TITLE
[gocd-server] New package - GoCD Server

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -340,6 +340,8 @@ plan_path = "go"
 plan_path = "go14"
 [go17]
 plan_path = "go17"
+[gocd-server]
+plan_path = "gocd-server"
 [googlemock]
 plan_path = "googlemock"
 [googletest]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -130,6 +130,7 @@ filebeat @predominant
 gdk-pixbuf @rsertelon
 glib @rsertelon
 go @afiune @nellshamrell
+gocd-server @predominant
 grpcurl @afiune
 gtk2 @rsertelon
 harfbuzz @rsertelon

--- a/gocd-server/README.md
+++ b/gocd-server/README.md
@@ -1,0 +1,30 @@
+# GoCD Server
+
+[GoCD][gocd] is an open source tool which is used in software development to help teams and organizations automate the continuous delivery (CD) of software.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+```
+hab pkg install core/gocd-server
+hab svc load core/gocd-server
+```
+
+## Topologies
+
+Currently only supports `standalone` topology.
+
+## Update Strategies
+
+Currently only supports `at-once` or no update strategy.
+
+## Notes
+
+[gocd]: https://www.gocd.org

--- a/gocd-server/default.toml
+++ b/gocd-server/default.toml
@@ -1,0 +1,5 @@
+memory = "512m"
+max-memory = "1024m"
+max-perm-gen = "256m"
+port = 8153
+ssl-port = 8154

--- a/gocd-server/hooks/run
+++ b/gocd-server/hooks/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+exec 2>&1
+
+JAVA_HOME="$(hab pkg path core/jre8)"
+SERVER_WORK_DIR="{{pkg.svc_var_path}}"
+SERVER_MEM="{{cfg.memory}}"
+SERVER_MAX_MEM="{{cfg.max-memory}}"
+SERVER_MAX_PERM_GEN="{{cfg.max-perm-gen}}"
+GO_SERVER_PORT="{{cfg.port}}"
+GO_SERVER_SSL_PORT="{{cfg.ssl-port}}"
+
+export JAVA_HOME SERVER_WORK_DIR SERVER_MEM SERVER_MAX_MEM SERVER_MAX_PERM_GEN GO_SERVER_PORT GO_SERVER_SSL_PORT
+
+exec server.sh

--- a/gocd-server/hooks/run
+++ b/gocd-server/hooks/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-JAVA_HOME="$(hab pkg path core/jre8)"
+JAVA_HOME="{{pkgPathFor "core/jre8"}}"
 SERVER_WORK_DIR="{{pkg.svc_var_path}}"
 SERVER_MEM="{{cfg.memory}}"
 SERVER_MAX_MEM="{{cfg.max-memory}}"

--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -24,6 +24,6 @@ do_build() {
 
 do_install() {
   mkdir -p "${pkg_prefix}/bin"
-  cp * "${pkg_prefix}/bin"
+  cp ./* "${pkg_prefix}/bin"
   mv "${pkg_prefix}/bin/LICENSE" "${pkg_prefix}/"
 }

--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -1,0 +1,29 @@
+pkg_name=gocd-server
+pkg_origin=core
+pkg_version="18.6.0"
+pkg_buildnumber="6883"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_source="https://download.gocd.org/binaries/${pkg_version}-${pkg_buildnumber}/generic/go-server-${pkg_version}-${pkg_buildnumber}.zip"
+pkg_shasum="70aaba161e26ee1cef43740626a92aa39a70cf6bf81ae373102edddf157baae3"
+pkg_description="GoCD is an open source tool which is used in software development to help teams and organizations automate the continuous delivery (CD) of software."
+pkg_upstream_url="https://www.gocd.org"
+pkg_filename="go-server-${pkg_version}-${pkg_buildnumber}.zip"
+pkg_dirname="go-server-${pkg_version}"
+pkg_deps=(core/jre8)
+pkg_bin_dirs=(bin)
+pkg_exports=(
+  [port]=port
+  [ssl-port]=ssl-port
+)
+pkg_exposes=(port ssl-port)
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mkdir -p "${pkg_prefix}/bin"
+  cp * "${pkg_prefix}/bin"
+  mv "${pkg_prefix}/bin/LICENSE" "${pkg_prefix}/"
+}

--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -10,7 +10,10 @@ pkg_description="GoCD is an open source tool which is used in software developme
 pkg_upstream_url="https://www.gocd.org"
 pkg_filename="go-server-${pkg_version}-${pkg_buildnumber}.zip"
 pkg_dirname="go-server-${pkg_version}"
-pkg_deps=(core/jre8)
+pkg_deps=(
+  core/git
+  core/jre8
+)
 pkg_bin_dirs=(bin)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
### Testing

```
# Run studio (with port forwarding)
HAB_DOCKER_OPTS="-p 8153:8153" hab studio enter

# Build / Run service
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident}

# Wait about 60 seconds for startup to complete.

# Convenience
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static nc

# Confirm port open
netstat -peanut

# Confirm exit code is 0
nc -z localhost:8153
```

Finally, if you did enable the port forwarding, you can browse to GoCD server via: http://localhost:8153

