### PR TITLE
[dep] Update golang dep to 0.5.0

### DIFF
--- a/dep/plan.sh
+++ b/dep/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=dep
 pkg_origin=core
-pkg_version=0.4.1
+pkg_version=0.5.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Go dependency management tool"
 pkg_license="BSD-3-Clause"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-168639469](https://user-images.githubusercontent.com/24568/43300294-4e2d4cc8-9199-11e8-95fa-a06fabbbfd22.gif)

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install --binlink results/${pkg_artifact}

# Confirm
dep version
```

### Sample output

```
# dep version
dep:
 version     : v0.5.0
 build date  : 2018-07-27
 git hash    : 224a564a
 go version  : go1.10.1
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
```
