### PR TITLE
[protobuf-c] Update protobuf-c to 1.3.1

### DIFF
--- a/protobuf-c/plan.sh
+++ b/protobuf-c/plan.sh
@@ -1,10 +1,10 @@
 pkg_origin=core
 pkg_name=protobuf-c
-pkg_version=1.3.0
+pkg_version=1.3.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://github.com/protobuf-c/protobuf-c/releases/download/v${pkg_version}/protobuf-c-${pkg_version}.tar.gz"
-pkg_shasum=5dc9ad7a9b889cf7c8ff6bf72215f1874a90260f60ad4f88acf21bb15d2752a1
+pkg_shasum=51472d3a191d6d7b425e32b612e477c06f73fe23e07f6a6a839b11808e9d2267
 pkg_deps=(core/gcc-libs core/protobuf-cpp core/zlib)
 pkg_build_deps=(core/gcc core/make core/pkg-config)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Updates protobuf-c to 1.3.1, fixes #1757 and makes changes to protobuf-c in #1784 no longer required.

cc @nellshamrell 

![tenor-226024449](https://user-images.githubusercontent.com/24568/44130095-d6f9cdf0-a086-11e8-8ecd-f3641f80f5f5.gif)
