### PR TITLE
Update pkg_source for bzip2

### DIFF
--- a/bzip2/plan.sh
+++ b/bzip2/plan.sh
@@ -10,7 +10,7 @@ archiver.\
 "
 pkg_upstream_url="http://www.bzip.org/"
 pkg_license=('bzip2')
-pkg_source="http://www.bzip.org/$pkg_version/${pkg_name}-${pkg_version}.tar.gz"
+pkg_source="https://github.com/nemequ/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_shasum="a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(


### PR DESCRIPTION
bzip.org domain name expired. Switch to an unofficial github mirror until bzip.org is back online.
checksums match on the tarball so we can be reasonably confident that it is the same file.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>