### PR TITLE
[Filebeat] Add runtime glibc dep to filebeat

### DIFF
--- a/filebeat/plan.sh
+++ b/filebeat/plan.sh
@@ -1,8 +1,10 @@
+# shellcheck disable=SC2164
 pkg_name=filebeat
 pkg_origin=core
 pkg_version="6.3.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
+pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/git core/make core/gcc)
 pkg_bin_dirs=(bin)
 pkg_binds_optional=(


### PR DESCRIPTION
Filebeat has a runtime dependency on `ld-linux-x86-64.so.2` which is provided by  core/glibc.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>