### PR TITLE
[hugo] Change to build hugo from source

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -4,20 +4,33 @@ pkg_version="0.46"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
-pkg_source="https://github.com/gohugoio/hugo/releases/download/v${pkg_version}/hugo_${pkg_version}_Linux-64bit.tar.gz"
-pkg_shasum="96c431b1b76aed4833739966235098162b97ca9933e1ff2bcd09f7571842ea6b"
-pkg_build_deps=(core/go)
+pkg_build_deps=(
+  core/dep
+  rakops/mage
+)
 pkg_bin_dirs=(bin)
+pkg_source="https://github.com/gohugoio/hugo"
 pkg_upstream_url="https://gohugo.io"
+pkg_scaffolding="core/scaffolding-go"
 
-do_prepare() {
-  export GOPATH="${HAB_CACHE_SRC_PATH}"
+scaffolding_go_build_deps=(
+  github.com/magefile/mage
+)
+
+do_download() {
+  scaffolding_go_download
+  pushd "${scaffolding_go_pkg_path}" > /dev/null
+  git reset --hard "v${pkg_version}"
+  popd > /dev/null
 }
 
 do_build() {
-  return 0
+  pushd "${scaffolding_go_pkg_path}" > /dev/null
+  mage vendor
+  mage install
+  popd > /dev/null
 }
 
 do_install() {
-  cp "${HAB_CACHE_SRC_PATH}/hugo" "${pkg_prefix}/bin/"
+  cp "${GOPATH}/bin/hugo" "${pkg_prefix}/bin/hugo"
 }

--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_build_deps=(
   core/dep
-  rakops/mage
+  core/mage
 )
 pkg_bin_dirs=(bin)
 pkg_source="https://github.com/gohugoio/hugo"


### PR DESCRIPTION
This requires #1769 before it can be merged.

Allows cacerts to be used from patched go source.

This is required for shortcodes like `{{< twitter >}}` in hugo content.

The test for this is just checking the version, unless you want to create a full site that tests the cacerts usage. Fortunately, I have done that!

Here's the previous core/hugo **failing**: https://bldr.habitat.sh/#/pkgs/grahamweldon/grahamweldon-website/builds/1043869293629317120

Here's the modified one (as rakops/hugo) **passing**: https://bldr.habitat.sh/#/pkgs/grahamweldon/grahamweldon-website/builds/1043939221711544320

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-258919160](https://user-images.githubusercontent.com/24568/43823366-c8808b68-9b29-11e8-8201-bca8a50ae3b4.gif)
