### PR TITLE
Remove chef-run in init hook

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -55,18 +55,6 @@ exec 2>&1
 exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
-
-  # Init hook
-  cat << EOF >> "$pkg_prefix/hooks/init"
-#!/bin/sh
-
-export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
-
-cd {{pkg.path}}
-exec 2>&1
-exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
-EOF
-  chown 0755 "$pkg_prefix/hooks/init"
 }
 
 do_default_build() {


### PR DESCRIPTION
Updating scaffolding-chef to no longer attempt an initial chef-run in the init hook. Performing a potentially long-running chef-run there can cause the supervisor to hang.