### PR TITLE
[mage] New plan: mage

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -746,6 +746,8 @@ plan_path = "lzo"
 plan_path = "lzop"
 [m4]
 plan_path = "m4"
+[mage]
+plan_path = "mage"
 [make]
 plan_path = "make"
 [man-db]

--- a/mage/README.md
+++ b/mage/README.md
@@ -1,0 +1,38 @@
+# Mage
+
+Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Binary Package
+
+## Usage
+
+Mage can be installed/used as a standalone binary:
+
+```
+hab pkg install core/mage
+$(hab pkg path core/mage)/bin/mage
+
+# or binlink
+
+hab pkg install core/mage
+hab pkg binlink core/mage
+mage
+```
+
+Alternatively, it can be used in your pacakges build dependencies for running Magefiles.
+
+```
+pkg_build_deps=(core/mage)
+
+do_build() {
+  ...
+  mage
+  ...
+}
+```

--- a/mage/plan.sh
+++ b/mage/plan.sh
@@ -1,0 +1,27 @@
+pkg_name=mage
+pkg_origin=core
+pkg_version="2.1"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_description="Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets."
+pkg_source="https://github.com/magefile/mage"
+pkg_upstream_url="https://magefile.org/"
+pkg_scaffolding="core/scaffolding-go"
+pkg_bin_dirs=(bin)
+
+do_download() {
+  scaffolding_go_download
+  pushd "${scaffolding_go_pkg_path}" > /dev/null
+  git reset --hard "${pkg_version}"
+  popd > /dev/null
+}
+
+do_build() {
+  pushd "${scaffolding_go_pkg_path}" > /dev/null
+  go run bootstrap.go
+  popd > /dev/null
+}
+
+do_install() {
+  cp "${GOPATH}/bin/mage" "${pkg_prefix}/bin/mage"
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Adding mage, for magefile / golang builds.

![tenor-6545914](https://user-images.githubusercontent.com/24568/43819968-c733c2de-9b1f-11e8-994e-7b10536b032f.gif)

### Testing

Testing just with a simple version check:

```
build; source results/last_build.env; hab pkg install results/${pkg_artifact} --binlink

mage --version
```

### Sample Output

```
# mage --version
Mage Build Tool 2.1
Build Date: 2018-08-08T06:14:44Z
Commit: 771ebed
```