### PR TITLE
[vault] Upgrade to 0.11.1

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.10.4
+pkg_version=0.11.1
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=b3c8a62e8f2f1b2d9d7ddca3d8bda620ab0091bb038da0d013c26f7b6b18f13a
+pkg_shasum=eb8d2461d0ca249c1f91005f878795998bdeafccfde0b9bae82343541ce65996
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)

--- a/vault/test.bats
+++ b/vault/test.bats
@@ -1,0 +1,12 @@
+source ./plan.sh
+
+@test "Version matches" {
+  result="$(vault version | awk '{print $2}')"
+  [ "$result" = "v${pkg_version}" ]
+}
+
+@test "Help command" {
+  run vault --help
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "Usage: vault <command> [args]" ]
+}

--- a/vault/test.sh
+++ b/vault/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+source ./plan.sh
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  set +e
+fi
+
+bats test.bats


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-214070832](https://user-images.githubusercontent.com/24568/45191282-45698700-b27d-11e8-945b-ccf2c8e6e554.gif)

Testing:

```
hab studio enter
cd vault
./test.sh
```

Sample output:

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```