### PR TITLE
[node] Update core/node to 8.11.3 for consistency with core/node8

### DIFF
--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=8.11.2
+pkg_version=8.11.3
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=0ac2c4de270caa08b5adcdb3c6bcb8aae3651a37d035d385bc819fbacaf350e6
+pkg_shasum=0d7e795c0579226c8b197353bbb9392cae802f4fefa4787a2c0e678beaf85cce
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This is a strange one.

We already have 8.11.3 in `core/node8`, but it was never updated in `core/node`. This aligns the two to the same version.