### PR TITLE
[prometheus-cpp] patch bump to 0.4.2 and make sure tests execute

### DIFF
--- a/prometheus-cpp/README.md
+++ b/prometheus-cpp/README.md
@@ -37,8 +37,6 @@ pkg_build_deps=(
 pkg_deps=(
   core/glibc
   core/gcc-libs
-  core/zlib
-  core/protobuf
 )
 
 pkg_bin_dirs=(bin)
@@ -75,5 +73,4 @@ target_link_libraries(myapp prometheus-cpp::prometheus-cpp)
 
 ### Example Application
 
-An example application built with Habitat is can be viewed
- [here](https://github.com/bdangit/prometheus-cpp-example).
+An example application built with Habitat is can be viewed [here](https://github.com/bdangit/prometheus-cpp-example).


### PR DESCRIPTION
This updates the cpp lib to 0.4.2 (patch).  A few other notables:

- make sure tests and benchmarks will run when `DO_CHECK` is set
- change to ninja because its faster

Signed-off-by: Ben Dang <me@bdang.it>

## Build and Test

This is a cpp library where the unit tests are built into the `do_check`.

```
hab studio run "DO_CHECK=1 build"
```

### Expectation

Build, Unit Tests and Benchmarks will pass.