### PR TITLE
Initial commit of plan variants

### DIFF
--- a/glibc/x86_64-linux-kernel2/0005-fix-binutils-2-29-build.patch
+++ b/glibc/x86_64-linux-kernel2/0005-fix-binutils-2-29-build.patch
@@ -1,0 +1,22 @@
+diff --git a/misc/regexp.c b/misc/regexp.c
+index 19d76c0..eaea7c3 100644
+--- a/misc/regexp.c
++++ b/misc/regexp.c
+@@ -29,14 +29,15 @@
+ 
+ #if SHLIB_COMPAT (libc, GLIBC_2_0, GLIBC_2_23)
+ 
+-/* Define the variables used for the interface.  */
+-char *loc1;
+-char *loc2;
++/* Define the variables used for the interface.  Avoid .symver on common
++   symbol, which just creates a new common symbol, not an alias.  */
++char *loc1 __attribute__ ((nocommon));
++char *loc2 __attribute__ ((nocommon));
+ compat_symbol (libc, loc1, loc1, GLIBC_2_0);
+ compat_symbol (libc, loc2, loc2, GLIBC_2_0);
+ 
+ /* Although we do not support the use we define this variable as well.  */
+-char *locs;
++char *locs __attribute__ ((nocommon));
+ compat_symbol (libc, locs, locs, GLIBC_2_0);

--- a/glibc/x86_64-linux-kernel2/dont-use-system-ld-so.patch
+++ b/glibc/x86_64-linux-kernel2/dont-use-system-ld-so.patch
@@ -1,0 +1,58 @@
+diff -ru glibc-2.22-orig/elf/ldconfig.c glibc-2.22/elf/ldconfig.c
+--- glibc-2.22-orig/elf/ldconfig.c	2015-12-12 02:05:44.630174539 +0000
++++ glibc-2.22/elf/ldconfig.c	2015-12-12 02:42:45.537441848 +0000
+@@ -51,7 +51,7 @@
+ #endif
+ 
+ #ifndef LD_SO_CONF
+-# define LD_SO_CONF SYSCONFDIR "/ld.so.conf"
++# define LD_SO_CONF PREFIX "/etc/ld.so.conf"
+ #endif
+ 
+ /* Get libc version number.  */
+diff -ru glibc-2.22-orig/elf/Makefile glibc-2.22/elf/Makefile
+--- glibc-2.22-orig/elf/Makefile	2015-12-12 02:05:44.626174409 +0000
++++ glibc-2.22/elf/Makefile	2015-12-12 02:44:17.044734055 +0000
+@@ -443,13 +443,13 @@
+ 
+ $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
+ 
+-SYSCONF-FLAGS := -D'SYSCONFDIR="$(sysconfdir)"'
+-CFLAGS-ldconfig.c = $(SYSCONF-FLAGS) -D'LIBDIR="$(libdir)"' \
++PREFIX-FLAGS := -D'PREFIX="$(prefix)"'
++CFLAGS-ldconfig.c = $(PREFIX-FLAGS) -D'LIBDIR="$(libdir)"' \
+ 		    -D'SLIBDIR="$(slibdir)"'
+ libof-ldconfig = ldconfig
+-CFLAGS-dl-cache.c = $(SYSCONF-FLAGS)
+-CFLAGS-cache.c = $(SYSCONF-FLAGS)
+-CFLAGS-rtld.c = $(SYSCONF-FLAGS)
++CFLAGS-dl-cache.c = $(PREFIX-FLAGS)
++CFLAGS-cache.c = $(PREFIX-FLAGS)
++CFLAGS-rtld.c = $(PREFIX-FLAGS)
+ 
+ cpp-srcs-left := $(all-rtld-routines:=.os)
+ lib := rtld
+diff -ru glibc-2.22-orig/elf/rtld.c glibc-2.22/elf/rtld.c
+--- glibc-2.22-orig/elf/rtld.c	2015-12-12 02:05:44.630174539 +0000
++++ glibc-2.22/elf/rtld.c	2015-12-12 02:48:31.673870395 +0000
+@@ -1513,7 +1513,7 @@
+      open().  So we do this first.  If it succeeds we do almost twice
+      the work but this does not matter, since it is not for production
+      use.  */
+-  static const char preload_file[] = "/etc/ld.so.preload";
++  static const char preload_file[] = "@prefix@/etc/ld.so.preload";
+   if (__glibc_unlikely (__access (preload_file, R_OK) == 0))
+     {
+       /* Read the contents of the file.  */
+diff -ru glibc-2.22-orig/sysdeps/generic/dl-cache.h glibc-2.22/sysdeps/generic/dl-cache.h
+--- glibc-2.22-orig/sysdeps/generic/dl-cache.h	2015-12-12 02:05:44.846181518 +0000
++++ glibc-2.22/sysdeps/generic/dl-cache.h	2015-12-12 02:45:08.982600296 +0000
+@@ -28,7 +28,7 @@
+ #endif
+ 
+ #ifndef LD_SO_CACHE
+-# define LD_SO_CACHE SYSCONFDIR "/ld.so.cache"
++# define LD_SO_CACHE PREFIX "/etc/ld.so.cache"
+ #endif
+ 
+ #ifndef add_system_dir

--- a/glibc/x86_64-linux-kernel2/gcc-implicit-boolean.patch
+++ b/glibc/x86_64-linux-kernel2/gcc-implicit-boolean.patch
@@ -1,0 +1,25 @@
+diff --git a/sysdeps/ieee754/dbl-64/e_pow.c b/sysdeps/ieee754/dbl-64/e_pow.c
+index 663fa39..bd758b5 100644
+--- a/sysdeps/ieee754/dbl-64/e_pow.c
++++ b/sysdeps/ieee754/dbl-64/e_pow.c
+@@ -466,15 +466,15 @@  checkint (double x)
+     return (n & 1) ? -1 : 1;	/* odd or even */
+   if (k > 20)
+     {
+-      if (n << (k - 20))
++      if (n << (k - 20) != 0)
+ 	return 0;		/* if not integer */
+-      return (n << (k - 21)) ? -1 : 1;
++      return (n << (k - 21) != 0) ? -1 : 1;
+     }
+   if (n)
+     return 0;			/*if  not integer */
+   if (k == 20)
+     return (m & 1) ? -1 : 1;
+-  if (m << (k + 12))
++  if (m << (k + 12) != 0)
+     return 0;
+-  return (m << (k + 11)) ? -1 : 1;
++  return (m << (k + 11) != 0) ? -1 : 1;
+ }
+ 

--- a/glibc/x86_64-linux-kernel2/glibc-2.23-upstream_fixes-1.patch
+++ b/glibc/x86_64-linux-kernel2/glibc-2.23-upstream_fixes-1.patch
@@ -1,0 +1,489 @@
+Submitted By:            Armin K. <krejzi at email dot com>
+Date:                    2016-04-28
+Initial Package Version: 2.23
+Upstream Status:         Committed
+Origin:                  Upstream
+Description:             Various fixes for issues identified upstream,
+                         including a fix for CVE-2016-3075
+
+--- a/elf/sln.c	2016-02-18 18:54:00.000000000 +0100
++++ b/elf/sln.c	2016-04-27 16:55:49.115749405 +0200
+@@ -164,11 +164,11 @@
+ static int
+ makesymlink (const char *src, const char *dest)
+ {
+-  struct stat stats;
++  struct stat64 stats;
+   const char *error;
+
+   /* Destination must not be a directory. */
+-  if (lstat (dest, &stats) == 0)
++  if (lstat64 (dest, &stats) == 0)
+     {
+       if (S_ISDIR (stats.st_mode))
+ 	{
+--- a/nis/nis_call.c	2016-02-18 18:54:00.000000000 +0100
++++ b/nis/nis_call.c	2016-04-27 16:54:03.132148493 +0200
+@@ -680,16 +680,18 @@
+   /* Choose which entry should be evicted from the cache.  */
+   loc = &nis_server_cache[0];
+   if (*loc != NULL)
+-    for (i = 1; i < 16; ++i)
+-      if (nis_server_cache[i] == NULL)
+-	{
++    {
++      for (i = 1; i < 16; ++i)
++	if (nis_server_cache[i] == NULL)
++	  {
++	    loc = &nis_server_cache[i];
++	    break;
++	  }
++	else if ((*loc)->uses > nis_server_cache[i]->uses
++		 || ((*loc)->uses == nis_server_cache[i]->uses
++		     && (*loc)->expires > nis_server_cache[i]->expires))
+ 	  loc = &nis_server_cache[i];
+-	  break;
+-	}
+-      else if ((*loc)->uses > nis_server_cache[i]->uses
+-	       || ((*loc)->uses == nis_server_cache[i]->uses
+-		   && (*loc)->expires > nis_server_cache[i]->expires))
+-	loc = &nis_server_cache[i];
++    }
+   old = *loc;
+   *loc = new;
+
+--- a/resolv/nss_dns/dns-network.c	2016-02-18 18:54:00.000000000 +0100
++++ b/resolv/nss_dns/dns-network.c	2016-04-27 16:54:18.844143281 +0200
+@@ -118,17 +118,14 @@
+   } net_buffer;
+   querybuf *orig_net_buffer;
+   int anslen;
+-  char *qbuf;
+   enum nss_status status;
+
+   if (__res_maybe_init (&_res, 0) == -1)
+     return NSS_STATUS_UNAVAIL;
+
+-  qbuf = strdupa (name);
+-
+   net_buffer.buf = orig_net_buffer = (querybuf *) alloca (1024);
+
+-  anslen = __libc_res_nsearch (&_res, qbuf, C_IN, T_PTR, net_buffer.buf->buf,
++  anslen = __libc_res_nsearch (&_res, name, C_IN, T_PTR, net_buffer.buf->buf,
+ 			       1024, &net_buffer.ptr, NULL, NULL, NULL, NULL);
+   if (anslen < 0)
+     {
+--- a/resolv/res_init.c	2016-02-18 18:54:00.000000000 +0100
++++ b/resolv/res_init.c	2016-04-27 16:54:55.047594514 +0200
+@@ -594,7 +594,7 @@
+ 		statp->_vcsock = -1;
+ 		statp->_flags &= ~(RES_F_VC | RES_F_CONN);
+ 	}
+-	for (ns = 0; ns < statp->_u._ext.nscount; ns++)
++	for (ns = 0; ns < statp->nscount; ns++)
+ 		if (statp->_u._ext.nsaddrs[ns]) {
+ 			if (statp->_u._ext.nssocks[ns] != -1) {
+ 				close_not_cancel_no_status(statp->_u._ext.nssocks[ns]);
+--- a/resolv/res_send.c	2016-02-18 18:54:00.000000000 +0100
++++ b/resolv/res_send.c	2016-04-27 16:54:35.368199379 +0200
+@@ -649,6 +649,18 @@
+     return (struct sockaddr *) (void *) &statp->nsaddr_list[n];
+ }
+
++/* Close the resolver structure, assign zero to *RESPLEN2 if RESPLEN2
++   is not NULL, and return zero.  */
++static int
++__attribute__ ((warn_unused_result))
++close_and_return_error (res_state statp, int *resplen2)
++{
++  __res_iclose(statp, false);
++  if (resplen2 != NULL)
++    *resplen2 = 0;
++  return 0;
++}
++
+ /* The send_vc function is responsible for sending a DNS query over TCP
+    to the nameserver numbered NS from the res_state STATP i.e.
+    EXT(statp).nssocks[ns].  The function supports sending both IPv4 and
+@@ -1114,7 +1126,11 @@
+  retry_reopen:
+ 	retval = reopen (statp, terrno, ns);
+ 	if (retval <= 0)
+-		return retval;
++	  {
++	    if (resplen2 != NULL)
++	      *resplen2 = 0;
++	    return retval;
++	  }
+  retry:
+ 	evNowTime(&now);
+ 	evConsTime(&timeout, seconds, 0);
+@@ -1127,8 +1143,6 @@
+ 	int recvresp2 = buf2 == NULL;
+ 	pfd[0].fd = EXT(statp).nssocks[ns];
+ 	pfd[0].events = POLLOUT;
+-	if (resplen2 != NULL)
+-	  *resplen2 = 0;
+  wait:
+ 	if (need_recompute) {
+ 	recompute_resend:
+@@ -1136,9 +1150,7 @@
+ 		if (evCmpTime(finish, now) <= 0) {
+ 		poll_err_out:
+ 			Perror(statp, stderr, "poll", errno);
+-		err_out:
+-			__res_iclose(statp, false);
+-			return (0);
++			return close_and_return_error (statp, resplen2);
+ 		}
+ 		evSubTime(&timeout, &finish, &now);
+ 		need_recompute = 0;
+@@ -1185,7 +1197,9 @@
+ 		  }
+
+ 		*gotsomewhere = 1;
+-		return (0);
++		if (resplen2 != NULL)
++		  *resplen2 = 0;
++		return 0;
+ 	}
+ 	if (n < 0) {
+ 		if (errno == EINTR)
+@@ -1253,7 +1267,7 @@
+
+ 		      fail_sendmmsg:
+ 			Perror(statp, stderr, "sendmmsg", errno);
+-			goto err_out;
++			return close_and_return_error (statp, resplen2);
+ 		      }
+ 		  }
+ 		else
+@@ -1271,7 +1285,7 @@
+ 		      if (errno == EINTR || errno == EAGAIN)
+ 			goto recompute_resend;
+ 		      Perror(statp, stderr, "send", errno);
+-		      goto err_out;
++		      return close_and_return_error (statp, resplen2);
+ 		    }
+ 		  just_one:
+ 		    if (nwritten != 0 || buf2 == NULL || single_request)
+@@ -1349,7 +1363,7 @@
+ 				goto wait;
+ 			}
+ 			Perror(statp, stderr, "recvfrom", errno);
+-			goto err_out;
++			return close_and_return_error (statp, resplen2);
+ 		}
+ 		*gotsomewhere = 1;
+ 		if (__glibc_unlikely (*thisresplenp < HFIXEDSZ))       {
+@@ -1360,7 +1374,7 @@
+ 			       (stdout, ";; undersized: %d\n",
+ 				*thisresplenp));
+ 			*terrno = EMSGSIZE;
+-			goto err_out;
++			return close_and_return_error (statp, resplen2);
+ 		}
+ 		if ((recvresp1 || hp->id != anhp->id)
+ 		    && (recvresp2 || hp2->id != anhp->id)) {
+@@ -1409,7 +1423,7 @@
+ 				? *thisanssizp : *thisresplenp);
+ 			/* record the error */
+ 			statp->_flags |= RES_F_EDNS0ERR;
+-			goto err_out;
++			return close_and_return_error (statp, resplen2);
+ 	}
+ #endif
+ 		if (!(statp->options & RES_INSECURE2)
+@@ -1461,10 +1475,10 @@
+ 			    goto wait;
+ 			  }
+
+-			__res_iclose(statp, false);
+ 			/* don't retry if called from dig */
+ 			if (!statp->pfcode)
+-				return (0);
++			  return close_and_return_error (statp, resplen2);
++			__res_iclose(statp, false);
+ 		}
+ 		if (anhp->rcode == NOERROR && anhp->ancount == 0
+ 		    && anhp->aa == 0 && anhp->ra == 0 && anhp->arcount == 0) {
+@@ -1486,6 +1500,8 @@
+ 			__res_iclose(statp, false);
+ 			// XXX if we have received one reply we could
+ 			// XXX use it and not repeat it over TCP...
++			if (resplen2 != NULL)
++			  *resplen2 = 0;
+ 			return (1);
+ 		}
+ 		/* Mark which reply we received.  */
+@@ -1501,21 +1517,22 @@
+ 					__res_iclose (statp, false);
+ 					retval = reopen (statp, terrno, ns);
+ 					if (retval <= 0)
+-						return retval;
++					  {
++					    if (resplen2 != NULL)
++					      *resplen2 = 0;
++					    return retval;
++					  }
+ 					pfd[0].fd = EXT(statp).nssocks[ns];
+ 				}
+ 			}
+ 			goto wait;
+ 		}
+-		/*
+-		 * All is well, or the error is fatal.  Signal that the
+-		 * next nameserver ought not be tried.
+-		 */
++		/* All is well.  We have received both responses (if
++		   two responses were requested).  */
+ 		return (resplen);
+-	} else if (pfd[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+-		/* Something went wrong.  We can stop trying.  */
+-		goto err_out;
+-	}
++	} else if (pfd[0].revents & (POLLERR | POLLHUP | POLLNVAL))
++	  /* Something went wrong.  We can stop trying.  */
++	  return close_and_return_error (statp, resplen2);
+ 	else {
+ 		/* poll should not have returned > 0 in this case.  */
+ 		abort ();
+--- a/stdlib/setenv.c	2016-02-18 18:54:00.000000000 +0100
++++ b/stdlib/setenv.c	2016-04-27 16:54:03.132148493 +0200
+@@ -278,18 +278,20 @@
+   ep = __environ;
+   if (ep != NULL)
+     while (*ep != NULL)
+-      if (!strncmp (*ep, name, len) && (*ep)[len] == '=')
+-	{
+-	  /* Found it.  Remove this pointer by moving later ones back.  */
+-	  char **dp = ep;
++      {
++	if (!strncmp (*ep, name, len) && (*ep)[len] == '=')
++	  {
++	    /* Found it.  Remove this pointer by moving later ones back.  */
++	    char **dp = ep;
+
+-	  do
+-	    dp[0] = dp[1];
+-	  while (*dp++);
+-	  /* Continue the loop in case NAME appears again.  */
+-	}
+-      else
+-	++ep;
++	    do
++		dp[0] = dp[1];
++	    while (*dp++);
++	    /* Continue the loop in case NAME appears again.  */
++	  }
++	else
++	  ++ep;
++      }
+
+   UNLOCK;
+
+--- a/sysdeps/i386/i686/multiarch/bcopy.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/bcopy.S	2016-04-27 16:55:36.725722535 +0200
+@@ -36,7 +36,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__bcopy_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__bcopy_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/bzero.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/bzero.S	2016-04-27 16:55:36.725722535 +0200
+@@ -31,7 +31,7 @@
+ 	HAS_CPU_FEATURE (SSE2)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX ( __bzero_sse2)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__bzero_sse2_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/memcpy_chk.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/memcpy_chk.S	2016-04-27 16:55:36.725722535 +0200
+@@ -39,7 +39,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memcpy_chk_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memcpy_chk_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/memcpy.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/memcpy.S	2016-04-27 16:55:36.725722535 +0200
+@@ -38,7 +38,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memcpy_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memcpy_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/memmove_chk.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/memmove_chk.S	2016-04-27 16:55:36.725722535 +0200
+@@ -36,7 +36,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memmove_chk_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memmove_chk_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/mempcpy_chk.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/mempcpy_chk.S	2016-04-27 16:55:36.725722535 +0200
+@@ -39,7 +39,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__mempcpy_chk_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__mempcpy_chk_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/mempcpy.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/mempcpy.S	2016-04-27 16:55:36.725722535 +0200
+@@ -38,7 +38,7 @@
+ 	HAS_CPU_FEATURE (SSSE3)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__mempcpy_ssse3)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__mempcpy_ssse3_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/memset_chk.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/memset_chk.S	2016-04-27 16:55:36.725722535 +0200
+@@ -31,7 +31,7 @@
+ 	HAS_CPU_FEATURE (SSE2)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memset_chk_sse2)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memset_chk_sse2_rep)
+ 2:	ret
+--- a/sysdeps/i386/i686/multiarch/memset.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/i386/i686/multiarch/memset.S	2016-04-27 16:55:36.725722535 +0200
+@@ -31,7 +31,7 @@
+ 	HAS_CPU_FEATURE (SSE2)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memset_sse2)
+-	HAS_CPU_FEATURE (Fast_Rep_String)
++	HAS_ARCH_FEATURE (Fast_Rep_String)
+ 	jz	2f
+ 	LOAD_FUNC_GOT_EAX (__memset_sse2_rep)
+ 2:	ret
+--- a/sysdeps/unix/sysv/linux/x86_64/64/dl-librecon.h	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/unix/sysv/linux/x86_64/64/dl-librecon.h	2016-04-27 16:55:09.392152302 +0200
+@@ -33,7 +33,7 @@
+   case 21:							      \
+     if (memcmp (envline, "PREFER_MAP_32BIT_EXEC", 21) == 0)	      \
+       GLRO(dl_x86_cpu_features).feature[index_Prefer_MAP_32BIT_EXEC]  \
+-	= bit_Prefer_MAP_32BIT_EXEC;				      \
++	|= bit_Prefer_MAP_32BIT_EXEC;				      \
+     break;
+
+ /* Extra unsecure variables.  The names are all stuffed in a single
+--- a/sysdeps/x86/bits/string.h	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/x86/bits/string.h	2016-04-27 16:55:24.429765840 +0200
+@@ -23,6 +23,9 @@
+ /* Use the unaligned string inline ABI.  */
+ #define _STRING_INLINE_unaligned 1
+
++/* Don't inline mempcpy into memcpy as x86 has an optimized mempcpy.  */
++#define _HAVE_STRING_ARCH_mempcpy 1
++
+ /* Enable inline functions only for i486 or better when compiling for
+    ia32.  */
+ #if !defined __x86_64__ && (defined __i486__ || defined __pentium__	      \
+--- a/sysdeps/x86_64/dl-trampoline.h	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/x86_64/dl-trampoline.h	2016-04-27 16:56:07.128466978 +0200
+@@ -30,7 +30,7 @@
+ #undef REGISTER_SAVE_AREA
+ #undef LOCAL_STORAGE_AREA
+ #undef BASE
+-#if DL_RUNIME_RESOLVE_REALIGN_STACK
++#if DL_RUNTIME_RESOLVE_REALIGN_STACK
+ # define REGISTER_SAVE_AREA	(REGISTER_SAVE_AREA_RAW + 8)
+ /* Local stack area before jumping to function address: RBX.  */
+ # define LOCAL_STORAGE_AREA	8
+@@ -57,7 +57,7 @@
+ 	cfi_startproc
+ _dl_runtime_resolve:
+ 	cfi_adjust_cfa_offset(16) # Incorporate PLT
+-#if DL_RUNIME_RESOLVE_REALIGN_STACK
++#if DL_RUNTIME_RESOLVE_REALIGN_STACK
+ # if LOCAL_STORAGE_AREA != 8
+ #  error LOCAL_STORAGE_AREA must be 8
+ # endif
+@@ -146,7 +146,7 @@
+ 	VMOV (REGISTER_SAVE_VEC_OFF + VEC_SIZE * 5)(%rsp), %VEC(5)
+ 	VMOV (REGISTER_SAVE_VEC_OFF + VEC_SIZE * 6)(%rsp), %VEC(6)
+ 	VMOV (REGISTER_SAVE_VEC_OFF + VEC_SIZE * 7)(%rsp), %VEC(7)
+-#if DL_RUNIME_RESOLVE_REALIGN_STACK
++#if DL_RUNTIME_RESOLVE_REALIGN_STACK
+ 	mov %RBX_LP, %RSP_LP
+ 	cfi_def_cfa_register(%rsp)
+ 	movq (%rsp), %rbx
+--- a/sysdeps/x86_64/dl-trampoline.S	2016-02-18 18:54:00.000000000 +0100
++++ b/sysdeps/x86_64/dl-trampoline.S	2016-04-27 16:56:07.128466978 +0200
+@@ -33,15 +33,19 @@
+ # define DL_STACK_ALIGNMENT 8
+ #endif
+
+-#ifndef DL_RUNIME_UNALIGNED_VEC_SIZE
+-/* The maximum size of unaligned vector load and store.  */
+-# define DL_RUNIME_UNALIGNED_VEC_SIZE 16
++#ifndef DL_RUNTIME_UNALIGNED_VEC_SIZE
++/* The maximum size in bytes of unaligned vector load and store in the
++   dynamic linker.  Since SSE optimized memory/string functions with
++   aligned SSE register load and store are used in the dynamic linker,
++   we must set this to 8 so that _dl_runtime_resolve_sse will align the
++   stack before calling _dl_fixup.  */
++# define DL_RUNTIME_UNALIGNED_VEC_SIZE 8
+ #endif
+
+ /* True if _dl_runtime_resolve should align stack to VEC_SIZE bytes.  */
+-#define DL_RUNIME_RESOLVE_REALIGN_STACK \
++#define DL_RUNTIME_RESOLVE_REALIGN_STACK \
+   (VEC_SIZE > DL_STACK_ALIGNMENT \
+-   && VEC_SIZE > DL_RUNIME_UNALIGNED_VEC_SIZE)
++   && VEC_SIZE > DL_RUNTIME_UNALIGNED_VEC_SIZE)
+
+ /* Align vector register save area to 16 bytes.  */
+ #define REGISTER_SAVE_VEC_OFF	0
+@@ -76,7 +80,7 @@
+ #ifdef HAVE_AVX512_ASM_SUPPORT
+ # define VEC_SIZE		64
+ # define VMOVA			vmovdqa64
+-# if DL_RUNIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
++# if DL_RUNTIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
+ #  define VMOV			vmovdqa64
+ # else
+ #  define VMOV			vmovdqu64
+@@ -100,7 +104,7 @@
+
+ #define VEC_SIZE		32
+ #define VMOVA			vmovdqa
+-#if DL_RUNIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
++#if DL_RUNTIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
+ # define VMOV			vmovdqa
+ #else
+ # define VMOV			vmovdqu
+@@ -119,7 +123,7 @@
+ /* movaps/movups is 1-byte shorter.  */
+ #define VEC_SIZE		16
+ #define VMOVA			movaps
+-#if DL_RUNIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
++#if DL_RUNTIME_RESOLVE_REALIGN_STACK || VEC_SIZE <= DL_STACK_ALIGNMENT
+ # define VMOV			movaps
+ #else
+ # define VMOV			movups

--- a/glibc/x86_64-linux-kernel2/nss-nisplus-gcc7.patch
+++ b/glibc/x86_64-linux-kernel2/nss-nisplus-gcc7.patch
@@ -1,0 +1,16 @@
+diff --git a/nis/nss_nisplus/nisplus-alias.c b/nis/nss_nisplus/nisplus-alias.c
+index 7f698b4e6d..509ace1f83 100644
+--- a/nis/nss_nisplus/nisplus-alias.c
++++ b/nis/nss_nisplus/nisplus-alias.c
+@@ -297,10 +297,10 @@  _nss_nisplus_getaliasbyname_r (const char *name, struct aliasent *alias,
+       return NSS_STATUS_UNAVAIL;
+     }
+ 
+-  char buf[strlen (name) + 9 + tablename_len];
++  char buf[tablename_len + 9];
+   int olderr = errno;
+ 
+-  snprintf (buf, sizeof (buf), "[name=%s],%s", name, tablename_val);
++  snprintf (buf, sizeof (buf), "[name=],%s", tablename_val);
+ 
+   nis_result *result = nis_list (buf, FOLLOW_PATH | FOLLOW_LINKS, NULL, NULL);

--- a/glibc/x86_64-linux-kernel2/plan.sh
+++ b/glibc/x86_64-linux-kernel2/plan.sh
@@ -1,0 +1,358 @@
+pkg_name=glibc
+pkg_origin=core
+pkg_version=2.23
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-2.0' 'LGPL-2.0')
+pkg_description="$(cat << EOF
+  The GNU C Library project provides the core libraries for the GNU system and GNU/Linux systems,
+  as well as many other systems that use Linux as the kernel. These libraries provide critical
+  APIs including ISO C11, POSIX.1-2008, BSD, OS-specific APIs and more. These APIs include such
+  foundational facilities as open, read, write, malloc, printf, getaddrinfo, dlopen,
+  pthread_create, crypt, login, exit and more.
+EOF
+)"
+pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
+pkg_shasum=94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9
+pkg_upstream_url=https://www.gnu.org/software/libc
+pkg_deps=(core/linux-headers)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/perl)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  # The `/bin/pwd` path is hardcoded, so we'll add a symlink if needed.
+  if [[ ! -r /bin/pwd ]]; then
+    ln -sv "$(pkg_path_for coreutils)/bin/pwd" /bin/pwd
+    _clean_pwd=true
+  fi
+
+  # Determine the full path to the linker which will be produced.
+  dynamic_linker="$pkg_prefix/lib/ld-linux-x86-64.so.2"
+
+  # We don't want glibc to try and reference itself before it's installed,
+  # no `$LD_RUN_PATH`s here
+  unset LD_RUN_PATH
+  build_line "Overriding LD_RUN_PATH=$LD_RUN_PATH"
+
+  unset CFLAGS
+  build_line "Overriding CFLAGS=$CFLAGS"
+
+  # Add a dynamic-linker option to `$LDFLAGS` so that every dynamic ELF binary
+  # will use our own dynamic linker and not a previously built version.
+  LDFLAGS="-Wl,--dynamic-linker=$dynamic_linker"
+  build_line "Setting LDFLAGS=$LDFLAGS"
+
+  # Don't depend on dynamically linked libgcc for nscd, as we don't want it
+  # depending on any bootstrapped version.
+  echo "LDFLAGS-nscd += -static-libgcc" >> nscd/Makefile
+
+  # Have `rpcgen(1)` look for `cpp(1)` in `$PATH`.
+  # Thanks to https://github.com/NixOS/nixpkgs/blob/1b55b07/pkgs/development/libraries/glibc/rpcgen-path.patch
+  patch -p1 < "$PLAN_CONTEXT/rpcgen-path.patch"
+
+  # Don't use the system's `/etc/ld.so.cache` and `/etc/ld.so.preload`, but
+  # rather the version under `$pkg_prefix/etc`.
+  #
+  # Thanks to https://github.com/NixOS/nixpkgs/blob/54fc2db/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache.patch
+  # and to https://github.com/NixOS/nixpkgs/blob/dac591a/pkgs/development/libraries/glibc/dont-use-system-ld-so-preload.patch
+  # shellcheck disable=SC2002
+  cat "$PLAN_CONTEXT/dont-use-system-ld-so.patch" \
+    | sed "s,@prefix@,$pkg_prefix,g" \
+    | patch -p1
+
+  # Fix for the scanf15 and scanf17 tests for arches that need
+  # misc/bits/syscall.h. This problem is present once a custom location is used
+  # for the Linux Kernel headers.
+  #
+  # Source: https://lists.debian.org/debian-glibc/2013/11/msg00116.html
+  patch -p1 < "$PLAN_CONTEXT/testsuite-fix.patch"
+
+  # Fix for CVE-2016-3075 and more
+  #
+  # Source: http://www.linuxfromscratch.org/patches/downloads/glibc/glibc-2.23-upstream_fixes-1.patch
+  patch -p1 < "$PLAN_CONTEXT/glibc-2.23-upstream_fixes-1.patch"
+
+  # Patch for symver issues.
+  #
+  # Source: https://patchwork.ozlabs.org/patch/797471/
+  patch -p1 < "$PLAN_CONTEXT/0005-fix-binutils-2-29-build.patch"
+
+  # Patch for GCC error that use to be a warning.
+  #
+  # Source: https://patchwork.ozlabs.org/patch/680578/
+  patch -p1 < "$PLAN_CONTEXT/gcc-implicit-boolean.patch"
+
+  # Removing sunrpc in 2.23 caused a bug
+  #
+  # Source https://lists.crux.nu/pipermail/crux-commits/2017-October/022800.html
+  patch -p1 < "$PLAN_CONTEXT/remove-sun-rpm-bug.patch"
+
+  # Fix error for GCC7 error
+  #
+  # Source: https://patches.linaro.org/patch/100439/
+  patch -p1 < "$PLAN_CONTEXT/nss-nisplus-gcc7.patch"
+
+
+  # Adjust `scripts/test-installation.pl` to use our new dynamic linker
+  sed -i "s|libs -o|libs -L${pkg_prefix}/lib -Wl,-dynamic-linker=${dynamic_linker} -o|" \
+    scripts/test-installation.pl
+}
+
+do_build() {
+  rm -rf ../${pkg_name}-build
+  mkdir ../${pkg_name}-build
+  pushd ../${pkg_name}-build > /dev/null
+    # Configure Glibc to install its libraries into `$pkg_prefix/lib`
+    echo "libc_cv_slibdir=$pkg_prefix/lib" >> config.cache
+    echo "libc_cv_ssp=no" >> config.cache
+
+    "../$pkg_dirname/configure" \
+      --prefix="$pkg_prefix" \
+      --sbindir="$pkg_prefix/bin" \
+      --with-headers="$(pkg_path_for linux-headers)/include" \
+      --libdir="$pkg_prefix/lib" \
+      --libexecdir="$pkg_prefix/lib/glibc" \
+      --sysconfdir="$pkg_prefix/etc" \
+      --enable-obsolete-rpc \
+      --disable-profile \
+      --enable-kernel=2.6.32 \
+      --cache-file=config.cache
+
+    make
+  popd > /dev/null
+}
+
+# Running a `make check` is considered one critical test of the correctness of
+# the resulting glibc build. Unfortunetly, the time to complete the test suite
+# rougly triples the build time of this Plan and there are at least 2 known
+# failures which means that `make check` certainly returns a non-zero exit
+# code. Despite these downsides, it is still worth the pain when building the
+# first time in a new environment, or when a new upstream version is attempted.
+#
+# There are known failures in `make check`, but most likely known ones, given a
+# build on a full virtual machine or physical server. Here are the known
+# failures and why:
+#
+# ## FAIL: elf/check-abi-libc
+#
+# "You might see a check failure due to a different size for
+# `_nl_default_dirname` if you build for a different prefix using the
+# `--prefix` configure option. The size of `_nl_default_dirname` depends on the
+# prefix and `/usr/share/locale` is considered the default and hence the value
+# 0x12. If you see such a difference, you should check that the size
+# corresponds to your prefix, i.e. `(length of prefix path + 1)` to ensure that
+# you haven't really broken abi with your change."
+#
+# Source: https://sourceware.org/glibc/wiki/Testing/Testsuite#Known_testsuite_failures
+#
+# ## FAIL: posix/tst-getaddrinfo4
+#
+# "This test will always fail due to not having the necessary networking
+# applications when the tests are run."
+#
+# Source: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/glibc.html
+#
+do_check() {
+  pushd ../${pkg_name}-build > /dev/null
+    # One of the tests uses the hardcoded `bin/cat` path, so we'll add it, if
+    # it doesn't exist.
+    if [[ ! -r /bin/cat ]]; then
+      ln -sv "$(pkg_path_for coreutils)/bin/cat" /bin/cat
+      _clean_cat=true
+    fi
+    # One of the tests uses the hardcoded `bin/echo` path, so we'll add it, if
+    # it doesn't exist.
+    if [[ ! -r /bin/echo ]]; then
+      ln -sv "$(pkg_path_for coreutils)/bin/echo" /bin/echo
+      _clean_echo=true
+    fi
+
+    # "If the test system does not have suitable copies of libgcc_s.so and
+    # libstdc++.so installed in system library directories, it is necessary to
+    # copy or symlink them into the build directory before testing (see
+    # https://sourceware.org/ml/libc-alpha/2012-04/msg01014.html regarding the
+    # use of system library directories here)."
+    #
+    # Source: https://sourceware.org/glibc/wiki/Release/2.23
+    # Source: http://www0.cs.ucl.ac.uk/staff/ucacbbl/glibc/index.html#bug-atexit3
+    if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+      ln -sv /tools/lib/libgcc_s.so.1 .
+      ln -sv /tools/lib/libstdc++.so.6 .
+    else
+      ln -sv "$(pkg_path_for gcc)/lib/libgcc_s.so.1" .
+      ln -sv "$(pkg_path_for gcc)/lib/libstdc++.so.6" .
+    fi
+
+    # It appears as though some tests *always* fail, but since the output (and
+    # passing tests) is of value, we will run the anyway. Expect ignore the
+    # exit code. I am sad.
+    make check || true
+
+    rm -fv ./libgcc_s.so.1 ./libstdc++.so.6
+
+    # Clean up the symlinks if we set it up.
+    if [[ -n "$_clean_echo" ]]; then
+      rm -fv /bin/echo
+    fi
+    if [[ -n "$_clean_cat" ]]; then
+      rm -fv /bin/cat
+    fi
+  popd > /dev/null
+}
+
+do_install() {
+  pushd ../${pkg_name}-build > /dev/null
+    # Prevent a `make install` warning of a missing `ld.so.conf`.
+    mkdir -p "$pkg_prefix/etc"
+    touch "$pkg_prefix/etc/ld.so.conf"
+
+    # To ensure the `make install` checks at the end succeed. Unfortunately,
+    # a multilib installation is assumed (i.e. 32-bit and 64-bit). We will
+    # fool this check by symlinking a "32-bit" file to the real loader.
+    mkdir -p "$pkg_prefix/lib"
+    ln -sv ld-2.23.so "$pkg_prefix/lib/ld-linux.so.2"
+
+    # Add a `lib64` -> `lib` symlink for `bin/ldd` to work correctly.
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L43-L47
+    ln -sv lib "$pkg_prefix/lib64"
+
+    if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+      # When building glibc using a build toolchain, we need libgcc_s at
+      # `$RPATH` which gets us by until we can link against this for real
+      if [ -f /tools/lib/libgcc_s.so.1 ]; then
+        cp -v /tools/lib/libgcc_s.so.1 "$pkg_prefix/lib/"
+        # the .so file used to be a symlink, but now it is a script
+        cp -av /tools/lib/libgcc_s.so "$pkg_prefix/lib/"
+      fi
+    fi
+
+    make install sysconfdir="$pkg_prefix/etc" sbindir="$pkg_prefix/bin"
+
+    # Move all remaining binaries in `sbin/` into `bin/`, namely `ldconfig`
+    mv "$pkg_prefix/sbin"/* "$pkg_prefix/bin/"
+    rm -rf "$pkg_prefix/sbin"
+
+    # Remove unneeded files from `include/rpcsvc`
+    rm -fv "$pkg_prefix/include/rpcsvc"/*.x
+
+    # Remove the `make install` check symlink
+    rm -fv "$pkg_prefix/lib/ld-linux.so.2"
+
+    # Remove `sln` (statically built ln)--not needed
+    rm -f "$pkg_prefix/bin/sln"
+
+    # Update the shebangs of a few shell scripts that have a fully-qualified
+    # path to `/bin/sh` so they will work in a minimal busybox
+    for b in ldd sotruss tzselect xtrace; do
+      sed -e 's,^#!.*$,#! /bin/sh,' -i "$pkg_prefix/bin/$b"
+    done
+
+    # Include the Linux kernel headers in Glibc, except the `scsi/` directory,
+    # which Glibc provides itself.
+    #
+    # We can thank GCC for this requirement; we must provide a single path
+    # value for the `--with-native-system-header-dir` configure option and this
+    # path must contain libc and kernel headers (the assumption is we are
+    # running a common operating system with everything under `/usr/include`).
+    # GCC then bakes this path in when it builds itself, thus it's pretty
+    # important for any future GCC-built packages. If there is an alternate way
+    # we can make GCC happy, then we'll change this up. This is the best of a
+    # sad, sad situation.
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L25-L32
+    pushd "$pkg_prefix/include" > /dev/null
+      # shellcheck disable=SC2010,SC2046
+      ln -sv $(ls -d $(pkg_path_for linux-headers)/include/* | grep -v 'scsi$') .
+    popd > /dev/null
+
+    mkdir -pv "$pkg_prefix/lib/locale"
+    localedef -i cs_CZ -f UTF-8 cs_CZ.UTF-8
+    localedef -i de_DE -f ISO-8859-1 de_DE
+    localedef -i de_DE@euro -f ISO-8859-15 de_DE@euro
+    localedef -i en_HK -f ISO-8859-1 en_HK
+    localedef -i en_PH -f ISO-8859-1 en_PH
+    localedef -i en_US -f ISO-8859-1 en_US
+    localedef -i en_US -f UTF-8 en_US
+    localedef -i es_MX -f ISO-8859-1 es_MX
+    localedef -i fa_IR -f UTF-8 fa_IR
+    localedef -i fr_FR -f ISO-8859-1 fr_FR
+    localedef -i fr_FR@euro -f ISO-8859-15 fr_FR@euro
+    localedef -i it_IT -f ISO-8859-1 it_IT
+    localedef -i ja_JP -f EUC-JP ja_JP
+
+    cp -v "../$pkg_dirname/nscd/nscd.conf" "$pkg_prefix/etc/"
+
+    cat > "$pkg_prefix/etc/nsswitch.conf" << "EOF"
+passwd: files
+group: files
+shadow: files
+
+hosts: files dns
+networks: files
+
+protocols: files
+services: files
+ethers: files
+rpc: files
+EOF
+
+    extract_src tzdata
+    pushd ./tzdata > /dev/null
+      ZONEINFO="$pkg_prefix/share/zoneinfo"
+      mkdir -p "$ZONEINFO"/{posix,right}
+      for tz in etcetera southamerica northamerica europe africa antarctica \
+          asia australasia backward pacificnew systemv; do
+        zic -L /dev/null -d "$ZONEINFO" -y "sh yearistype.sh" ${tz}
+        zic -L /dev/null -d "$ZONEINFO/posix" -y "sh yearistype.sh" ${tz}
+        zic -L leapseconds -d "$ZONEINFO/right" -y "sh yearistype.sh" ${tz}
+      done
+      cp -v zone.tab zone1970.tab iso3166.tab "$ZONEINFO"
+      zic -d "$ZONEINFO" -p America/New_York
+      unset ZONEINFO
+    popd > /dev/null
+    cp -v "$pkg_prefix/share/zoneinfo/UTC" "$pkg_prefix/etc/localtime"
+  popd > /dev/null
+}
+
+do_end() {
+  # Clean up the `pwd` link, if we set it up.
+  if [[ -n "$_clean_pwd" ]]; then
+    rm -fv /bin/pwd
+  fi
+}
+
+extract_src() {
+  build_dirname=$pkg_dirname/../${pkg_name}-build
+  plan=$1
+
+  (source "$PLAN_CONTEXT/../../$plan/plan.sh"
+    # Re-override the defaults as this plan is sourced externally
+    pkg_filename="$(basename $pkg_source)"
+    pkg_dirname="${pkg_name}-${pkg_version}"
+    CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+
+    build_line "Downloading $pkg_source"
+    do_download
+    build_line "Verifying $pkg_filename"
+    do_verify
+    build_line "Clean the cache"
+    do_clean
+    build_line "Unpacking $pkg_filename"
+    do_unpack
+    mv -v "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$HAB_CACHE_SRC_PATH/$build_dirname/$plan"
+  )
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=()
+fi

--- a/glibc/x86_64-linux-kernel2/remove-sun-rpm-bug.patch
+++ b/glibc/x86_64-linux-kernel2/remove-sun-rpm-bug.patch
@@ -1,0 +1,11 @@
+--- a/sunrpc/rpc_parse.c
++++ b/sunrpc/rpc_parse.c
+@@ -521,7 +521,7 @@ static void
+ get_prog_declaration (declaration * dec, defkind dkind, int num /* arg number */ )
+ {
+   token tok;
+-  char name[10];		/* argument name */
++  char name[MAXLINESIZE];		/* argument name */
+ 
+   if (dkind == DEF_PROGRAM)
+     {

--- a/glibc/x86_64-linux-kernel2/rpcgen-path.patch
+++ b/glibc/x86_64-linux-kernel2/rpcgen-path.patch
@@ -1,0 +1,53 @@
+--- glibc-2.22-orig/sunrpc/rpc_main.c	2015-12-12 02:05:44.830181000 +0000
++++ glibc-2.22/sunrpc/rpc_main.c	2015-12-12 02:07:10.412966825 +0000
+@@ -78,7 +78,7 @@
+ 
+ static const char *svcclosetime = "120";
+ static int cppDefined;	/* explicit path for C preprocessor */
+-static const char *CPP = "/lib/cpp";
++static const char *CPP = "cpp";
+ static const char CPPFLAGS[] = "-C";
+ static char *pathbuf;
+ static int cpp_pid;
+@@ -107,7 +107,6 @@
+ static void open_output (const char *infile, const char *outfile);
+ static void add_warning (void);
+ static void clear_args (void);
+-static void find_cpp (void);
+ static void open_input (const char *infile, const char *define);
+ static int check_nettype (const char *name, const char *list_to_check[]);
+ static void c_output (const char *infile, const char *define,
+@@ -322,25 +321,6 @@
+   argcount = FIXEDARGS;
+ }
+ 
+-/* make sure that a CPP exists */
+-static void
+-find_cpp (void)
+-{
+-  struct stat64 buf;
+-
+-  if (stat64 (CPP, &buf) == 0)
+-    return;
+-
+-  if (cppDefined) /* user specified cpp but it does not exist */
+-    {
+-      fprintf (stderr, _ ("cannot find C preprocessor: %s\n"), CPP);
+-      crash ();
+-    }
+-
+-  /* fall back to system CPP */
+-  CPP = "cpp";
+-}
+-
+ /*
+  * Open input file with given define for C-preprocessor
+  */
+@@ -359,7 +339,6 @@
+   switch (cpp_pid)
+     {
+     case 0:
+-      find_cpp ();
+       putarg (0, CPP);
+       putarg (1, CPPFLAGS);
+       addarg (define);

--- a/glibc/x86_64-linux-kernel2/testsuite-fix.patch
+++ b/glibc/x86_64-linux-kernel2/testsuite-fix.patch
@@ -1,0 +1,15 @@
+diff -ru glibc-2.22.orig/stdio-common/Makefile glibc-2.22/stdio-common/Makefile
+--- glibc-2.22.orig/stdio-common/Makefile	2015-08-05 06:42:21.000000000 +0000
++++ glibc-2.22/stdio-common/Makefile	2015-12-17 04:51:00.303026327 +0000
+@@ -107,9 +107,9 @@
+ # GNU extension.  The latter are needed, though, when internal headers
+ # are used.  So made sure we see the installed headers first.
+ CFLAGS-scanf15.c = -I../libio -I../stdlib -I../wcsmbs -I../time -I../string \
+-		   -I../wctype
++		   -I../wctype -I$(common-objpfx)misc
+ CFLAGS-scanf17.c = -I../libio -I../stdlib -I../wcsmbs -I../time -I../string \
+-		   -I../wctype
++		   -I../wctype -I$(common-objpfx)misc
+ 
+ CPPFLAGS += $(libio-mtsafe)
+ 

--- a/libcap/x86_64-linux-kernel2/README.md
+++ b/libcap/x86_64-linux-kernel2/README.md
@@ -1,0 +1,13 @@
+# libcap
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/libcap/x86_64-linux-kernel2/libcap-old-kernel-headers.patch
+++ b/libcap/x86_64-linux-kernel2/libcap-old-kernel-headers.patch
@@ -1,0 +1,40 @@
+diff --git a/libcap/cap_file.c b/libcap/cap_file.c
+index 40756ea..e3d54dd 100644
+--- a/libcap/cap_file.c
++++ b/libcap/cap_file.c
+@@ -23,6 +23,33 @@ extern int fsetxattr(int, const char *, const void *, size_t, int);
+ extern int removexattr(const char *, const char *);
+ extern int fremovexattr(int, const char *);
+ 
++
++/*
++ * Old kernels (before 2.6.36) were defining XATTR_NAME_CAPS in
++ * <linux/capability.h>, but using XATTR_SECURITY_PREFIX and
++ * XATTR_CAPS_SUFFIX which were defined in the kernel-only part of
++ * <linux/xattr.h>.
++ *
++ * In kernel 2.6.36 (commit af4f136056c984b0aa67feed7d3170b958370b2f),
++ * the XATTR_NAME_CAPS definition was moved to the kernel-only part of
++ * <linux/xattr.h>. It's only in kernel 3.0 (commit
++ * 1dbe39424a43e56a6c9aed12661192af51dcdb9f) that <linux/xattr.h> was
++ * fixed to expose XATTR_NAME_CAPS and the related definitions to
++ * userspace.
++ *
++ * In order to cope with kernels < 3.0, we define here the appropriate
++ * values, which we assume haven't changed over history.
++ */
++#ifndef XATTR_CAPS_SUFFIX
++#define XATTR_CAPS_SUFFIX "capability"
++#endif
++#ifndef XATTR_SECURITY_PREFIX
++#define XATTR_SECURITY_PREFIX "security."
++#endif
++#ifndef XATTR_NAME_CAPS
++#define XATTR_NAME_CAPS XATTR_SECURITY_PREFIX XATTR_CAPS_SUFFIX
++#endif
++
+ #include "libcap.h"
+ 
+ #ifdef VFS_CAP_U32
+-- 
+2.6.4

--- a/libcap/x86_64-linux-kernel2/plan.sh
+++ b/libcap/x86_64-linux-kernel2/plan.sh
@@ -1,0 +1,60 @@
+pkg_name=libcap
+pkg_origin=core
+pkg_version=2.25
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="POSIX 1003.1e capabilities."
+pkg_upstream_url="http://sites.google.com/site/fullycapable/"
+pkg_license=('gplv2')
+pkg_source="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="693c8ac51e983ee678205571ef272439d83afe62dd8e424ea14ad9790bc35162"
+pkg_deps=(
+  core/glibc
+  core/attr
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/linux-headers
+  core/perl
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  do_default_prepare
+
+  # Install binaries under `bin/` vs. `sbin/`
+  sed -i "/SBINDIR/s#sbin#bin#" Make.Rules
+
+  # Patch to use old kernel header symbols, not newer ones.
+  #
+  # Thanks to: http://lists.busybox.net/pipermail/buildroot/2016-March/156250.html
+  patch -p1 < "$PLAN_CONTEXT/libcap-old-kernel-headers.patch"
+}
+
+do_build() {
+  make KERNEL_HEADERS="$(pkg_path_for linux-headers)/include" LDFLAGS="$LDFLAGS"
+}
+
+do_install() {
+  make prefix="$pkg_prefix" lib=lib RAISE_SETFCAP=no install
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/linux-headers
+  )
+fi

--- a/libsodium/plan.sh
+++ b/libsodium/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=libsodium
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.13
+pkg_version=1.0.16
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Sodium is a new, easy-to-use software library for encryption, decryption, \
@@ -11,8 +11,8 @@ API to improve usability even further.\
 "
 pkg_upstream_url="https://github.com/jedisct1/libsodium"
 pkg_license=('ISC')
-pkg_source="https://download.libsodium.org/libsodium/releases/old/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd"
+pkg_source="https://download.libsodium.org/libsodium/releases/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc

--- a/linux-headers/x86_64-linux-kernel2/plan.sh
+++ b/linux-headers/x86_64-linux-kernel2/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=linux-headers
+pkg_origin=core
+pkg_version=2.6.39
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="The Linux kernel headers"
+pkg_upstream_url="https://kernel.org"
+pkg_license=('gplv2')
+pkg_source="https://www.kernel.org/pub/linux/kernel/v2.6/linux-${pkg_version}.tar.xz"
+pkg_shasum="d3a579104e0d3154727793f4fa79b6b882ddafeded73cc8c0eb8c2536ad77373"
+pkg_dirname="linux-$pkg_version"
+pkg_deps=()
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/perl
+)
+pkg_include_dirs=(include)
+
+do_build() {
+  make headers_install ARCH=x86 INSTALL_HDR_PATH="$pkg_prefix"
+}
+
+do_install() {
+  find "$pkg_prefix/include" \
+    \( -name ..install.cmd -o -name .install \) \
+    -print0 \
+  | xargs -0 rm -v
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=()
+fi


### PR DESCRIPTION
#### What is this?
This is the set of base plans that require variations to work under the "x86-64-linux-kernel2" package target introduced in habitat-sh/core#42. These plans are specifically locked to older versions of software in order to ensure compatibility with Linux kernel versions as low as 2.6.32.

#### What does this mean for me?
There will be no differences from how you build and run Habitat plans and packages today. As we build out packages for the "kernel2 variant" you will see a hab cli with an Active Target of 'x86-64-linux-kernel2'. This will allow you to build and consume packages for the "kernel2 variant" if your environment requires support for Linux systems running on that era of the kernel.

#### Where can I learn more?
As this is foundational for work that is still in flight, we don't have any new blog posts or documentation to share at this time. Please look forward to that as this work nears a more complete state. You can see some of the early discussion here: habitat-sh/core-plans#1652 and the initial blog post here: https://www.habitat.sh/blog/2018/06/core-plans-and-certain-linux-kernels/

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>