### PR TITLE
[ps-lock] lift powershell version restriction

### DIFF
--- a/ps-lock/PSLock.psd1
+++ b/ps-lock/PSLock.psd1
@@ -6,6 +6,5 @@
     CompanyName = 'Chef Software Inc.'
     Copyright = 'Copyright (c) 2018 Chef Software Inc. and/or applicable contributors'
     Description = 'Provides synchronization of scripts run in hooks that declare the same lock.'
-    PowerShellVersion = '6.0.0'
     FunctionsToExport = 'Enter-PSLock'
 }


### PR DESCRIPTION
There is nothing in this module that depends on ps v6. Ran into someone who wanted to use this outside of habitat but did not want to be in v6.

Signed-off-by: mwrock <matt@mattwrock.com>