### PR TITLE
[hugo] Update hugo to 0.47, and add testing

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.46"
+pkg_version="0.47"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/test.bats
+++ b/hugo/test.bats
@@ -1,0 +1,19 @@
+source ./plan.sh
+
+@test "Version matches" {
+  result="$(hugo version | sed 's/.*v\([0-9.]\+\)\-.*/\1/')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Basic help" {
+  run hugo help
+  [ $status -eq 0 ]
+}
+
+@test "Create new site" {
+  run hugo new site habtestsite
+  [ $status -eq 0 ]
+  [ -d habtestsite ]
+  [ -f "habtestsite/config.toml" ]
+  rm -rf habtestsite
+}

--- a/hugo/test.sh
+++ b/hugo/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+source ./plan.sh
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  set +e
+fi
+
+bats test.bats


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
# Inside studio
cd hugo
./test.sh
```

### Sample Output

```
 ✓ Version matches
 ✓ Basic help
 ✓ Create new site

3 tests, 0 failures
```