### PR TITLE
[ps-lock] adding ps-lock plan to manage concurrency sensitive operations

### DIFF
--- a/ps-lock/PSLock.psd1
+++ b/ps-lock/PSLock.psd1
@@ -1,0 +1,11 @@
+@{
+    RootModule = 'PSLock.psm1'
+    ModuleVersion = '0.1.0'
+    GUID = 'f423fe73-1cb4-4e3c-b3ac-8b29592bb022'
+    Author = 'The Habitat Maintainers'
+    CompanyName = 'Chef Software Inc.'
+    Copyright = 'Copyright (c) 2018 Chef Software Inc. and/or applicable contributors'
+    Description = 'Provides synchronization of scripts run in hooks that declare the same lock.'
+    PowerShellVersion = '6.0.0'
+    FunctionsToExport = 'Enter-PSLock'
+}

--- a/ps-lock/PSLock.psm1
+++ b/ps-lock/PSLock.psm1
@@ -1,0 +1,91 @@
+<#
+    .SYNOPSIS
+        Provides a way to sychronize scripts run from Habitat hooks so that
+        Supervisor threads running these scripts will be serialized to one
+        call at a time
+
+    .PARAMETER ScriptBlock
+        The script to synchronize
+
+    .PARAMETER Name
+        The name to give to the lock. If not provided, the default lock
+        name of _hab_pslock_default will be used
+
+    .PARAMETER Interval
+        The number of seconds to pause before running the block again. The
+        block will only be run once if no Interval or Splay are provided
+
+    .PARAMETER Splay
+        The maximum random number to add to Interval
+
+    .EXAMPLE
+        Using a lock named 'MSILock' will block as it waits its turn to run
+        its ScriptBlock
+
+        Enter-PSLock -Name MSILock {
+            Start-Process mymsi.msi -wait -ArgumentList "/S"
+        }
+
+    .EXAMPLE
+        Using no lock name will use the default '_hab_pslock_default' lock
+
+        Enter-PSLock { Start-Process my.exe -wait }
+
+    .EXAMPLE
+        Providing `-Interval` and `-Splay` arguments will run the `ScriptBlock`
+        continuously and wait before calling the block again.
+        The time to wait will be the number of seconds in the `Interval` plus a
+        random number of seconds between `0` and `Splay`
+
+        Enter-PSLock -Name MSILock -Interval 1800 -Splay 30 {
+            Start-Process "{{pkgPathFor "core/chef-dk"}}\chefdk\bin\chef-client.bat" -ArgumentList "-z" -Wait -NoNewWindow
+        }
+
+#>
+function Enter-PSLock {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $Name = "_hab_pslock_default",
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $Interval,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $Splay
+    )
+    if(($Interval + $Splay) -eq 0) {
+        Enter-InternalPSLock $ScriptBlock $Name
+    }
+    else {
+        $Interval = $Interval + (Get-Random -Maximum $Splay)
+        while($true) {
+            Enter-InternalPSLock $ScriptBlock $Name
+            Write-Host "Sleeping for $Interval seconds before attempting $Name lock"
+            Start-Sleep -Seconds $Interval
+        }
+    }
+}
+
+function Enter-InternalPSLock($block, $name) {
+    $lock = [System.Threading.Mutex]::new($false, $name)
+
+    try {
+        Write-Host "Waiting for $name lock..."
+        $lock.WaitOne() | Out-Null
+        Write-Host "Obtained lock for $name"
+        Invoke-Command -ScriptBlock $block
+    }
+    finally {
+        $lock.ReleaseMutex()
+        Write-Host "Released lock for $name"
+        $lock.Dispose()
+    }
+}

--- a/ps-lock/README.md
+++ b/ps-lock/README.md
@@ -1,0 +1,55 @@
+# ps-lock
+
+The `ps-lock` plan provides a way to sychronize scripts run from Habitat hooks so that Supervisor threads running these scripts will be serialized to one call at a time. One example where this maybe useful is if multiple services on a single Supervisor need to install an `MSI` file. If two `run` hooks execute the `msi` install at the same time, one will fail because only one `MSIEXEC` instance can run on the os at a time. This plan exposes a `Enter-PSLock` function that takes a lock name and a `ScriptBlock` which will not be simultaneously with any other block run under the same lock name.
+
+The plan puts its `psd1` and `psm1` files in the `PSModulePath` so that its function `Start-DscCore` is automatically discoverable.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+
+## Type of Package
+
+A Binary package containing a Powershell Module
+
+## Usage
+
+### Locking Hook Execution with a Named Lock
+
+You may have multiple services that Install an MSI. You can ensure that all MSI actions are serialized to one operation at a time with:
+
+```
+Enter-PSLock -Name MSILock {
+    Start-Process mymsi.msi -wait -ArgumentList "/S"
+}
+```
+
+Any hook that calls `Enter-PSLock` with a lock named `MSILock` will block as it waits its turn to run its `ScriptBlock`.
+
+### Using the Default Lock
+
+If you do not provide a `-Name` argument, the `ScriptBlock` will run under the default lock `_hab_pslock_default`.
+
+### Using Interval and Splay with `Enter-PSLock`
+
+It's possible that your `run` hook may need to run a script in a continuous loop at a specific interval. When it is time for your script to run, you want it to wait and hold the lock and then release the lock before waiting for the next interval. An example use case here is if your hook call `chef-client` which may have cookbooks that converge resources that can not be run concurrently on a single Supervisor.
+
+You can provide `-Interval` and `-Splay` arguments to `Enter-PSLock` which will run the `ScriptBlock` continuously and wait before calling the block again. The time to wait will be the number of seconds in the `Interval` plus a random number of seconds between `0` and `Splay`.
+
+```
+Enter-PSLock -Name MSILock -Interval 1800 -Splay 30 {
+    Start-Process "{{pkgPathFor "core/chef-dk"}}\chefdk\bin\chef-client.bat" -ArgumentList "-z" -Wait -NoNewWindow
+}
+```
+
+### Problems using in a local Windows Studio
+
+The `PSModulePath` in a local Windows studio (one started with `hab studio enter -w`) will get assigned the wrong package path and thus simply calling `Enter-PSLock` will not automatically import this module.
+
+You can work around this by explicitly importing the module before using the command:
+
+```
+Import-Module "{{pkgPathFor "core/ps-lock"}}/Modules/PSLock"
+Enter-PSLock { <SOME_POWERSHELL_CODE>}
+```

--- a/ps-lock/plan.ps1
+++ b/ps-lock/plan.ps1
@@ -1,0 +1,16 @@
+$pkg_name="ps-lock"
+$pkg_origin="core"
+$pkg_version="0.1.0"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@("Apache-2.0")
+$pkg_description="Provides synchronization of scripts run in hooks that declare the same lock"
+
+function Invoke-SetupEnvironment {
+    Push-RuntimeEnv "PSModulePath" "\hab\pkgs\$pkg_origin\$pkg_name\$pkg_version\$pkg_release\Modules"
+}
+
+function Invoke-Install {
+    mkdir "$pkg_prefix/Modules/PSLock"
+    Copy-Item "$PLAN_CONTEXT/PSLock.psm1" "$pkg_prefix/Modules/PSLock"
+    Copy-Item "$PLAN_CONTEXT/PSLock.psd1" "$pkg_prefix/Modules/PSLock"
+}


### PR DESCRIPTION
This partially addresses #1776 by providing concurrency control and ensuring some blocks of hook code are serialized.

Signed-off-by: mwrock <matt@mattwrock.com>