### PR TITLE
[consul] Update to 1.2.1, Allow legacy UI

### DIFF
--- a/consul/default.toml
+++ b/consul/default.toml
@@ -11,9 +11,8 @@ bind = "127.0.0.1"
 data-dir = "/hab/svc/consul/data/consul"
 datacenter = "dc1"
 loglevel = "INFO"
-# Consul WebUI has been redesigned, switch this to true to use the new Beta UI
-# https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-new-ui
-beta_ui = false
+# Revert back to the Legacy UI
+legacy_ui = false
 # switch this to false you want to start in DEVMODE
 # https://www.consul.io/docs/guides/bootstrapping.html
 mode = true

--- a/consul/hooks/run
+++ b/consul/hooks/run
@@ -3,7 +3,7 @@
 exec 2>&1
 
 SERVERMODE={{cfg.server.mode}}
-export CONSUL_UI_BETA={{cfg.server.beta_ui}}
+export CONSUL_UI_LEGACY={{cfg.server.legacy_ui}}
 
 CONSUL_OPTS="-dev"
 if [ "$SERVERMODE" = true ]; then

--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.1.0
+pkg_version=1.2.1
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=09c40c8b5be868003810064916d8460bff334ccfb59a5046390224b27e052c45
+pkg_shasum=e4146334be453146890023303da3e0c815669e108a18fb7d742745df3414a31a
 pkg_filename=${pkg_name}-${pkg_version}_linux_amd64.zip
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-56953709](https://user-images.githubusercontent.com/24568/42664162-499c0b70-8674-11e8-9c57-24d2908eacf2.gif)

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident}

# Convenience
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat

# Confirm ports listening:
#   tcp: 8300, 8301, 8302, 8500, 8600
#   udp: 8301, 8302, 8600
netstat -peanut | grep consul
```

### Example output
```
tcp        0      0 127.0.0.1:8300          0.0.0.0:*               LISTEN      203/consul
tcp        0      0 127.0.0.1:8301          0.0.0.0:*               LISTEN      203/consul
tcp        0      0 127.0.0.1:8302          0.0.0.0:*               LISTEN      203/consul
tcp        0      0 127.0.0.1:8500          0.0.0.0:*               LISTEN      203/consul
tcp        0      0 127.0.0.1:8600          0.0.0.0:*               LISTEN      203/consul
udp        0      0 127.0.0.1:8600          0.0.0.0:*                           203/consul
udp        0      0 127.0.0.1:8301          0.0.0.0:*                           203/consul
udp        0      0 127.0.0.1:8302          0.0.0.0:*                           203/consul
```