### PR TITLE
[gdb] Update GDB to work with python 3.7

### DIFF
--- a/gdb/fix-python37.patch
+++ b/gdb/fix-python37.patch
@@ -1,0 +1,66 @@
+From aeab512851bf6ed623d1c6c4305b6ce05e51a10c Mon Sep 17 00:00:00 2001
+From: Paul Koning <paul_koning@dell.com>
+Date: Fri, 8 Jun 2018 13:26:36 -0400
+Subject: [PATCH] Fix build issue with Python 3.7
+
+Originally reported in
+https://bugzilla.redhat.com/show_bug.cgi?id=1577396 -- gdb build fails
+with Python 3.7 due to references to a Python internal function whose
+declaration changed in 3.7.
+
+gdb/ChangeLog
+2018-06-08  Paul Koning  <paul_koning@dell.com>
+
+	    PR gdb/23252
+
+	    * python/python.c (do_start_initialization):
+	    Avoid call to internal Python API.
+	    (init__gdb_module): New function.
+---
+ gdb/ChangeLog       |  8 ++++++++
+ gdb/python/python.c | 18 +++++++++++++++---
+ 2 files changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/gdb/python/python.c b/gdb/python/python.c
+index 1805c906284..20fc674f20a 100644
+--- a/gdb/python/python.c
++++ b/gdb/python/python.c
+@@ -1667,6 +1667,17 @@ finalize_python (void *ignore)
+   restore_active_ext_lang (previous_active);
+ }
+ 
++#ifdef IS_PY3K
++/* This is called via the PyImport_AppendInittab mechanism called
++   during initialization, to make the built-in _gdb module known to
++   Python.  */
++PyMODINIT_FUNC
++init__gdb_module (void)
++{
++  return PyModule_Create (&python_GdbModuleDef);
++}
++#endif
++
+ static bool
+ do_start_initialization ()
+ {
+@@ -1707,6 +1718,9 @@ do_start_initialization ()
+      remain alive for the duration of the program's execution, so
+      it is not freed after this call.  */
+   Py_SetProgramName (progname_copy);
++
++  /* Define _gdb as a built-in module.  */
++  PyImport_AppendInittab ("_gdb", init__gdb_module);
+ #else
+   Py_SetProgramName (progname.release ());
+ #endif
+@@ -1716,9 +1730,7 @@ do_start_initialization ()
+   PyEval_InitThreads ();
+ 
+ #ifdef IS_PY3K
+-  gdb_module = PyModule_Create (&python_GdbModuleDef);
+-  /* Add _gdb module to the list of known built-in modules.  */
+-  _PyImport_FixupBuiltin (gdb_module, "_gdb");
++  gdb_module = PyImport_ImportModule ("_gdb");
+ #else
+   gdb_module = Py_InitModule ("_gdb", python_GdbMethods);
+ #endif

--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -37,6 +37,8 @@ do_prepare() {
   export CXXFLAGS="${CXXFLAGS} -O2 -fstack-protector-strong -Wformat -Werror=format-security "
   export CPPFLAGS="${CPPFLAGS} -Wdate-time"
   export LDFLAGS="${LDFLAGS} -Wl,-Bsymbolic-functions -Wl,-z,relro"
+
+  patch -p1 < "${PLAN_CONTEXT}/fix-python37.patch"
 }
 
 do_build() {

--- a/gdb7/plan.sh
+++ b/gdb7/plan.sh
@@ -18,7 +18,7 @@ pkg_deps=(
   core/expat
   core/guile
   core/bdwgc
-  core/python
+  core/python36
 )
 pkg_build_deps=(
   core/coreutils


### PR DESCRIPTION
Context on why this is necessary can be found https://sourceware.org/ml/gdb/2018-05/msg00027.html

GDB7 I've changed to core/python36 since there is no patch available for the GDB7 series. 