### PR TITLE
[leproxy] Add new plan for leproxy

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -533,6 +533,8 @@ paths = [
 plan_path = "lcms2"
 [leiningen]
 plan_path = "leiningen"
+[leproxy]
+plan_path = "leproxy"
 [leptonica]
 plan_path = "leptonica"
 [less]

--- a/leproxy/README.md
+++ b/leproxy/README.md
@@ -1,0 +1,43 @@
+# leproxy
+
+HTTPS reverse proxy with automatic Letsencrypt usage for multiple hostnames/backends.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+`leproxy` is a simple HTTPS proxy, and configuration will be specific to the backend services that are being proxied. As such, this package remains as a binary package that can be wrapped by service plans. Since this uses name based directives in `mapping.yml` there is no appropriate default settings.
+
+A simple proxy would include a configuration `mapping.yml` matching server names to be used with their backends:
+
+```yml
+subdomain1.example.com: 127.0.0.1:8080
+subdomain2.example.com: /var/run/http.socket
+static.example.com: /var/www/
+```
+
+For a full example, please see the [leproxy readme][leproxy-readme].
+
+This config would be paired with the service run command, such as:
+
+```sh
+leproxy -addr :https -map /path/to/mapping.yml -cacheDir /path/to/letsencrypt
+```
+
+Here is a full plan example, using leproxy:
+
+```sh
+pkg_name=web-proxy
+pkg_origin=myorigin
+pkg_version="0.1.0"
+
+pkg_svc_run="leproxy -addr :https -map ${pkg_svc_config_path}/mapping.yml -cacheDir ${pkg_svc_var_path}/letsencrypt"
+```
+
+[leproxy-readme]: https://github.com/artyom/leproxy

--- a/leproxy/plan.sh
+++ b/leproxy/plan.sh
@@ -1,0 +1,19 @@
+pkg_name=leproxy
+pkg_origin=core
+pkg_version="20180113"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("MIT")
+pkg_source="https://github.com/artyom/${pkg_name}/releases/download/${pkg_version}/leproxy-linux-amd64.tar.gz"
+pkg_shasum="c8a7ee698c8f4b4f828905d13978de30a79d6d394f992d8b1a170469c8e0d148"
+pkg_deps=(core/glibc)
+pkg_bin_dirs=(bin)
+pkg_description="https reverse proxy with automatic Letsencrypt usage for multiple hostnames/backends"
+pkg_upstream_url="https://github.com/artyom/leproxy"
+
+do_build() {
+  mv "${HAB_CACHE_SRC_PATH}/leproxy" "${HAB_CACHE_SRC_PATH}/${pkg_dirname}/"
+}
+
+do_install() {
+  install -Dm755 leproxy "${pkg_prefix}/bin/leproxy"
+}

--- a/leproxy/plan.sh
+++ b/leproxy/plan.sh
@@ -5,7 +5,6 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
 pkg_source="https://github.com/artyom/${pkg_name}/releases/download/${pkg_version}/leproxy-linux-amd64.tar.gz"
 pkg_shasum="c8a7ee698c8f4b4f828905d13978de30a79d6d394f992d8b1a170469c8e0d148"
-pkg_deps=(core/glibc)
 pkg_bin_dirs=(bin)
 pkg_description="https reverse proxy with automatic Letsencrypt usage for multiple hostnames/backends"
 pkg_upstream_url="https://github.com/artyom/leproxy"


### PR DESCRIPTION
New plan for leproxy (Lets Encrypt Proxy).

### Testing

```
# Build and install
build; source results/last_build.env; hab pkg install --binlink results/${pkg_artifact}

# Test command
leproxy -version
```

Running the above test will show command usage. 