### PR TITLE
[consul] Update consul to 1.2.2, and add testing

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.2.1
+pkg_version=1.2.2
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
-pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=e4146334be453146890023303da3e0c815669e108a18fb7d742745df3414a31a
-pkg_filename=${pkg_name}-${pkg_version}_linux_amd64.zip
+pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
+pkg_shasum=7fa3b287b22b58283b8bd5479291161af2badbc945709eb5412840d91b912060
+pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)
@@ -25,7 +25,7 @@ pkg_svc_group="${pkg_svc_user}"
 
 do_unpack() {
   cd "${HAB_CACHE_SRC_PATH}" || exit
-  unzip ${pkg_filename} -d "${pkg_name}-${pkg_version}"
+  unzip "${pkg_filename}" -d "${pkg_name}-${pkg_version}"
 }
 
 do_build() {

--- a/consul/test.sh
+++ b/consul/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 test_value() {
-  if [ $1 -eq $2 ]; then
+  if [ ${1} -eq ${2} ]; then
     printf "Pass"
   else
     printf "FAIL"
@@ -43,7 +43,7 @@ wait_listen tcp 9632 30
 
 # Ensure environment is clean for service testing
 source ./plan.sh
-hab svc unload ${HAB_ORIGIN}/${pkg_name}
+hab svc unload "${HAB_ORIGIN}/${pkg_name}"
 
 # Build and install
 set -e

--- a/consul/test.sh
+++ b/consul/test.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+test_value() {
+  if [ $1 -eq $2 ]; then
+    printf "Pass"
+  else
+    printf "FAIL"
+  fi
+}
+
+# Usage: test_listen <protocol> <port> [wait-duration]
+# protocol: tcp or udp
+# port: int
+# wait-duration: time in seconds
+test_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-3}
+  nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
+  test_value $? 0
+  echo " ... Listening on ${1}/${2}"
+}
+
+wait_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-1}
+  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
+    sleep 1
+  done
+}
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+
+# Wait for supervisor to start
+echo "Waiting for supervisor to start"
+wait_listen tcp 9632 30
+
+# Ensure environment is clean for service testing
+source ./plan.sh
+hab svc unload ${HAB_ORIGIN}/${pkg_name}
+
+# Build and install
+set -e
+build
+source results/last_build.env
+hab pkg install "results/${pkg_artifact}"
+hab svc load "${pkg_ident}"
+set +e
+
+# Confirm ports listening:
+# * tcp: 8300, 8301, 8302, 8500, 8600
+# * udp: 8301, 8302, 8600
+# Wait for 30 seconds on first check, to ensure service is up.
+echo "Waiting for consul to start"
+wait_listen tcp 8300 30
+
+echo "---------------------------------------"
+echo "Test Output"
+echo "---------------------------------------"
+
+test_listen tcp 8300
+test_listen tcp 8301
+test_listen tcp 8302
+test_listen tcp 8500
+test_listen tcp 8600
+test_listen udp 8301
+test_listen udp 8302
+test_listen udp 8600

--- a/consul/test.sh
+++ b/consul/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 test_value() {
-  if [ ${1} -eq ${2} ]; then
+  if [ "${1}" -eq "${2}" ]; then
     printf "Pass"
   else
     printf "FAIL"


### PR DESCRIPTION
![tenor-79564648](https://user-images.githubusercontent.com/24568/43440074-e4f3bcf2-94d0-11e8-8e55-f723a2bb8302.gif)

This does a minor upgrade (addresses security/bugfixes in consul). But also adds testing.

### Testing

```
hab studio enter
cd consul
./test.sh
```

```
---------------------------------------
Test Output
---------------------------------------
Pass ... Listening on tcp/8300
Pass ... Listening on tcp/8301
Pass ... Listening on tcp/8302
Pass ... Listening on tcp/8500
Pass ... Listening on tcp/8600
Pass ... Listening on udp/8301
Pass ... Listening on udp/8302
Pass ... Listening on udp/8600
```