### PR TITLE
[sensu] security updates

### DIFF
--- a/sensu/Gemfile
+++ b/sensu/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sensu', '~> 0.29.0'
-gem 'sensu-plugin', '~> 1.4', '>= 1.4.3'
+gem 'sensu', '= 1.4.3'
+gem 'sensu-plugin', '= 2.5.0'

--- a/sensu/config/config.json
+++ b/sensu/config/config.json
@@ -1,22 +1,20 @@
 
 {
-  {{#if bind.rabbitmq ~}}
   "rabbitmq": {
+    {{#if bind.rabbitmq ~}}
     "host": "{{bind.rabbitmq.first.sys.ip}}",
     "port": {{bind.rabbitmq.first.cfg.port}},
     "user": "{{cfg.rabbitmq.user}}",
     "password": "{{cfg.rabbitmq.password}}",
     "vhost": "{{cfg.rabbitmq.vhost}}"
-  },
-  {{else ~}}
-  "rabbitmq": {
+    {{else ~}}
     "host": "{{cfg.rabbitmq.host}}",
     "port": {{cfg.rabbitmq.port}},
     "user": "{{cfg.rabbitmq.user}}",
     "password": "{{cfg.rabbitmq.password}}",
     "vhost": "{{cfg.rabbitmq.vhost}}"
+    {{/if ~}}
   },
-  {{/if ~}}
   "client": {
     "name": "{{cfg.client.name}}",
     "address": "{{cfg.client.ipaddress}}",

--- a/sensu/config/server.json
+++ b/sensu/config/server.json
@@ -1,32 +1,28 @@
 {
-  {{#if bind.rabbitmq ~}}
   "rabbitmq": {
+    {{#if bind.rabbitmq ~}}
     "host": "{{bind.rabbitmq.first.sys.ip}}",
     "port": {{bind.rabbitmq.first.cfg.port}},
     "user": "{{cfg.rabbitmq.user}}",
     "password": "{{cfg.rabbitmq.password}}",
     "vhost": "{{cfg.rabbitmq.vhost}}"
-  },
-  {{else ~}}
-  "rabbitmq": {
+    {{else ~}}
     "host": "{{cfg.rabbitmq.host}}",
     "port": {{cfg.rabbitmq.port}},
     "user": "{{cfg.rabbitmq.user}}",
     "password": "{{cfg.rabbitmq.password}}",
     "vhost": "{{cfg.rabbitmq.vhost}}"
+    {{/if ~}}
   },
-  {{/if ~}}
-  {{#if bind.redis ~}}
   "redis": {
+    {{#if bind.redis ~}}
     "host": "{{bind.redis.first.sys.ip}}",
     "port": {{bind.redis.first.cfg.port}}
-  },
-  {{else ~}}
-  "redis": {
+    {{else ~}}
     "host": "{{cfg.redis.host}}",
     "port": {{cfg.redis.port}}
+    {{/if}}
   },
-  {{/if}}
   "api": {
     "host": "localhost",
     "port": 4567

--- a/sensu/config/server.json
+++ b/sensu/config/server.json
@@ -24,8 +24,9 @@
     {{/if}}
   },
   "api": {
-    "host": "localhost",
-    "port": 4567
+    "host": "{{cfg.api.host}}",
+    "bind": "{{cfg.api.bind}}",
+    "port": {{cfg.api.port}}
   },
   "handlers": {
     "default": {

--- a/sensu/default.toml
+++ b/sensu/default.toml
@@ -1,6 +1,11 @@
 log_level = "error"
 mode = "server"
 
+[api]
+host = "localhost"
+bind = "0.0.0.0"
+port = 4567
+
 [rabbitmq]
 user = "sensu"
 password = "sensu"

--- a/sensu/default.toml
+++ b/sensu/default.toml
@@ -1,19 +1,18 @@
-log_level="error"
-
-mode="server"
+log_level = "error"
+mode = "server"
 
 [rabbitmq]
-user="sensu"
-password="sensu"
-vhost="/sensu"
-port=5672
-host="localhost"
+user = "sensu"
+password = "sensu"
+vhost = "/sensu"
+port = 5672
+host = "localhost"
 
 [redis]
-host="localhost"
-port=6379
+host = "localhost"
+port = 6379
 
 [client]
-subscriptions=["test"]
-name="localhost"
-ipaddress="127.0.0.1"
+subscriptions = ["test"]
+name = "localhost"
+ipaddress = "127.0.0.1"

--- a/sensu/hooks/run
+++ b/sensu/hooks/run
@@ -2,18 +2,15 @@
 
 exec 2>&1
 
-export GEM_HOME="{{pkg.path}}/vendor/bundle/ruby/2.3.0"
-export GEM_PATH="{{pkgPathFor "core/ruby"}}/lib/ruby/gems/2.3.0:{{pkgPathFor "core/bundler"}}:$GEM_HOME"
+export GEM_HOME="{{pkg.path}}/vendor/bundle/ruby/2.5.0"
+export GEM_PATH="{{pkgPathFor "core/ruby"}}/lib/ruby/gems/2.5.0:{{pkgPathFor "core/bundler"}}:$GEM_HOME"
 export LD_LIBRARY_PATH="{{pkgPathFor "core/gcc-libs"}}/lib:{{pkgPathFor "core/libffi"}}/lib:{{pkgPathFor "core/openssl"}}/lib"
 export CONFIG_DIR="{{pkg.svc_config_path}}"
 
-if [ "{{cfg.mode}}" == "client" ]
-then
-exec sensu-client -d "{{pkg.svc_config_path}}" -L {{cfg.log_level}}
-elif [ "{{cfg.mode}}" == "server" ]
-then
-exec sensu-server -d "{{pkg.svc_config_path}}" -L {{cfg.log_level}}
+if [ "{{cfg.mode}}" == "client" ]; then
+  echo "Running Sensu Client"
+  exec sensu-client -d "{{pkg.svc_config_path}}" -L {{cfg.log_level}}
 else
-echo "{{cfg.mode}} is not supported."
-exit 1
+  echo "Running Sensu Server"
+  exec sensu-server -d "{{pkg.svc_config_path}}" -L {{cfg.log_level}}
 fi

--- a/sensu/plan.sh
+++ b/sensu/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=sensu
 pkg_origin=core
-pkg_version=0.29.0
+pkg_version=1.4.3
 pkg_source=http://nothing.to.download.from.com
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A monitoring framework that aims to be simple, malleable, and scalable."
@@ -10,12 +10,24 @@ pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_svc_user=root
 pkg_svc_group=${pkg_svc_user}
-pkg_build_deps=(core/make core/gcc core/gcc-libs)
-pkg_deps=(core/ruby core/bundler core/coreutils)
-pkg_binds=(
+pkg_build_deps=(
+  core/make
+  core/gcc
+  core/gcc-libs
+)
+pkg_deps=(
+  core/ruby
+  core/bundler
+  core/coreutils
+)
+pkg_binds_optional=(
   [rabbitmq]="port"
   [redis]="port"
 )
+pkg_exports=(
+  [port]=api.port
+)
+pkg_exposes=(port)
 
 do_download() {
   return 0
@@ -34,7 +46,6 @@ do_install() {
   cp -R . "$pkg_prefix/"
   fix_interpreter "$pkg_prefix/bin/*" core/coreutils bin/env
 }
-
 
 do_build() {
   local _bundler_dir


### PR DESCRIPTION

![tenor-49081999](https://user-images.githubusercontent.com/24568/43674376-2f73e802-980e-11e8-8b62-6d2335d1b467.gif)

Fixes #1743 

### Testing

```
# Convenience / tools
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat

# Setup Configuration
echo '
default_vhost = "/sensu"
default_user = "sensu"
default_pass = "sensu"' | hab config apply rabbitmq.default $(date +%s)

echo '
protected-mode = "no"' | hab config apply redis.default $(date +%s)

echo 'log_level="debug"' | hab config apply sensu.default $(date +%s)


# Load RabbitMQ
hab svc load core/rabbitmq

# Load Redis
hab svc load core/redis

# Build and run Sensu
build; source results/last_build.env; hab pkg install results/${pkg_artifact}
hab svc load ${pkg_ident} --bind rabbitmq:rabbitmq.default --bind redis:redis.default

# Test Sensu Server connections
netstat -p | grep ESTABLISHED | grep ruby | grep 6379 > /dev/null
if [ $? -ne 0 ]; then echo "FAILED: No connection to Redis"; else echo "PASS: Redis connected"; fi
netstat -p | grep ESTABLISHED | grep ruby | grep 5672 > /dev/null
if [ $? -ne 0 ]; then echo "FAILED: No connection to RabbitMQ"; else echo "PASS: RabbitMQ connected"; fi
```

This checks that the sensu service is connected to Redis and RabbitMQ. Sensu doesn't expose a port or listen.