### PR TITLE
[caddy] Update caddy to v0.11.0 and enable service!

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -1,15 +1,61 @@
-# caddy
+# Caddy
 
 Fast, cross-platform HTTP/2 web server with automatic HTTPS
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Habitat Maintainers <humans@habitat.sh>
 
 ## Type of Package
 
-Binary package
+Service package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+This package can be used as binary or service package.
+
+Usage as a binary package is simply running the command after installation:
+
+```
+hab pkg install --binlink core/caddy
+caddy
+```
+
+As a service package, you can load the service and use the bundled default configuration:
+
+```
+hab pkg install core/caddy
+hab svc load core/caddy
+```
+
+Or you can wrap this with a configuration plan, by adding `core/caddy` as a runtime dependency of your plan:
+
+```
+...
+pkg_deps=(core/caddy)
+...
+```
+
+## Bindings
+
+Caddy exposes a `port` variable containing the HTTP listening port. This can be referenced in service bindings.
+
+```
+hab svc load my/service --bind caddy.default
+```
+
+## Topologies
+
+This package currently only supports the standalone topology.
+
+## Update Strategies
+
+The recommended update strategy is `at-once`.
+
+## Notes
+
+The default configuration is extremely simple and may likely not meet your specific needs.
+
+We recommend that for customization, you wrap this with a configuration plan as mentioned in the **Usage** section above.
+
+Additionally, the default configuration uses port `8080` to allow running without root privileges. If you want to run on a sub `1024` port number, you will need to compose a wrapper plan and change the `pkg_svc_user`.

--- a/caddy/config/Caddyfile
+++ b/caddy/config/Caddyfile
@@ -1,0 +1,5 @@
+0.0.0.0:{{cfg.http.port}}
+{{#if cfg.gzip.enabled ~}}
+gzip
+{{/if ~}}
+root {{pkg.svc_data_path}}

--- a/caddy/default.toml
+++ b/caddy/default.toml
@@ -1,0 +1,5 @@
+[http]
+port = 8080
+
+[gzip]
+enabled = true

--- a/caddy/plan.sh
+++ b/caddy/plan.sh
@@ -1,13 +1,24 @@
 pkg_name=caddy
-pkg_description="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
-pkg_upstream_url="https://caddyserver.com"
 pkg_origin=core
-pkg_version="v0.10.9"
+pkg_version="v0.11.0"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
-pkg_source="https://github.com/mholt/caddy/caddy"
+pkg_source="https://github.com/mholt/caddy/releases/download/v0.11.0/caddy_v0.11.0_linux_amd64.tar.gz"
+pkg_shasum="93e77bdbaba0a2b39f9e1de653d17ab1939491f7727948ec65750b4996d07c18"
+pkg_description="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
+pkg_upstream_url="https://caddyserver.com"
+pkg_svc_run="caddy -conf ${pkg_svc_config_path}/Caddyfile"
+pkg_exposes=(port)
+pkg_exports=(
+  [port]=http.port
+)
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc)
-pkg_scaffolding=core/scaffolding-go
-scaffolding_go_base_path=github.com/mholt/caddy/caddy
-scaffolding_go_build_deps=()
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  install -Dm755 "${HAB_CACHE_SRC_PATH}/caddy" "${pkg_prefix}/bin/caddy"
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-79950382](https://user-images.githubusercontent.com/24568/43061160-1e43e9de-8e8f-11e8-9877-5dc8ebb48927.gif)

### Testing

```
# Start studio with a port forward
HAB_DOCKER_OPTS="-p 18080:8080" hab studio enter

# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Follow Logs - Confirm admin password is displayed
sl

# Extra tools
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static nc
hab pkg binlink core/busybox-static ifconfig

# Confirm 8080 is listening
netstat -peanut

# Confirm listening (exit code 0)
IP_ADDRESS=$(ifconfig eth0 | grep 'inet addr' | awk -F'[: ]+' '{print $4}')
nc -z ${IP_ADDRESS} 8080

# Create a test file to serve
echo '<h1>Hello Habitat, via Caddy!</h1>' > /hab/svc/${pkg_name}/data/index.html

# Browse to URL on local machine (port 18080) and confirm hello message is displayed.
```
