### PR TITLE
[vault] Update vault to 0.10.4

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.10.2
+pkg_version=0.10.4
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
-pkg_source=https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip
-pkg_shasum=f725be68316d10ef2e7779fdedd8eb5d4ed9975303c828466bb9a729e01392dd
-pkg_filename=${pkg_name}-${pkg_version}_linux_amd64.zip
+pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
+pkg_shasum=b3c8a62e8f2f1b2d9d7ddca3d8bda620ab0091bb038da0d013c26f7b6b18f13a
+pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact} --binlink

# Check / confirm version
vault --version
```

### Sample Output

```
# vault --version
Vault v0.10.4 ('e21712a687889de1125e0a12a980420b1a4f72d3')
```
