### PR TITLE
[rabbitmq] Update RabbitMQ to 3.7.7

### DIFF
--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=rabbitmq
 pkg_distname="${pkg_name}-server"
 pkg_origin=core
-pkg_version=3.7.6
+pkg_version=3.7.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL')
 pkg_description="Open source multi-protocol messaging broker"
 pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source="https://github.com/rabbitmq/rabbitmq-server/releases/download/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz"
-pkg_shasum=acfa2960c45262e96747be2ade4f19e4f0280b1a760012583cad91b8393b7872
+pkg_shasum=3549963ba562768387095eddeb2e69b6885fb11c7f4a3b8f53250694b4265431
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

## Testing

Run with `DO_CHECK=1` set.

```
# Build and install
DO_CHECK=1 build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Check supervisor startup, confirm loaded (sample output below)
sl
```

### Sample output

```
hab-sup(MR): Supervisor Member-ID 4d9f8a6e97224a228ea615c5999d9d36
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting ctl-gateway on 127.0.0.1:9632
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
hab-sup(AG): The rakops/rabbitmq/3.7.7/20180725044148 service was successfully loaded
hab-sup(MR): Starting rakops/rabbitmq/3.7.7/20180725044148
rabbitmq.default(UCW): Watching user.toml
rabbitmq.default(HK): health_check, compiled to /hab/svc/rabbitmq/hooks/health_check
rabbitmq.default(HK): reconfigure, compiled to /hab/svc/rabbitmq/hooks/reconfigure
rabbitmq.default(HK): run, compiled to /hab/svc/rabbitmq/hooks/run
rabbitmq.default(HK): Hooks compiled
rabbitmq.default(SR): Hooks recompiled
default(CF): Updated env 518f2af11eccd67523648d807ed4d7b3f49be97398c34d0b7e28aacac667b4d1
default(CF): Updated .erlang.cookie 4ef335de23218ec952baf7cab13153f75711915cf5c1d13ada2105d2b174ef83
default(CF): Updated rabbitmq.conf 4544123ef8e4e61ec2bc85d8f54904bebfd0c514950459ceffd02d3aa198663e
rabbitmq.default(SR): Configuration recompiled
rabbitmq.default(SR): Initializing
rabbitmq.default(SV): Starting service as user=hab, group=hab
rabbitmq.default(O): Disabling management console
rabbitmq.default hook[health_check]:(HK): Error: unable to perform an operation on node 'rabbit@79ec163d37d4'. Please see diagnostics information and suggestions below.
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): Most common reasons for this are:
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK):  * Target node is unreachable (e.g. due to hostname resolution, TCP connection or firewall issues)
rabbitmq.default hook[health_check]:(HK):  * CLI tool fails to authenticate with the server (e.g. due to CLI tool's Erlang cookie not matching that of the server)
rabbitmq.default hook[health_check]:(HK):  * Target node is not running
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): In addition to the diagnostics info below:
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK):  * See the CLI, clustering and networking guides on http://rabbitmq.com/documentation.html to learn more
rabbitmq.default hook[health_check]:(HK):  * Consult server logs on node rabbit@79ec163d37d4
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): DIAGNOSTICS
rabbitmq.default hook[health_check]:(HK): ===========
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): attempted to contact: [rabbit@79ec163d37d4]
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): rabbit@79ec163d37d4:
rabbitmq.default hook[health_check]:(HK):   * connected to epmd (port 4369) on 79ec163d37d4
rabbitmq.default hook[health_check]:(HK):   * epmd reports: node 'rabbit' not running at all
rabbitmq.default hook[health_check]:(HK):                   no other nodes on 79ec163d37d4
rabbitmq.default hook[health_check]:(HK):   * suggestion: start the node
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default hook[health_check]:(HK): Current node details:
rabbitmq.default hook[health_check]:(HK):  * node name: rabbitmqcli66@79ec163d37d4
rabbitmq.default hook[health_check]:(HK):  * effective user's home directory: /hab/svc/rabbitmq/var
rabbitmq.default hook[health_check]:(HK):  * Erlang cookie hash: EbSK7nxia4UCAkuJh+zkDQ==
rabbitmq.default hook[health_check]:(HK):
rabbitmq.default(HK): Health check exited with an unknown status code, 69
rabbitmq.default(O): All plugins have been disabled.
rabbitmq.default(O): Applying plugin configuration to rabbit@79ec163d37d4...
rabbitmq.default(O): Plugin configuration unchanged.
rabbitmq.default(O): 2018-07-25 04:49:57.897 [error] <0.97.0> Failed to open crash log file /var/log/rabbitmq/log/crash.log with error: no such file or directory
rabbitmq.default(O): 2018-07-25 04:49:58.184 [info] <0.33.0> Application lager started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.431 [info] <0.33.0> Application xmerl started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.431 [info] <0.33.0> Application recon started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.431 [info] <0.33.0> Application jsx started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.431 [info] <0.33.0> Application crypto started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.595 [info] <0.33.0> Application mnesia started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.699 [info] <0.33.0> Application inets started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.708 [info] <0.33.0> Application os_mon started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.708 [info] <0.33.0> Application asn1 started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.709 [info] <0.33.0> Application public_key started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.808 [info] <0.33.0> Application ssl started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.814 [info] <0.33.0> Application ranch started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.814 [info] <0.33.0> Application ranch_proxy_protocol started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.814 [info] <0.33.0> Application rabbit_common started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:49:58.831 [info] <0.192.0>
rabbitmq.default(O):  Starting RabbitMQ 3.7.7 on Erlang 20.0
rabbitmq.default(O):  Copyright (C) 2007-2018 Pivotal Software, Inc.
rabbitmq.default(O):  Licensed under the MPL.  See http://www.rabbitmq.com/
rabbitmq.default(O):
rabbitmq.default(O):   ##  ##
rabbitmq.default(O):   ##  ##      RabbitMQ 3.7.7. Copyright (C) 2007-2018 Pivotal Software, Inc.
rabbitmq.default(O):   ##########  Licensed under the MPL.  See http://www.rabbitmq.com/
rabbitmq.default(O):   ######  ##
rabbitmq.default(O):   ##########  Logs: <stdout>
rabbitmq.default(O):
rabbitmq.default(O):               Starting broker...
rabbitmq.default(O): 2018-07-25 04:49:58.855 [info] <0.192.0>
rabbitmq.default(O):  node           : rabbit@79ec163d37d4
rabbitmq.default(O):  home dir       : /hab/svc/rabbitmq/var
rabbitmq.default(O):  config file(s) : /hab/svc/rabbitmq/config/rabbitmq.conf
rabbitmq.default(O):  cookie hash    : EbSK7nxia4UCAkuJh+zkDQ==
rabbitmq.default(O):  log(s)         : <stdout>
rabbitmq.default(O):  database dir   : /hab/svc/rabbitmq/var/db/rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:50:01.654 [info] <0.200.0> Memory high watermark set to 799 MiB (838464307 bytes) of 1999 MiB (2096160768 bytes) total
rabbitmq.default(O): 2018-07-25 04:50:01.665 [info] <0.202.0> Enabling free disk space monitoring
rabbitmq.default(O): 2018-07-25 04:50:01.665 [info] <0.202.0> Disk free limit set to 50MB
rabbitmq.default(O): 2018-07-25 04:50:01.674 [info] <0.204.0> Limiting to approx 1048476 file handles (943626 sockets)
rabbitmq.default(O): 2018-07-25 04:50:01.675 [info] <0.205.0> FHC read buffering:  OFF
rabbitmq.default(O): 2018-07-25 04:50:01.675 [info] <0.205.0> FHC write buffering: ON
rabbitmq.default(O): 2018-07-25 04:50:01.676 [info] <0.192.0> Node database directory at /hab/svc/rabbitmq/var/db/rabbit@79ec163d37d4 is empty. Assuming we need to join an existing cluster or initialise from scratch...
rabbitmq.default(O): 2018-07-25 04:50:01.676 [info] <0.192.0> Configured peer discovery backend: rabbit_peer_discovery_classic_config
rabbitmq.default(O): 2018-07-25 04:50:01.676 [info] <0.192.0> Will try to lock with peer discovery backend rabbit_peer_discovery_classic_config
rabbitmq.default(O): 2018-07-25 04:50:01.677 [info] <0.192.0> Peer discovery backend does not support locking, falling back to randomized delay
rabbitmq.default(O): 2018-07-25 04:50:01.677 [info] <0.192.0> Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping randomized startup delay.
rabbitmq.default(O): 2018-07-25 04:50:01.677 [info] <0.192.0> All discovered existing cluster peers:
rabbitmq.default(O): 2018-07-25 04:50:01.677 [info] <0.192.0> Discovered no peer nodes to cluster with
rabbitmq.default(O): 2018-07-25 04:50:01.687 [info] <0.33.0> Application mnesia exited with reason: stopped
rabbitmq.default(O): 2018-07-25 04:50:01.708 [info] <0.33.0> Application mnesia started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:50:01.802 [info] <0.192.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbitmq.default(O): 2018-07-25 04:50:01.825 [info] <0.192.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbitmq.default(O): 2018-07-25 04:50:01.854 [info] <0.192.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
rabbitmq.default(O): 2018-07-25 04:50:01.855 [info] <0.192.0> Peer discovery backend rabbit_peer_discovery_classic_config does not support registration, skipping registration.
rabbitmq.default(O): 2018-07-25 04:50:01.856 [info] <0.192.0> Priority queues enabled, real BQ is rabbit_variable_queue
rabbitmq.default(O): 2018-07-25 04:50:01.861 [info] <0.371.0> Starting rabbit_node_monitor
rabbitmq.default(O): 2018-07-25 04:50:01.884 [info] <0.192.0> message_store upgrades: 1 to apply
rabbitmq.default(O): 2018-07-25 04:50:01.884 [info] <0.192.0> message_store upgrades: Applying rabbit_variable_queue:move_messages_to_vhost_store
rabbitmq.default(O): 2018-07-25 04:50:01.885 [info] <0.192.0> message_store upgrades: No durable queues found. Skipping message store migration
rabbitmq.default(O): 2018-07-25 04:50:01.885 [info] <0.192.0> message_store upgrades: Removing the old message store data
rabbitmq.default(O): 2018-07-25 04:50:01.886 [info] <0.192.0> message_store upgrades: All upgrades applied successfully
rabbitmq.default(O): 2018-07-25 04:50:01.912 [info] <0.192.0> Adding vhost '/'
rabbitmq.default(O): 2018-07-25 04:50:01.928 [info] <0.407.0> Making sure data directory '/hab/svc/rabbitmq/var/db/rabbit@79ec163d37d4/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists
rabbitmq.default(O): 2018-07-25 04:50:01.933 [info] <0.407.0> Starting message stores for vhost '/'
rabbitmq.default(O): 2018-07-25 04:50:01.933 [info] <0.411.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_transient": using rabbit_msg_store_ets_index to provide index
rabbitmq.default(O): 2018-07-25 04:50:01.935 [info] <0.407.0> Started message store of type transient for vhost '/'
rabbitmq.default(O): 2018-07-25 04:50:01.935 [info] <0.414.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": using rabbit_msg_store_ets_index to provide index
rabbitmq.default(O): 2018-07-25 04:50:01.936 [warning] <0.414.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
rabbitmq.default(O): 2018-07-25 04:50:01.938 [info] <0.407.0> Started message store of type persistent for vhost '/'
rabbitmq.default(O): 2018-07-25 04:50:01.940 [info] <0.192.0> Creating user 'guest'
rabbitmq.default(O): 2018-07-25 04:50:01.943 [info] <0.192.0> Setting user tags for user 'guest' to [administrator]
rabbitmq.default(O): 2018-07-25 04:50:01.945 [info] <0.192.0> Setting permissions for 'guest' in '/' to '.*', '.*', '.*'
rabbitmq.default(O): 2018-07-25 04:50:01.950 [info] <0.452.0> started TCP Listener on [::]:5672
rabbitmq.default(O): 2018-07-25 04:50:01.954 [info] <0.192.0> Setting up a table for connection tracking on this node: tracked_connection_on_node_rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:50:01.959 [info] <0.192.0> Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost_on_node_rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:50:01.959 [info] <0.33.0> Application rabbit started on node rabbit@79ec163d37d4
rabbitmq.default(O): 2018-07-25 04:50:02.217 [info] <0.5.0> Server startup complete; 0 plugins started.
rabbitmq.default(O):  completed with 0 plugins.
```