### PR TITLE
[memcached] Update memcached to 1.5.10

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.9
+pkg_version=1.5.10
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=4af3577dbf71cb0a748096dc6562ccd587cddb7565c720f1fdb23e8a34241d06
+pkg_shasum=494c060dbd96d546c74ab85a3cc3984d009b4423767ac33e05dd2340c01f1c4b
 pkg_deps=(core/glibc core/libevent)
 pkg_build_deps=(core/git core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Convenience
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static telnet

# Build and install
build; source results/last_build.env; hab svc load ${pkg_ident}

# Wait 5 seconds, check it is listening
netstat -alpn | grep LISTEN | grep memcached
```

### Sample output

```
tcp        0      0 0.0.0.0:11211           0.0.0.0:*               LISTEN      2969/memcached
```

### Further testing

```
$ telnet localhost 11211
set greeting 1 0 11
Hello world
STORED
END
ERROR
quit
Connection closed by foreign host


$ telnet localhost 11211
get greeting
VALUE greeting 1 11
Hello world
END
quit
Connection closed by foreign host
```