### PR TITLE
[lessmsi] Update lessmsi to 1.6.1

### DIFF
--- a/lessmsi/plan.ps1
+++ b/lessmsi/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="lessmsi"
 $pkg_origin="core"
-$pkg_version="1.5.1"
+$pkg_version="1.6.1"
 $pkg_license=('MIT')
 $pkg_upstream_url="http://lessmsi.activescott.com/"
 $pkg_description="A tool to view and extract the contents of a Windows Installer (.msi) file."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://github.com/activescott/lessmsi/releases/download/v$pkg_version/lessmsi-v${pkg_version}.zip"
-$pkg_shasum="478564a8430cc74c3fb727175e4bbb46ce6d9c8874e7c1555f719dcff9ee91af"
+$pkg_shasum="540b8801e08ec39ba26a100c855898f455410cecbae4991afae7bb2b4df026c7"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
build
hab pkg exec core/lessmsi lessmsi h
```

Windows build is uploaded, needs to be set to stable after approval/merge : https://bldr.habitat.sh/#/pkgs/core/lessmsi/1.6.1/20180810160745

