### PR TITLE
[python] Updated python for rfc 0003

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -995,6 +995,29 @@ plan_path = "pv"
 plan_path = "python"
 [python2]
 plan_path = "python2"
+paths = [
+  "python/*"
+]
+[python34]
+plan_path = "python34"
+paths = [
+  "python/*"
+]
+[python35]
+plan_path = "python35"
+paths = [
+  "python/*"
+]
+[python36]
+plan_path = "python36"
+paths = [
+  "python/*"
+]
+[python37]
+plan_path = "python37"
+paths = [
+  "python/*"
+]
 [qemu]
 plan_path = "qemu"
 [R]

--- a/python/plan.sh
+++ b/python/plan.sh
@@ -1,26 +1,35 @@
 pkg_name=python
 pkg_distname=Python
-pkg_version=3.6.5
+pkg_version=3.7.0
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
 pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
 pkg_upstream_url="https://www.python.org"
-pkg_dirname=${pkg_distname}-${pkg_version}
-pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
-pkg_shasum=53a3e17d77cd15c5230192b6a8c1e031c07cd9f34a2f089a731c6f6bd343d5c6
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/python bin/python3 bin/python3.7)
+
 pkg_deps=(
   core/bzip2
+  core/expat
   core/gcc-libs
   core/gdbm
   core/glibc
+  core/libffi
   core/ncurses
   core/openssl
   core/readline
   core/sqlite
   core/zlib
 )
+
 pkg_build_deps=(
   core/coreutils
   core/diffutils
@@ -29,10 +38,6 @@ pkg_build_deps=(
   core/make
   core/util-linux
 )
-pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
-pkg_include_dirs=(include)
-pkg_interpreters=(bin/python bin/python3 bin/python3.6)
 
 do_prepare() {
   sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
@@ -41,10 +46,16 @@ do_prepare() {
 
 do_build() {
   export LDFLAGS="$LDFLAGS -lgcc_s"
+
+  # TODO: We should build with `--enable-optimizations`
   ./configure --prefix="$pkg_prefix" \
               --enable-loadable-sqlite-extensions \
               --enable-shared \
+              --with-threads \
+              --with-system-expat \
+              --with-system-ffi \
               --with-ensurepip
+
   make
 }
 
@@ -55,11 +66,17 @@ do_check() {
 do_install() {
   do_default_install
 
-  # link python3.6 to python for pkg_interpreters
-  ln -rs "$pkg_prefix/bin/pip3.6" "$pkg_prefix/bin/pip"
-  ln -rs "$pkg_prefix/bin/pydoc3.6" "$pkg_prefix/bin/pydoc"
-  ln -rs "$pkg_prefix/bin/python3.6" "$pkg_prefix/bin/python"
-  ln -rs "$pkg_prefix/bin/python3.6-config" "$pkg_prefix/bin/python-config"
+  # link pythonx.x to python for pkg_interpreters
+  local v=${pkg_version%.*}
+  local mv=${v%.*}
+  ln -rs "$pkg_prefix/bin/pip$v" "$pkg_prefix/bin/pip"
+  ln -rs "$pkg_prefix/bin/pydoc$v" "$pkg_prefix/bin/pydoc"
+  ln -rs "$pkg_prefix/bin/python$v" "$pkg_prefix/bin/python"
+  ln -rs "$pkg_prefix/bin/python$v-config" "$pkg_prefix/bin/python-config"
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle$mv"
+  rm -vf "$pkg_prefix/bin/idle$v"
 
   platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
   cat <<EOF > "$platlib/_manylinux.py"

--- a/python/plan.sh
+++ b/python/plan.sh
@@ -67,16 +67,16 @@ do_install() {
   do_default_install
 
   # link pythonx.x to python for pkg_interpreters
-  local v=${pkg_version%.*}
-  local mv=${v%.*}
-  ln -rs "$pkg_prefix/bin/pip$v" "$pkg_prefix/bin/pip"
-  ln -rs "$pkg_prefix/bin/pydoc$v" "$pkg_prefix/bin/pydoc"
-  ln -rs "$pkg_prefix/bin/python$v" "$pkg_prefix/bin/python"
-  ln -rs "$pkg_prefix/bin/python$v-config" "$pkg_prefix/bin/python-config"
+  local minor=${pkg_version%.*}
+  local major=${minor%.*}
+  ln -rs "$pkg_prefix/bin/pip$minor" "$pkg_prefix/bin/pip"
+  ln -rs "$pkg_prefix/bin/pydoc$minor" "$pkg_prefix/bin/pydoc"
+  ln -rs "$pkg_prefix/bin/python$minor" "$pkg_prefix/bin/python"
+  ln -rs "$pkg_prefix/bin/python$minor-config" "$pkg_prefix/bin/python-config"
 
   # Remove idle as we are not building with Tk/x11 support so it is useless
-  rm -vf "$pkg_prefix/bin/idle$mv"
-  rm -vf "$pkg_prefix/bin/idle$v"
+  rm -vf "$pkg_prefix/bin/idle$major"
+  rm -vf "$pkg_prefix/bin/idle$minor"
 
   platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
   cat <<EOF > "$platlib/_manylinux.py"

--- a/python2/README.md
+++ b/python2/README.md
@@ -1,7 +1,6 @@
 # python2
 
-Python is a programming language that lets you work quickly
-  and integrate systems more effectively.
+Python is a programming language that lets you work quickly and integrate systems more effectively.
 
 ## Maintainers
 

--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -1,64 +1,41 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+# TODO: Should this be renamed to python27 in accordance with RFC 0003?
+# If so, the python2 namespace would need to be deprecated per RFC 0007
 pkg_name=python2
 pkg_distname=Python
-pkg_version=2.7.14
+pkg_version=2.7.15
 pkg_origin=core
-pkg_license=('Python-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_description="Python is a programming language that lets you work quickly
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
-pkg_upstream_url=https://www.python.org/
-pkg_dirname=${pkg_distname}-${pkg_version}
-pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
-pkg_shasum=304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8
-pkg_deps=(
-  core/bzip2
-  core/gcc-libs
-  core/gdbm
-  core/glibc
-  core/ncurses
-  core/openssl
-  core/readline
-  core/sqlite
-  core/zlib
-)
-pkg_build_deps=(
-  core/coreutils
-  core/diffutils
-  core/gcc
-  core/gdb
-  core/linux-headers
-  core/make
-  core/util-linux
-)
-pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
-pkg_include_dirs=(include Include)
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db"
+
 pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 
-do_prepare() {
-  sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
-  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
-
-  # Allow embedded sqlite to load extensions
-  # Uncertain if this is absolutely required, leaving commented for now.
-  # https://docs.python.org/2/library/sqlite3.html#f1
-  # sed -i 's/sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))//g' setup.py
-}
-
 do_build() {
+    # TODO: We should build with `--enable-optimizations`
     ./configure --prefix="$pkg_prefix" \
                 --enable-shared \
                 --enable-unicode=ucs4 \
+                --with-threads \
+                --with-system-expat \
+                --with-system-ffi \
                 --with-ensurepip
-    make
-}
 
-do_check() {
-  make test
+    make
 }
 
 do_install() {
   do_default_install
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle"
 
   platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
   cat <<EOF > "$platlib/_manylinux.py"

--- a/python34/README.md
+++ b/python34/README.md
@@ -1,4 +1,4 @@
-# python
+# python34
 
 Python is a programming language that lets you work quickly and integrate systems more effectively.
 

--- a/python34/plan.sh
+++ b/python34/plan.sh
@@ -1,0 +1,17 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+pkg_name=python34
+pkg_distname=Python
+pkg_version=3.4.8
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639"
+
+pkg_interpreters=(bin/python bin/python3 bin/python3.4)

--- a/python35/README.md
+++ b/python35/README.md
@@ -1,4 +1,4 @@
-# python
+# python35
 
 Python is a programming language that lets you work quickly and integrate systems more effectively.
 

--- a/python35/plan.sh
+++ b/python35/plan.sh
@@ -1,0 +1,17 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+pkg_name=python35
+pkg_distname=Python
+pkg_version=3.5.5
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5"
+
+pkg_interpreters=(bin/python bin/python3 bin/python3.5)

--- a/python36/README.md
+++ b/python36/README.md
@@ -1,4 +1,4 @@
-# python
+# python36
 
 Python is a programming language that lets you work quickly and integrate systems more effectively.
 

--- a/python36/plan.sh
+++ b/python36/plan.sh
@@ -1,0 +1,17 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+pkg_name=python36
+pkg_distname=Python
+pkg_version=3.6.6
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58"
+
+pkg_interpreters=(bin/python bin/python3 bin/python3.6)

--- a/python37/README.md
+++ b/python37/README.md
@@ -1,4 +1,4 @@
-# python
+# python37
 
 Python is a programming language that lets you work quickly and integrate systems more effectively.
 

--- a/python37/plan.sh
+++ b/python37/plan.sh
@@ -1,0 +1,17 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+pkg_name=python37
+pkg_distname=Python
+pkg_version=3.7.0
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
+
+pkg_interpreters=(bin/python bin/python3 bin/python3.7)


### PR DESCRIPTION
- Rolled python version forward to 3.7.0
- Broke out major versions of python in accordance with RFC 0003

General plan updates
- Build python with system libffi (This was required for 3.7 to build properly)
- Build python with system expat
- Removed idle since it isn't usable without tk/x11

Some TODOs/Questions:
It would make sense to compile with optimizations. This takes build time from 5 minutes up to ~40. Do others agree?

Should python2 be renamed to python27 in accordance with RFC 0003. Or since it is the only remaining python 2 version in support, does it make sense to leave it as python2? If we should rename, the python2 packages/namespace would need to be deprecated per RFC 0007.