### PR TITLE
[docutils] Move core/python2 to pkg_deps from pkg_build_deps.  Fixes #1780

### DIFF
--- a/docutils/README.md
+++ b/docutils/README.md
@@ -10,4 +10,10 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+```
+    hab pkg install core/docutils
+    hab pkg exec core/docutils rs2tman.py --version
+    --------
+    hab pkg install core/docutils --binlink
+    rst2man.py --version
+```

--- a/docutils/README.md
+++ b/docutils/README.md
@@ -12,7 +12,7 @@ Binary package
 
 ```
     hab pkg install core/docutils
-    hab pkg exec core/docutils rs2tman.py --version
+    hab pkg exec core/docutils rst2man.py --version
     --------
     hab pkg install core/docutils --binlink
     rst2man.py --version

--- a/docutils/plan.sh
+++ b/docutils/plan.sh
@@ -10,6 +10,8 @@ pkg_license=(
 )
 pkg_source=https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa
+pkg_description="Docutils is an open-source text processing system for processing plaintext documentation into useful formats, e.g.: HTML, LaTeX, man-pages, open-document, or XML."
+pkg_upstream_url="http://docutils.sourceforge.net"
 pkg_deps=(core/python2)
 pkg_build_deps=(
   core/make

--- a/docutils/plan.sh
+++ b/docutils/plan.sh
@@ -10,11 +10,10 @@ pkg_license=(
 )
 pkg_source=https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa
-pkg_deps=()
+pkg_deps=(core/python2)
 pkg_build_deps=(
   core/make
   core/gcc
-  core/python2
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)

--- a/docutils/plan.sh
+++ b/docutils/plan.sh
@@ -31,12 +31,11 @@ do_install() {
   python install.py
 
   # write our wrapper script
-  bash_path=$(hab pkg path core/bash)
-  # echo "core/bash path: ${bash_path}"
+  bash_path=$(pkg_path_for core/bash)
   for file in ${pkg_prefix}/bin/*.py; do
-    # echo "Renaming ${file} to ${file}.real"
+    # Rename executable to ${file}.real"
     mv "${file}" "${file}.real"
-    # echo "Writing wrapper script"
+    # Write wrapper script to replace ${file}
     cat <<EOF > "${file}"
 #!${bash_path}/bin/bash
 export PYTHONPATH=$PYTHONPATH:${pkg_prefix}/lib/python2.7/site-packages

--- a/docutils/plan.sh
+++ b/docutils/plan.sh
@@ -12,7 +12,10 @@ pkg_source=https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}/${p
 pkg_shasum=c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa
 pkg_description="Docutils is an open-source text processing system for processing plaintext documentation into useful formats, e.g.: HTML, LaTeX, man-pages, open-document, or XML."
 pkg_upstream_url="http://docutils.sourceforge.net"
-pkg_deps=(core/python2)
+pkg_deps=(
+  core/bash
+  core/python2
+)
 pkg_build_deps=(
   core/make
   core/gcc
@@ -26,4 +29,20 @@ do_build() {
 
 do_install() {
   python install.py
+
+  # write our wrapper script
+  bash_path=$(hab pkg path core/bash)
+  # echo "core/bash path: ${bash_path}"
+  for file in ${pkg_prefix}/bin/*.py; do
+    # echo "Renaming ${file} to ${file}.real"
+    mv "${file}" "${file}.real"
+    # echo "Writing wrapper script"
+    cat <<EOF > "${file}"
+#!${bash_path}/bin/bash
+export PYTHONPATH=$PYTHONPATH:${pkg_prefix}/lib/python2.7/site-packages
+exec ${file}.real "\$@"
+EOF
+    # set the execute bit
+    chmod a+x "${file}"
+  done
 }


### PR DESCRIPTION
This includes python2 as a runtime dep for the docutils package.