### PR TITLE
[redis3] Update redis to 3.2.12

### DIFF
--- a/redis3/plan.sh
+++ b/redis3/plan.sh
@@ -5,6 +5,7 @@ pkg_origin=core
 pkg_version="3.2.12"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io"
+pkg_license=("BSD-3-Clause")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
 pkg_shasum="98c4254ae1be4e452aa7884245471501c9aa657993e0318d88f048093e7f88fd"

--- a/redis3/plan.sh
+++ b/redis3/plan.sh
@@ -2,10 +2,10 @@ source '../redis/plan.sh'
 
 pkg_name=redis3
 pkg_origin=core
-pkg_version="3.2.4"
+pkg_version="3.2.12"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
-pkg_shasum="2ad042c5a6c508223adeb9c91c6b1ae091394b4026f73997281e28914c9369f1"
+pkg_shasum="98c4254ae1be4e452aa7884245471501c9aa657993e0318d88f048093e7f88fd"
 pkg_dirname="${pkg_dist_name}-${pkg_version}"

--- a/redis4/plan.sh
+++ b/redis4/plan.sh
@@ -5,6 +5,7 @@ pkg_origin=core
 pkg_version="4.0.10"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io"
+pkg_license=("BSD-3-Clause")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
 pkg_shasum="1db67435a704f8d18aec9b9637b373c34aa233d65b6e174bdac4c1b161f38ca4"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Convenience tools
hab pkg install --binlink core/busybox-static
unalias grep egrep fgrep

# Build and install (+ binlink)
build; source results/last_build.env; hab pkg install --binlink results/${pkg_artifact}

# Configuration, password
echo '
requirepass="password"
' | hab config apply redis3.default $(date +%s)

# Load service
hab svc load ${pkg_ident}

# Wait for 5 seconds, Begin testing
## Test Listening
NETSTAT_RESULT=$(netstat -peanut | grep redis-server)
if [ $(echo "${NETSTAT_RESULT}" | wc -l) -eq 2 ]; then printf "Pass"; else printf "FAIL"; fi; echo " - Redis is listening"

## Test basic functions
for i in {0..24}; do redis-cli -a password incr habitat-test-key > /dev/null; done
REDIS_RESULT=$(redis-cli -a password get habitat-test-key)
if [ $(echo "${REDIS_RESULT}") -eq 25 ]; then printf "Pass"; else printf "FAIL"; fi; echo " - Basic Redis functionality"

# Cleanup
hab svc unload ${pkg_origin}/${pkg_name}
```