### PR TITLE
[protobuf] Update to version 3.6.0

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -997,6 +997,8 @@ plan_path = "prometheus"
 plan_path = "prometheus-cpp"
 [protobuf]
 plan_path = "protobuf"
+[protobuf2]
+plan_path = "protobuf2"
 [protobuf-c]
 plan_path = "protobuf-c"
 [protobuf-cpp]

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -10,4 +10,8 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Provides the `protoc` binary for compiling Protocol Buffer definitions; e.g.:
+
+```
+hab pkg exec core/protobuf protoc --help
+```

--- a/protobuf/plan.sh
+++ b/protobuf/plan.sh
@@ -1,11 +1,21 @@
 pkg_name=protobuf
 pkg_origin=core
-pkg_version=2.6.1
+pkg_version=3.6.0
+
+pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
+pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 pkg_license=('BSD')
-pkg_source=https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2
-pkg_shasum=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
-pkg_deps=(core/gcc core/zlib)
+
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz
+pkg_shasum=1532154addf85080330fdd037949d4653dfce16550df5c70ea0cd212d8aff3af
+
+pkg_deps=(
+    core/gcc
+    core/zlib
+)
 pkg_build_deps=(core/make)
+
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)

--- a/protobuf2/README.md
+++ b/protobuf2/README.md
@@ -1,0 +1,13 @@
+# protobuf2
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/protobuf2/README.md
+++ b/protobuf2/README.md
@@ -10,4 +10,8 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Provides the `protoc` binary for compiling Protocol Buffer definitions; e.g.:
+
+```
+hab pkg exec core/protobuf2 protoc --help
+```

--- a/protobuf2/plan.sh
+++ b/protobuf2/plan.sh
@@ -1,0 +1,24 @@
+pkg_name=protobuf2
+pkg_origin=core
+pkg_version=2.6.1
+
+pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
+
+pkg_upstream_url="https://developers.google.com/protocol-buffers/"
+pkg_license=('BSD')
+
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+
+pkg_source=https://github.com/google/protobuf/releases/download/v${pkg_version}/protobuf-${pkg_version}.tar.bz2
+pkg_shasum=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
+pkg_dirname="protobuf-${pkg_version}"
+
+pkg_deps=(
+    core/gcc
+    core/zlib
+)
+pkg_build_deps=(core/make)
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)


### PR DESCRIPTION
Our `core/protobuf` package was pretty old; this brings it back up to date with the current release.

I've verified this by generating some protobuf-based code over in the Habitat repo.

Signed-off-by: Christopher Maier <cmaier@chef.io>