### PR TITLE
[mongodb] Remove deprecated settings from mongod.conf

### DIFF
--- a/mongodb/config/mongod.conf
+++ b/mongodb/config/mongod.conf
@@ -57,12 +57,6 @@ net:
       pathPrefix: {{pkg.svc_files_path}}/tmp
       filePermissions: {{cfg.mongod.net.unix_domain_socket.file_permissions}}
 
-net:
-   http:
-      enabled: {{cfg.mongod.net.http.enabled}}
-      JSONPEnabled: {{cfg.mongod.net.http.jsonp_enabled}}
-      RESTInterfaceEnabled: {{cfg.mongod.net.http.rest_interface_enabled}}
-
 {{~#if cfg.mongod.net.ssl.enabled}}
 net:
    ssl:

--- a/mongodb/default.toml
+++ b/mongodb/default.toml
@@ -66,12 +66,6 @@ ipv6 = false
 	enabled = true
 	file_permissions = "0700"
 
-	#warning may produce vulnerabilties to server if enabled
-	[mongod.net.http]
-	enabled = false
-	jsonp_enabled = false
-	rest_interface_enabled = false
-
 	[mongod.net.ssl]
 	enabled = false
 	mode = "disabled"


### PR DESCRIPTION
MongoDB deprecated the settings for the REST interface in MongoDB 3.2 and officially removed them in MongDB 3.6.  The settings remained in the `config/mongod.conf` file causing the service to fail at start up.  This commit removes the `net.http` settings related to the REST interface to allow proper startup of MongoDB 3.6

See #1677 