### PR TITLE
[gnatsd] added config files for gnatsd

### DIFF
--- a/gnatsd/config/default.conf
+++ b/gnatsd/config/default.conf
@@ -33,4 +33,3 @@ max_payload: {{cfg.gnatsd.max_payload}}
 # Duration the server can block on a socket write to a client.  Exceeding the
 # deadline will designate a client as a slow consumer.
 write_deadline: "{{cfg.gnatsd.write_deadline}}"
-

--- a/gnatsd/config/default.conf
+++ b/gnatsd/config/default.conf
@@ -1,0 +1,36 @@
+net: {{cfg.gnatsd.net}}
+port: {{cfg.gnatsd.port}}
+http_port: {{cfg.gnatsd.http.port}}
+
+# logging options
+debug: {{cfg.gnatsd.logging.debug}}
+trace: {{cfg.gnatsd.logging.trace}}
+logtime: {{cfg.gnatsd.logging.log_time}}
+log_file: "{{cfg.gnatsd.logging.file}}"
+
+authorization {
+  user: "{{cfg.gnatsd.auth.user}}"
+  password: "{{cfg.gnatsd.auth.password}}"
+  timeout:  {{cfg.gnatsd.auth.timeout}}
+}
+
+# pid file
+pid_file: "{{cfg.gnatsd.pid_file}}"
+
+# Some system overides
+# max_connections
+max_connections: {{cfg.gnatsd.max_connections}}
+
+# max_subscriptions (per connection)
+max_subscriptions: {{cfg.gnatsd.max_subscriptions}}
+
+# maximum protocol control line
+max_control_line: {{cfg.gnatsd.max_control_line}}
+
+# maximum payload
+max_payload: {{cfg.gnatsd.max_payload}}
+
+# Duration the server can block on a socket write to a client.  Exceeding the
+# deadline will designate a client as a slow consumer.
+write_deadline: "{{cfg.gnatsd.write_deadline}}"
+

--- a/gnatsd/default.toml
+++ b/gnatsd/default.toml
@@ -1,0 +1,24 @@
+[gnatsd]
+net = "localhost"
+port = 4242
+use_auth = false
+pid_file = "/tmp/nats-server.pid"
+max_connections = 100
+max_subscriptions = 1000
+max_control_line = 512
+max_payload = 65536
+write_deadline = "2s"
+
+[gnatsd.http]
+port = 8222
+
+[gnatsd.auth]
+user = ""
+password = ""
+timeout = 1
+
+[gnatsd.logging]
+debug = true
+trace = true
+log_time = true
+file = ""

--- a/gnatsd/plan.sh
+++ b/gnatsd/plan.sh
@@ -10,8 +10,12 @@ pkg_shasum=18d6d1b014bfd262da101e15ed914e194b51b47e3e1a8ca4e8743c742d65310c
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)
-pkg_svc_run="${pkg_name}"
-
+pkg_svc_run="${pkg_name} -c ${pkg_svc_config_path}/default.conf"
+pkg_exports=(
+  [port]=gnatsd.port
+  [http_port]=gnatsd.http.port
+)
+pkg_exposes=(port http_port)
 
 do_begin() {
   export GOPATH="/hab/cache"


### PR DESCRIPTION
This PR adds config files for gnatsd as well as exporting the gnatsd and nats-http ports.  The config file was sourced from https://nats.io/documentation/server/gnatsd-config/ and the clustering section has been removed.