### PR TITLE
Add initial chef-client run with no splay or interval

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -52,7 +52,8 @@ export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 cd {{pkg.path}}
 
 exec 2>&1
-exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb && chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
+exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
+exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
 }

--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -52,7 +52,7 @@ export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 cd {{pkg.path}}
 
 exec 2>&1
-exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
+exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb && chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
 }


### PR DESCRIPTION
By default, the chef scaffolding will wait for ```cfg.interval``` seconds before performing the initial chef-client run in the run hook. This change makes it perform an initial chef-client run without waiting, and then hand over to the chef-client with interval and splay configured going forwards.

Signed-off-by: Jon Cowie <jonlives@gmail.com>