### PR TITLE
[kubernetes] Upgrade to k8s 1.11.2

### DIFF
--- a/kubernetes-apiserver/plan.sh
+++ b/kubernetes-apiserver/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
-pkg_deps=("core/kubernetes")
+pkg_version=1.11.2
+pkg_deps=("core/kubernetes/1.11.2")
 
 do_build() {
   return 0

--- a/kubernetes-controller-manager/plan.sh
+++ b/kubernetes-controller-manager/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
-pkg_deps=("core/kubernetes")
+pkg_version=1.11.2
+pkg_deps=("core/kubernetes/1.11.2")
 
 do_build() {
   return 0

--- a/kubernetes-kubelet/plan.sh
+++ b/kubernetes-kubelet/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
-pkg_deps=("core/kubernetes")
+pkg_version=1.11.2
+pkg_deps=("core/kubernetes/1.11.2")
 pkg_svc_user="root"
 pkg_svc_group="${pkg_svc_user}"
 

--- a/kubernetes-proxy/plan.sh
+++ b/kubernetes-proxy/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
-pkg_deps=("core/kubernetes")
+pkg_version=1.11.2
+pkg_deps=("core/kubernetes/1.11.2")
 pkg_svc_user="root"
 pkg_svc_group="${pkg_svc_user}"
 

--- a/kubernetes-scheduler/plan.sh
+++ b/kubernetes-scheduler/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
-pkg_deps=("core/kubernetes")
+pkg_version=1.11.2
+pkg_deps=("core/kubernetes/1.11.2")
 
 do_build() {
   return 0

--- a/kubernetes/plan.sh
+++ b/kubernetes/plan.sh
@@ -4,9 +4,9 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
+pkg_version=1.11.2
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=073b77321812f26df6513c0ad0aef3a8b0c17f6281a186d515f5855ae009ea17
+pkg_shasum=43f42c64426247d909010bf77f18c72ab1f36104a67e9c878cf897ee9f0ab6a6
 
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
This PR updates the following packages to version 1.11.2

- kubernetes
- kubernetes-apiserver
- kubernetes-controller-manager
- kubernetes-kubelet
- kubernetes-proxy
- kubernetes-scheduler

**Testing:**

The packages have been built and uploaded to builder with `kosy` as the package origin.

**Prerequisites**
* Linux or MacOS on the host (Windows is not supported)
* [Vagrant](https://www.vagrantup.com/downloads.html)
* [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
* [cfssl](https://github.com/cloudflare/cfssl#installation) (with cfssljson)
* [jq](https://stedolan.github.io/jq/download/) Command-line JSON processor

**Steps**
```
$ git clone https://github.com/kinvolk/kubernetes-the-hab-way.git

$ sed -i 's/core\/k/kosy\/k/g' scripts/setup

$ ./scripts/setup
```
Verify the 3 nodes are up and ready:
```
$ kubectl get nodes
```
Output should look like this:

```
NAME      STATUS    ROLES     AGE       VERSION
node-0    Ready     <none>    23m       v1.8.2
node-1    Ready     <none>    23m       v1.8.2
node-2    Ready     <none>    23m       v1.8.2
```
Test the setup by creating a Nginx deployment, expose it and send a request to the service IP:
```
# On Linux
$ sudo route add -net 10.32.0.0/24 gw 192.168.222.10
# On macOS
$ sudo route -n add -net 10.32.0.0/24 192.168.222.10

# Run the smoke test
$ ./scripts/smoke-test

# Clean up 
$ vagrant destroy -f 
```

Fixes https://github.com/kinvolk/kubernetes-the-hab-way/issues/14