### PR TITLE
[unixodbc] Added plan for unixodbc

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1187,6 +1187,8 @@ plan_path = "ttyrec"
 plan_path = "tzdata"
 [unibilium]
 plan_path = "unibilium"
+[unixodbc]
+plan_path = "unixodbc"
 [unzip]
 plan_path = "unzip"
 [userspace-rcu]

--- a/unixodbc/README.md
+++ b/unixodbc/README.md
@@ -1,0 +1,15 @@
+# unixodbc
+
+ODBC driver manager for Unix. ODBC is an open specification for providing application developers with a predictable API with which to access Data Sources.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/unixodbc/plan.sh
+++ b/unixodbc/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=unixodbc
+pkg_origin=core
+pkg_version=2.3.6
+pkg_license=('LGPL2.1')
+pkg_upstream_url="http://www.unixodbc.org/"
+pkg_description="ODBC driver manager for Unix"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${pkg_version}.tar.gz"
+pkg_shasum="88b637f647c052ecc3861a3baa275c3b503b193b6a49ff8c28b2568656d14d69"
+pkg_dirname="unixODBC-${pkg_version}"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+pkg_deps=(
+  core/glibc
+  core/libtool
+)
+
+pkg_build_deps=(
+  core/binutils
+  core/gcc
+  core/make
+)
+
+do_build() {
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --disable-gui
+
+  make
+}


### PR DESCRIPTION
Added binary plan for unixodbc

I've built and compiled haskell projects against this that depends on the libs and headers.

Still working out usage details as far as driver management. You can set the path to your ODBC config files using env variables ODBCINI and ODBCSYSINI, so you can bundle your ODBC config with your app/service that depends on unixODBC.