### PR TITLE
[git] Update git to 2.18.0

### DIFF
--- a/git/plan.ps1
+++ b/git/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name = "git"
 $pkg_origin = "core"
-$pkg_version = "2.13.3"
+$pkg_version = "2.18.0"
 $pkg_description = "Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
   speed and efficiency."
@@ -9,7 +9,7 @@ $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license = @("Apache-2.0")
 $pkg_license= @("GPL-2.0")
 $pkg_source = "https://github.com/git-for-windows/git/releases/download/v$pkg_version.windows.1/Git-$pkg_version-64-bit.tar.bz2"
-$pkg_shasum = "741da847e4d8ee7c21eebf4d9ac6bbe6766cf50d388a4ac269751ec1bb2e051d"
+$pkg_shasum = "120b7501b5563212f1ecbcd8fadac257e510067e0297ff844bc3b18d90eefb96"
 $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @("core/7zip")
 

--- a/git/plan.ps1
+++ b/git/plan.ps1
@@ -6,8 +6,7 @@ $pkg_description = "Git is a free and open source distributed version control
   speed and efficiency."
 $pkg_upstream_url = "https://git-scm.com/"
 $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
-$pkg_license = @("Apache-2.0")
-$pkg_license= @("GPL-2.0")
+$pkg_license = @("GPL-2.0")
 $pkg_source = "https://github.com/git-for-windows/git/releases/download/v$pkg_version.windows.1/Git-$pkg_version-64-bit.tar.bz2"
 $pkg_shasum = "120b7501b5563212f1ecbcd8fadac257e510067e0297ff844bc3b18d90eefb96"
 $pkg_bin_dirs = @("bin")

--- a/git/plan.sh
+++ b/git/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=git
-pkg_version=2.14.4
+pkg_version=2.18.0
 pkg_origin=core
 pkg_description="Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
@@ -9,7 +9,7 @@ pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.kernel.org/pub/software/scm/git/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=0556330e267dc968749619cd90ff6a815eda26f0c89faa5cfba56756e852202f
+pkg_shasum=94faf2c0b02a7920b0b46f4961d8e9cad08e81418614102898a55f980fa3e7e4
 pkg_deps=(
   core/cacerts
   core/curl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Build
build
hab pkg exec core/git git --version
```

### Sample Output

```
# Windows
git version 2.18.0.windows.1

# Linux
git version 2.18.0
```