### PR TITLE
[scaffolding-chef] don't use exec to run chef-client and fix a configuration issue

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -52,7 +52,7 @@ export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 cd {{pkg.path}}
 
 exec 2>&1
-exec chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
+chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
 exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
@@ -119,7 +119,7 @@ log_level = "warn"
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 
 [data_collector]
-enable = "false"
+enable = false
 token = "set_to_your_token"
 server_url = "set_to_your_url"
 EOF

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.1.1"
+pkg_version="0.1.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Currently the `chef-client` run with `--once` will exit the run hook after completion.
This results in the Supervisor continuously running `chef-client` and never running it
with the configured interval and splay times.

In the generated `default.toml` file the `data_collector.enable` property is set to a string `"false"` which evaluates to true.

This PR resolves both issues by removing `exec` so the shell isn't replaced by the `chef-client` process, and changing the generated `default.toml`.

Fixes #1775. 