### PR TITLE
[node/node10] Update NodeJS to 10.8.0

### DIFF
--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=10.7.0
+pkg_version=10.8.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=b9691cbc6e6a2e209a9b8cb88fd942802236dae06652080f582304dbdd505ad2
+pkg_shasum=5584205b601a5bb0727eb5dd0c9824caf26ce1c02fd157d31e14b3a8765a0c0c
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -2,13 +2,13 @@ source "../node/plan.sh"
 
 pkg_name=node10
 pkg_origin=core
-pkg_version=10.7.0
+pkg_version=10.8.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=b9691cbc6e6a2e209a9b8cb88fd942802236dae06652080f582304dbdd505ad2
+pkg_shasum=5584205b601a5bb0727eb5dd0c9824caf26ce1c02fd157d31e14b3a8765a0c0c
 
 # the archive contains a 'v' version # prefix, but the default value of
 # pkg_dirname is node-${pkg_version} (without the v). This tweak makes build happy


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
build; source results/last_build.env; hab pkg install --binlink results/${pkg_artifact}
node --version
```

### Sample Output

```
# node --version
v10.8.0
```

Combined node and node10 into the same PR as they're approved by the same people.

![tenor-171291327](https://user-images.githubusercontent.com/24568/43570620-be7a0a76-9675-11e8-9f99-d02fb98d52ad.gif)
