### PR TITLE
[jenkins] Update to 2.121.3 - Security updates

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.121.2
+pkg_version=2.121.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="da0f9d106e936246841a898471783fb4fbdbbacc8d42a156b7306a0855189602"
+pkg_shasum="50fbce11fa147d0ecd9ecf36cdae83ef795fb7d4776f33b5ea13bc15bf6e3c13"
 pkg_deps=(core/jre8 core/curl)
 pkg_exports=(
   [port]=jenkins.http.port


### PR DESCRIPTION
Fixes #1806

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

```
# Start studio with a port forward
HAB_DOCKER_OPTS="-p 10080:80" hab studio enter

# Build and install
build; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident};

# Follow Logs - Confirm admin password is displayed
sl

# Extra tools
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static nc
hab pkg binlink core/busybox-static ifconfig

# Confirm 80 is listening
netstat -peanut

# Confirm listening (exit code 0)
IP_ADDRESS=$(ifconfig eth0 | grep 'inet addr' | awk -F'[: ]+' '{print $4}')
nc -z ${IP_ADDRESS} 80

# Browse to URL on local machine (port 10080) and confirm installer is displayed.
# It will show a page with heading: Getting Started / Unlock Jenkins
```