### PR TITLE
[zookeeper] Update zookeeper to 3.4.13

### DIFF
--- a/zookeeper/plan.sh
+++ b/zookeeper/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=zookeeper
 pkg_origin=core
-pkg_version=3.4.12
+pkg_version=3.4.13
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications."
 pkg_upstream_url="https://zookeeper.apache.org"
 pkg_license=('Apache-2.0')
 pkg_source="http://apache.mirrors.ionfish.org/zookeeper/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="c686f9319050565b58e642149cb9e4c9cc8c7207aacc2cb70c5c0672849594b9"
+pkg_shasum="7ced798e41d2027784b8fd55c908605ad5bd94a742d5dab2506be8f94770594d"
 pkg_build_deps=()
 pkg_deps=(
   core/bash-static
@@ -26,5 +26,5 @@ do_build() {
 do_install() {
   fix_interpreter "bin/*" core/coreutils bin/env
 
-  cp -r bin lib "dist-maven/$pkg_dirname.jar" "$pkg_prefix"
+  cp -r bin lib "dist-maven/${pkg_dirname}.jar" "${pkg_prefix}"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Convenience / tooling
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat

# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}
hab svc load ${pkg_ident}

# Check listening port (2181) (allow ~ 5 seconds for startup)
netstat -peanut | grep java
```

### Sample output

```
# netstat -peanut
tcp        0      0 0.0.0.0:34573           0.0.0.0:*               LISTEN      962/java
tcp        0      0 0.0.0.0:2181            0.0.0.0:*               LISTEN      962/java
```

