### PR TITLE
[libpng] Update libpng to 1.6.35

### DIFF
--- a/libpng/plan.sh
+++ b/libpng/plan.sh
@@ -26,11 +26,12 @@ pkg_lib_dirs=(lib)
 do_build() {
   _zlib_dir=$(pkg_path_for zlib)
 
-  ./configure --prefix="${pkg_prefix}" \
-              --host=x86_64-unknown-linux-gnu \
-              --build=x86_64-unknown-linux-gnu \
-              --disable-static \
-              --with-zlib-prefix="${_zlib_dir}"
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --host=x86_64-unknown-linux-gnu \
+    --build=x86_64-unknown-linux-gnu \
+    --disable-static \
+    --with-zlib-prefix="${_zlib_dir}"
   make
 }
 

--- a/libpng/plan.sh
+++ b/libpng/plan.sh
@@ -1,6 +1,7 @@
 pkg_name=libpng
 pkg_version=1.6.35
 pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("libpng")
 pkg_description="An Open, Extensible Image Format with Lossless Compression"
 pkg_upstream_url=http://www.libpng.org/pub/png/

--- a/libpng/plan.sh
+++ b/libpng/plan.sh
@@ -1,15 +1,24 @@
 pkg_name=libpng
-pkg_version=1.6.21
+pkg_version=1.6.35
 pkg_origin=core
-pkg_license=('libpng')
+pkg_license=("libpng")
 pkg_description="An Open, Extensible Image Format with Lossless Compression"
 pkg_upstream_url=http://www.libpng.org/pub/png/
-pkg_source=http://download.sourceforge.net/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
-pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=b36a3c124622c8e1647f360424371394284f4c6c4b384593e478666c59ff42d3
-pkg_deps=(core/glibc core/zlib)
-pkg_build_deps=(core/gcc core/make core/coreutils core/diffutils
-                core/autoconf core/automake)
+pkg_source="http://download.sourceforge.net/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=2b82ab3e996803b80bc73206857e826a155d3ebb374e8eb03a87a63c6f672cf7
+pkg_deps=(
+  core/glibc
+  core/zlib
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/coreutils
+  core/diffutils
+  core/autoconf
+  core/automake
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -23,4 +32,8 @@ do_build() {
               --disable-static \
               --with-zlib-prefix="${_zlib_dir}"
   make
+}
+
+do_check() {
+  make test
 }


### PR DESCRIPTION
Add testing and upgrade

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build with checks:
DO_CHECK=1 build

# Sample output:
============================================================================
Testsuite summary for libpng 1.6.35
============================================================================
# TOTAL: 33
# PASS:  33
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```