### PR TITLE
add echohack to maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -77,7 +77,7 @@ dejagnu @fnichol
 check @fnichol
 libidn @fnichol
 cacerts @fnichol
-openssl @fnichol @reset
+openssl @fnichol @reset @echohack
 wget @fnichol
 unzip @fnichol @nellshamrell
 rq @fnichol

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,6 +34,7 @@ To become a maintainer, open a pull request to this list.
 * [Jon Bauman](https://github.com/baumanj)
 * [Graham Weldon](https://github.com/predominant)
 * [W. Duncan Fraser](https://github.com/wduncanfraser)
+* [David Echols](https://github.com/echohack)
 
 ## Alumni
 


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

I'd like to add myself to maintainers for core-plans, along with as a CODEOWNER of openssl.