### PR TITLE
[sbt] add new plan using version 1.1.6

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1129,6 +1129,8 @@ plan_path = "rust"
 plan_path = "rust-nightly"
 [sassc]
 plan_path = "sassc"
+[sbt]
+plan_path = "sbt"
 [scaffolding-base]
 plan_path = "scaffolding-base"
 [scaffolding-chef]

--- a/sbt/README.md
+++ b/sbt/README.md
@@ -1,0 +1,17 @@
+# SBT
+
+[sbt](1) is a build tool for Scala, Java, and more.
+
+## Maintainers
+
+The Habitat Maintainers: <humans@habitat.sh>
+
+## Usage
+
+This is binary package. To use `sbt` in the dev shell:
+
+```
+hab pkg binlink core/maven mvn
+```
+
+[1]: https://www.scala-sbt.org/1.x/docs/index.html

--- a/sbt/README.md
+++ b/sbt/README.md
@@ -11,7 +11,8 @@ The Habitat Maintainers: <humans@habitat.sh>
 This is binary package. To use `sbt` in the dev shell:
 
 ```
-hab pkg binlink core/maven mvn
+hab pkg install core/jre8 --binlink
+hab pkg install core/sbt --binlink
 ```
 
 [1]: https://www.scala-sbt.org/1.x/docs/index.html

--- a/sbt/README.md
+++ b/sbt/README.md
@@ -1,6 +1,6 @@
 # SBT
 
-[sbt](1) is a build tool for Scala, Java, and more.
+[sbt][1] is a build tool for Scala, Java, and more.
 
 ## Maintainers
 
@@ -8,7 +8,7 @@ The Habitat Maintainers: <humans@habitat.sh>
 
 ## Usage
 
-This is binary package. To use `sbt` in the dev shell:
+This is a binary package. To use `sbt` in the dev shell:
 
 ```
 hab pkg install core/jre8 --binlink

--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -29,8 +29,8 @@ do_build() {
 }
 
 do_install() {
-  mkdir -p $pkg_prefix/share
-  cp -ra $HAB_CACHE_SRC_PATH/sbt $pkg_prefix/share
-  ln -s $pkg_prefix/share/sbt/bin/sbt $pkg_prefix/bin/
+  mkdir -p "$pkg_prefix/share"
+  cp -ra "$HAB_CACHE_SRC_PATH/sbt" "$pkg_prefix/share"
+  ln -s "$pkg_prefix/share/sbt/bin/sbt" "$pkg_prefix/bin/"
   fix_interpreter "${pkg_prefix}/bin/sbt" core/coreutils bin/env
 }

--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,4 +1,4 @@
-pkg_origin=afiore
+pkg_origin=core
 pkg_name=sbt
 pkg_version=1.1.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -8,7 +8,6 @@ pkg_license=("BSD-3-Clause")
 pkg_source=https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz
 pkg_shasum=f545b530884e3abbca026df08df33d5a15892e6d98da5b8c2297413d1c7b68c1
 pkg_dirname="$pkg_name-$pkg_version"
-pkg_interpreters=(bin/bash)
 pkg_deps=(
   core/coreutils
   core/jre8
@@ -19,8 +18,8 @@ pkg_deps=(
 pkg_bin_dirs=(bin)
 
 do_prepare() {
-  export JAVA_HOME
   JAVA_HOME="$(pkg_path_for jre8)"
+  export JAVA_HOME
   build_line "Setting JAVA_HOME=$JAVA_HOME"
 }
 

--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,0 +1,36 @@
+pkg_origin=afiore
+pkg_name=sbt
+pkg_version=1.1.6
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="A build tool for Scala, Java, and more"
+pkg_upstream_url="https://www.scala-sbt.org"
+pkg_license=("BSD-3-Clause")
+pkg_source=https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz
+pkg_shasum=f545b530884e3abbca026df08df33d5a15892e6d98da5b8c2297413d1c7b68c1
+pkg_dirname="$pkg_name-$pkg_version"
+pkg_interpreters=(bin/bash)
+pkg_deps=(
+  core/coreutils
+  core/jre8
+  core/bash
+  core/sed
+  core/grep
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  export JAVA_HOME
+  JAVA_HOME="$(pkg_path_for jre8)"
+  build_line "Setting JAVA_HOME=$JAVA_HOME"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mkdir -p $pkg_prefix/share
+  cp -ra $HAB_CACHE_SRC_PATH/sbt $pkg_prefix/share
+  ln -s $pkg_prefix/share/sbt/bin/sbt $pkg_prefix/bin/
+  fix_interpreter "${pkg_prefix}/bin/sbt" core/coreutils bin/env
+}


### PR DESCRIPTION
Add a plan for Scala build tool `sbt`.

[plan in bldr](https://bldr.habitat.sh/#/pkgs/afiore/sbt/1.1.6/20180731063806)

Other implementations, like [cvasquez/sbt](https://bldr.habitat.sh/#/pkgs/cvasquez/sbt/latest) didn't require `core/bash`, `core/grep` and `core/sed`. These are all used by sbt's bootstrapping, so I thought to add them as run-time dependencies. 

Signed-off-by: Andrea Fiore <andrea.giulio.fiore@gmail.com>