### PR TITLE
[zsh] Update to zsh 5.5.1, fix tests

### DIFF
--- a/zsh/plan.sh
+++ b/zsh/plan.sh
@@ -1,32 +1,44 @@
 pkg_name=zsh
 pkg_origin=core
-pkg_version=5.3.1
+pkg_version=5.5.1
 pkg_description="Zsh is a shell designed for interactive use, although it is also a powerful scripting language."
 pkg_upstream_url="http://www.zsh.org"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('zsh')
-pkg_source=https://downloads.sourceforge.net/project/zsh/zsh/$pkg_version/zsh-$pkg_version.tar.gz
-pkg_shasum=3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e
-pkg_deps=(core/glibc core/pcre core/ncurses core/readline core/gdbm core/coreutils core/perl)
-pkg_build_deps=(core/make core/gcc)
+pkg_source="https://downloads.sourceforge.net/project/zsh/zsh/${pkg_version}/zsh-${pkg_version}.tar.gz"
+pkg_shasum=774caa89e7aea5f33c3033cbffd93e28707f72ba5149c79709e48e6c2d2ee080
+pkg_deps=(
+  core/coreutils
+  core/gdbm
+  core/glibc
+  core/pcre
+  core/ncurses
+  core/perl
+  core/readline
+)
+pkg_build_deps=(
+  core/busybox-static
+  core/gcc
+  core/make
+)
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/zsh)
 
 do_build() {
   ./configure \
-    --prefix="$pkg_prefix" \
+    --prefix="${pkg_prefix}" \
     --enable-multibyte \
     --enable-cap \
     --enable-pcre \
-    --enable-etcdir="$pkg_prefix/etc" \
+    --enable-etcdir="${pkg_prefix}/etc" \
     --enable-zsh-secure-free
   make
 }
 
 do_install() {
   make install
-  mkdir -p "$pkg_prefix/etc"
-  cp "$PLAN_CONTEXT/zprofile" "$pkg_prefix/etc"
+  mkdir -p "${pkg_prefix}/etc"
+  cp "${PLAN_CONTEXT}/zprofile" "${pkg_prefix}/etc"
 }
 
 do_check() {


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Note: Previous builds don't pass any tests.

This improves, with a strange `echo` failure, but still working fine. Improvement, but not perfect on the testing front:

```
DO_CHECK=1 build
```

Old output:

```
**************************************
0 successful test scripts, 48 failures, 0 skipped
**************************************
```

New output:

```
**************************************
49 successful test scripts, 2 failures, 0 skipped
**************************************
```