### PR TITLE
[strace] Update strace to 4.24, add testing

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=4.23
+pkg_version=4.24
 pkg_license=("BSD-3-Clause-LBNL")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
-pkg_source="https://github.com/strace/strace/releases/download/v4.23/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=7860a6965f1dd832747bd8281a04738274398d32c56e9fbd0a68b1bb9ec09aad
+pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum=1f4e59fc1edfa2bfb4adf2a748623dc25b105ec79713dd84404199f91b0b0634
 pkg_deps=(
   core/glibc
   core/libunwind

--- a/strace/test.bats
+++ b/strace/test.bats
@@ -1,0 +1,11 @@
+source ./plan.sh
+
+@test "Version matches" {
+  result="$(strace -V | head -1 | awk '{print $4}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Can strace" {
+  run strace strace -h
+  [ $status -eq 0 ]
+}

--- a/strace/test.sh
+++ b/strace/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+hab pkg install --binlink core/bats
+
+source ./plan.sh
+
+set -e
+build
+source results/last_build.env
+hab pkg install --binlink --force "results/${pkg_artifact}"
+set +e
+
+bats test.bats


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Adds some testing, requires bats.

### Testing

```
# (In studio)
./test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```

![tenor-184915220](https://user-images.githubusercontent.com/24568/44131744-f58e0642-a08f-11e8-8a90-215970c6ef42.gif)
