### PR TITLE
[docutils] Bump version of package to current

### DIFF
--- a/docutils/plan.sh
+++ b/docutils/plan.sh
@@ -1,6 +1,6 @@
 pkg_origin=core
 pkg_name=docutils
-pkg_version='0.12'
+pkg_version='0.14'
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=(
   'GPL-3.0'
@@ -9,7 +9,7 @@ pkg_license=(
   'Docutils Public Domain Dedication'
 )
 pkg_source=https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa
+pkg_shasum=51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274
 pkg_description="Docutils is an open-source text processing system for processing plaintext documentation into useful formats, e.g.: HTML, LaTeX, man-pages, open-document, or XML."
 pkg_upstream_url="http://docutils.sourceforge.net"
 pkg_deps=(


### PR DESCRIPTION
The version of docutils in `core/docutils` is really really really really old (the last commit was July 2014).

This commit bumps the version of `core/docutils` to the current v14.

This depends on #1781 and may need to be rebased...?  I had already done the work so wanted to get the PR submitted while I was thinking about it.