### PR TITLE
[packer] Update packer to 1.2.5

### DIFF
--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.2.4
+pkg_version=1.2.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
-pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=258d1baa23498932baede9b40f2eca4ac363b86b32487b36f48f5102630e9fbb
+pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
+pkg_shasum="bc58aa3f3db380b76776e35f69662b49f3cf15cf80420fc81a15ce971430824c"
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
-pkg_upstream_url=packer.io
+pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build/install
build; source results/last_build.env; hab pkg install ${pkg_ident} --binlink;

# Confirm
packer --version
packer help

# Output
$ packer --version
1.2.5

$ packer help
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build       build image(s) from template
    fix         fixes templates from old versions of packer
    inspect     see components of a template
    push        push a template and supporting files to a Packer build service
    validate    check that a template is valid
    version     Prints the Packer version
```

