### PR TITLE
[node10] New plan - node10

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -855,6 +855,11 @@ plan_path = "node9"
 paths = [
   "node/*",
 ]
+[node10]
+plan_path = "node10"
+paths = [
+  "node/*",
+]
 [node_exporter]
 plan_path = "node_exporter"
 [npth]

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=8.11.2
+pkg_version=8.11.3
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=0ac2c4de270caa08b5adcdb3c6bcb8aae3651a37d035d385bc819fbacaf350e6
+pkg_shasum=0d7e795c0579226c8b197353bbb9392cae802f4fefa4787a2c0e678beaf85cce
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=8.11.3
+pkg_version=10.7.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=0d7e795c0579226c8b197353bbb9392cae802f4fefa4787a2c0e678beaf85cce
+pkg_shasum=b9691cbc6e6a2e209a9b8cb88fd942802236dae06652080f582304dbdd505ad2
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node10/README.md
+++ b/node10/README.md
@@ -1,0 +1,15 @@
+# node10
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -1,0 +1,15 @@
+source "../node/plan.sh"
+
+pkg_name=node10
+pkg_origin=core
+pkg_version=10.7.0
+pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
+pkg_license=('MIT')
+pkg_upstream_url=https://nodejs.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
+pkg_shasum=b9691cbc6e6a2e209a9b8cb88fd942802236dae06652080f582304dbdd505ad2
+
+# the archive contains a 'v' version # prefix, but the default value of
+# pkg_dirname is node-${pkg_version} (without the v). This tweak makes build happy
+pkg_dirname=node-v$pkg_version


### PR DESCRIPTION
Should be merged after #1711 which adds node 10 to the common `core/node` plan.