### PR TITLE
[hugo] Update hugo to 0.45.1

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.45"
+pkg_version="0.45.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_source="https://github.com/gohugoio/hugo/releases/download/v${pkg_version}/hugo_${pkg_version}_Linux-64bit.tar.gz"
-pkg_shasum="5f03adc1b38609909e1f36add347ed838a8af0e770b2b26c8793ccf799465b42"
+pkg_shasum="e10e4162d4d568b92e3c8b49efeb1fc3fd6310138dc5d7a63b86b852d37af158"
 pkg_build_deps=(core/go)
 pkg_bin_dirs=(bin)
 pkg_upstream_url="https://gohugo.io"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact} --binlink
hugo version
```

### Sample Output

```
# hugo version
Hugo Static Site Generator v0.45.1 linux/amd64 BuildDate: 2018-07-25T08:56:24Z
```
