### PR TITLE
[scaffolding-ruby] ensure bundler version is the version number

### DIFF
--- a/scaffolding-ruby/CHANGELOG.md
+++ b/scaffolding-ruby/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-ruby)
 
+# 0.8.10 (09-20-2018)
+
+- Fix parsing of `bundler --version` output to ensure ${_bundler_version}
+  is really the version number of bundler
+
 # 0.8.9 (12-08-2017)
 
 - Improve git detection with `git rev-parse --is-in-work-tree`, makes

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -197,7 +197,7 @@ EOT
 scaffolding_bundle_install() {
   local start_sec elapsed
 
-  build_line "Installing dependencies using $(_bundle --version)"
+  build_line "Installing dependencies using Bundler version ${_bundler_version}"
   start_sec="$SECONDS"
 
   {
@@ -347,7 +347,7 @@ scaffolding_generate_binstubs() {
 }
 
 scaffolding_vendor_bundler() {
-  build_line "Vendoring $(_bundle --version)"
+  build_line "Vendoring 'bundler' version ${_bundler_version}"
   gem install \
     --local "$(pkg_path_for bundler)/cache/bundler-${_bundler_version}.gem" \
     --install-dir "$GEM_HOME" \
@@ -451,7 +451,7 @@ _setup_vars() {
     tgbyte-activerecord-jdbcpostgresql-adapter)
   # The version of Bundler in use
   _bundler_version="$("$(pkg_path_for bundler)/bin/bundle" --version \
-    | awk '{print $NF}')"
+    | awk '/^Bundler version/ {print $NF}')"
   # The install prefix path for the app
   app_prefix="app"
   #

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-ruby
 pkg_origin=core
-pkg_version="0.8.9"
+pkg_version="0.8.10"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"


### PR DESCRIPTION
This commit ensures that the `_bundler_version` variable is set only
to the version as returned by the `bundle --version` command. Bundler
itself does not differentiate error and warning messages to STDERR, so
if there are problems such as a non-extistent $HOME directory, those
messages aren't partially captured in this output.

See habitat-sh/habitat#5569 for background.

Example of warning output:

```
> bundler --version
`/root` is not a directory.
Bundler will use `/tmp/bundler/home/unknown' as your home directory temporarily.
Bundler version 1.16.2
```

Which the previous code would parse and set `_bundler_version` to:

```
directory.
temporarily.
1.16.2.gem
```

This breaks the attempt to `gem install --local "$(pkg_path_for bundler)/cache/bundler-${_bundler_version}.gem" ...` in `scaffolding_vendor_bundler()`.

```
...
   my_project: Vendoring `/root` is not a directory.
Bundler will use `/tmp/bundler/home/unknown' as your home directory temporarily.
Bundler version 1.16.2
ERROR:  Could not find a valid gem '/hab/pkgs/core/bundler/1.16.2/20180702163315/cache/bundler-directory.
temporarily.
1.16.2.gem' (>= 0) in any repository
...
```