### PR TITLE
[hugo] Upgrade to 0.48, add tests

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_build_deps=(
   core/dep
-  rakops/mage
+  core/mage
 )
 pkg_bin_dirs=(bin)
 pkg_source="https://github.com/gohugoio/hugo"

--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.46"
+pkg_version="0.48"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_build_deps=(
   core/dep
-  core/mage
+  rakops/mage
 )
 pkg_bin_dirs=(bin)
 pkg_source="https://github.com/gohugoio/hugo"

--- a/hugo/test.bats
+++ b/hugo/test.bats
@@ -1,0 +1,24 @@
+source ./plan.sh
+
+@test "Command is on path" {
+  [ "$(command -v hugo)" ]
+}
+
+@test "Version matches" {
+  result="$(hugo version | sed 's/.*v\([0-9.]\+\)\-.*/\1/')"
+  [ "${result}" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run hugo help
+  [ $status -eq 0 ]
+}
+
+@test "Create new site" {
+  [ ! -d habtestsite ]
+  run hugo new site habtestsite
+  [ $status -eq 0 ]
+  [ -d habtestsite ]
+  [ -f "habtestsite/config.toml" ]
+  rm -rf habtestsite
+}

--- a/hugo/test.sh
+++ b/hugo/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+source ./plan.sh
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  set +e
+fi
+
+bats test.bats


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-25475570](https://user-images.githubusercontent.com/24568/44826728-1afb4680-ac4b-11e8-8f58-c0c42c96d112.gif)

**Note**: this requires #1821 to be built and promoted in order to build successfully.

Testing:

```
hab studio enter
cd hugo
./test.sh
```

Sample output:

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Create new site

4 tests, 0 failures
```
