### PR TITLE
[scaffolding-chef] Move chef-client --once into init hook

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -43,6 +43,19 @@ do_default_build_service() {
   mkdir -p "$pkg_prefix/hooks"
   chown 0644 "$pkg_prefix/hooks"
 
+  # Init hook
+  cat << EOF >> "$pkg_prefix/hooks/init"
+#!/bin/sh
+
+export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
+
+cd {{pkg.path}}
+
+exec 2>&1
+exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
+EOF
+  chown 0755 "$pkg_prefix/hooks/init"
+
   # Run hook
   cat << EOF >> "$pkg_prefix/hooks/run"
 #!/bin/sh
@@ -52,8 +65,7 @@ export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 cd {{pkg.path}}
 
 exec 2>&1
-exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
-exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
+chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
 }

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.1.1"
+pkg_version="0.1.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
The PR moves the chef-client --once command into an init hook.

After #1729 chef-client seems to run in an infinite loop.  Has anyone else noticed this?

```bash
chef-base.default(SR): Initializing
chef-base.default(SV): Starting service as user=root, group=hab
chef-base.default(O): Starting Chef Client, version 14.2.0
chef-base.default(O): Using policy 'base' at revision '0d8dad1143c63810bbec1ea9085152ff24824fd55710fb8393c025b4513fc001'
chef-base.default(O): resolving cookbooks for run list: ["patching::default@0.1.0 (b864f79)"]
chef-base.default(O): Synchronizing Cookbooks:
chef-base.default(O):   - fb_sysctl (0.0.1)
chef-base.default(O):   - fb_helpers (0.1.0)
chef-base.default(O):   - habitat (0.59.0)
chef-base.default(O):   - audit (7.0.1)
chef-base.default(O):   - ntp (3.6.0)
chef-base.default(O):   - patching (0.1.0)
chef-base.default(O): Installing Cookbook Gems:
chef-base.default(O): Compiling Cookbooks...
chef-base.default(O): Converging 0 resources
chef-base.default(O):
chef-base.default(O): Running handlers:
chef-base.default(O): Running handlers complete
chef-base.default(O): Chef Client finished, 0/0 resources updated in 04 seconds
hab-launch(SV): Child for service 'chef-base.default' with PID 1224 exited with code exit code: 0
chef-base.default(SV): Starting service as user=root, group=hab
chef-base.default(O): Starting Chef Client, version 14.2.0
chef-base.default(O): Using policy 'base' at revision '0d8dad1143c63810bbec1ea9085152ff24824fd55710fb8393c025b4513fc001'
```

Signed-off-by: gscho <greg.c.schofield@gmail.com>