### PR TITLE
[Node] windows enhancements

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -11,14 +11,17 @@ $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {
-  write-host
-  lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
   mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  Move-Item "node-v$pkg_version-x64/SourceDir/nodejs" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+
+  Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  try {
+    lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+  }
+  finally { Pop-Location }
 }
 
 function Invoke-Install {
-  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/*" "$pkg_prefix/bin" -Recurse
+  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/node-v$pkg_version-x64/SourceDir/nodejs/*" "$pkg_prefix/bin" -Recurse
 }
 
 function Invoke-Check() {

--- a/node10/plan.ps1
+++ b/node10/plan.ps1
@@ -1,26 +1,8 @@
+. "..\node\plan.ps1"
+
 $pkg_name="node10"
 $pkg_origin="core"
 $pkg_version="10.8.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
-$pkg_upstream_url="https://nodejs.org/"
-$pkg_license=@("MIT")
-$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
 $pkg_shasum="9d03d6bc78d7375fa549005c9b12cf5da4b01ee52b60834107f5f603d82a68f2"
-$pkg_build_deps=@("core/lessmsi")
-$pkg_bin_dirs=@("bin")
-
-function Invoke-Unpack {
-  write-host
-  lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
-  mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  Move-Item "node-v$pkg_version-x64/SourceDir/nodejs" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-}
-
-function Invoke-Install {
-  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/*" "$pkg_prefix/bin" -Recurse
-}
-
-function Invoke-Check() {
-  (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/node" --version) -eq "v$pkg_version"
-}

--- a/node6/plan.ps1
+++ b/node6/plan.ps1
@@ -1,26 +1,9 @@
+. "..\node\plan.ps1"
+
 $pkg_name="node6"
 $pkg_origin="core"
-$pkg_version="6.11.5"
+$pkg_version="6.14.3"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
-$pkg_upstream_url="https://nodejs.org/"
-$pkg_license=@("MIT")
-$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="c4aed94e82dbf246a1c9e0705c3054f0c0f3d9c4d8d025d877e0ef1f7b6cde4c"
-$pkg_build_deps=@("core/lessmsi")
-$pkg_bin_dirs=@("bin")
+$pkg_shasum="f67a3f3e24c25859c429fbd576d6d89301c74b5fff70533f4bcc97351df6dc02"
 
-function Invoke-Unpack {
-  write-host
-  lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
-  mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  Move-Item "node-v$pkg_version-x64/SourceDir/nodejs" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-}
-
-function Invoke-Install {
-  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/*" "$pkg_prefix/bin" -Recurse
-}
-
-function Invoke-Check() {
-  (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/node" --version) -eq "v$pkg_version"
-}


### PR DESCRIPTION
Discovered when testing node on Windows that I could only build the plan once, files were not being cleaned up that needed to be and I was receiving errors.  This fixes those issues.

### Testing

```
# Build
build node
hab pkg exec core/node node --version
build node6
hab pkg exec core/node6 node --version
build node10
hab pkg exec core/node10 node --version
```