### PR TITLE
Add dgraph-ratel plan

### DIFF
--- a/dgraph-ratel/README.md
+++ b/dgraph-ratel/README.md
@@ -1,0 +1,15 @@
+# Dgraph-ratel
+
+Dgraph is a distributed, transactiona, graph database written in go. This is the UI server for its visualizations
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dgraph-ratel/plan.sh
+++ b/dgraph-ratel/plan.sh
@@ -1,9 +1,9 @@
-pkg_name=dgraph
+pkg_name=dgraph-ratel
 pkg_origin=core
 pkg_version="1.0.6"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/${pkg_name}-io/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-linux-amd64.tar.gz"
+pkg_source="https://github.com/dgraph-io/dgraph/releases/download/v${pkg_version}/dgraph-linux-amd64.tar.gz"
 pkg_shasum="616a3dc22973c48bbe57036dde5ea91055761f565a22bfbe20b6079fd16a9156"
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/patchelf)


### PR DESCRIPTION
This plan was already in the .bldr.toml but there wasn't actually a plan for it :joy:

Also, bump the version for dgraph.

![](https://media3.giphy.com/media/xT77XGRCkgX6urqmY0/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>