### PR TITLE
[terraform] Update terraform to 0.11.8, add testing

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.11.7
+pkg_version=0.11.8
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
 pkg_filename=${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
+pkg_shasum=84ccfb8e13b5fce63051294f787885b76a1fedef6bdbecf51c5e586c9e20c9b7
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)

--- a/terraform/test.bats
+++ b/terraform/test.bats
@@ -1,0 +1,12 @@
+source ./plan.sh
+
+@test "Version matches" {
+  result="$(terraform version | head -1 | awk '{print $2}')"
+  [ "$result" = "v${pkg_version}" ]
+}
+
+@test "Terraform default workspace" {
+  run terraform workspace list
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "* default" ]
+}

--- a/terraform/test.sh
+++ b/terraform/test.sh
@@ -5,7 +5,7 @@ SKIPBUILD=${SKIPBUILD:-0}
 hab pkg install --binlink core/bats
 source ./plan.sh
 
-if [ ${SKIPBUILD} -eq 0 ]; then
+if [ "${SKIPBUILD}" -eq 0 ]; then
   set -e
   build
   source results/last_build.env

--- a/terraform/test.sh
+++ b/terraform/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+source ./plan.sh
+
+if [ ${SKIPBUILD} -eq 0 ]; then
+  set -e
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  set +e
+fi
+
+bats test.bats


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Upgrade version
* Add testing with bats

Testing is evolving each time I add some. This adds a simple filter to skip the actual build. This is super handy when you're in the process of building out tests for something that takes a long time to build, or something that is already built.

### Testing

```
# (In studio)
./test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```

![tenor-130103534](https://user-images.githubusercontent.com/24568/44180489-b2cf3f80-a137-11e8-9008-c858e203306e.gif)

