### PR TITLE
[googletest] bump to 1.8.1 and deprecate googlemock

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -374,8 +374,6 @@ plan_path = "go14"
 plan_path = "go17"
 [gocd-server]
 plan_path = "gocd-server"
-[googlemock]
-plan_path = "googlemock"
 [googletest]
 plan_path = "googletest"
 [goreplay]

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -1,17 +1,10 @@
-Google Mock
-===========
+Google Mock (deprecated)
+========================
 
-Maintainer: [Ben Dang](me@bdang.it)
+Google Mock has been folded into [Google Test](../googletest/README.md) which means if you need any
+of the Google Mock libraries, all you need to include your plan is `core/googletest`.
 
-Google Mock are part of the Google Test unit test framework for C/C++.  This package contains
-pre-built static libraries for you to include into your project.  More info on usage can be
-followed [here](https://github.com/google/googletest/tree/master/googlemock).
+## Maintainers:
 
-To help with locating the static libraries, a custom `pkg_config` has been included.  When you
-build your app with Habitat, your `CXX_FLAGS` will have the correct include folder and your
-`LD_LIBRARY_PATH` will have the path to the static library.  All you get to focus on is writing
-awesome tests!
-
-## Usage
-
-Just include `core/googlemock` preferably in `pkg_build_deps`.
+* The Habitat Maintainers: <humans@habitat.sh>
+* [Ben Dang](me@bdang.it)

--- a/googletest/README.md
+++ b/googletest/README.md
@@ -1,18 +1,82 @@
 Google Test
 ===========
 
-Maintainer: [Ben Dang](me@bdang.it)
+[Google C++ Testing Framework](https://github.com/google/googletest) helps you write better C++
+tests.  This package contains pre-built static libraries for googletest and googlemock for you to
+include into your project.  To unit test your C/C++ app, you have to link and compile your unit
+tests and then you will have an executable with the Google Test runner.  More info on usage can be
+followed [here](https://github.com/google/googletest).
 
-Google Test is a unit test framework for C/C++.  This package contains pre-built static libraries
-for you to include into your project.  To unit test your C/C++ app, you have to link and compile
-your unit tests and then you will have executable with the Google Test runner.  More info on usage
-can be followed [here](https://github.com/google/googletest/tree/master/googletest).
+## Maintainers
 
-To help with locating the static libraries, a custom `pkg_config` has been included.  When you
-build your app with Habitat, your `CXX_FLAGS` will have the correct include folder and your
-`LD_LIBRARY_PATH` will have the path to the static library.  All you get to focus on is writing
-awesome tests!
+* The Habitat Maintainers: <humans@habitat.sh>
+* [Ben Dang](me@bdang.it)
+
+## Type of Package
+
+Static C++ Library and Include Headers
 
 ## Usage
 
-Just include `core/googletest` preferably in `pkg_build_deps`.
+If you require `gtest` and `gmock` just include `core/googletest` preferably in `pkg_build_deps`.  
+Habitat will then update `CFLAGS`, `CXXFLAGS`, `CPPFLAGS`, `LDFLAGS` and `PKG_CONFIG_PATH` with
+paths to the libs and includes.
+
+### CMake
+
+For those using `cmake`, this is an example `plan.sh`
+
+```bash
+pkg_origin=bdangit
+pkg_name=googletest-cmake-example
+pkg_version='0.1.0'
+pkg_description="googletest cmake example"
+pkg_license=('MIT')
+pkg_maintainer='Ben Dang <me@bdang.it>'
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/cmake
+  core/googletest
+)
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  set_buildtime_env BUILD_DIR "build"
+}
+
+do_prepare() {
+  mkdir -p "${BUILD_DIR}"
+}
+
+do_build() {
+  pushd "${BUILD_DIR}" > /dev/null
+
+  _GTEST_PATH="$(pkg_path_for core/googletest)"
+
+  cmake \
+    -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
+    -DGTest_DIR="${_GTEST_PATH}/lib64/cmake/GTest" \
+    ..
+  make
+
+  popd > /dev/null
+}
+```
+
+In your `CMakeLists.txt`, make sure to find the package `GTest` and set your target to link against
+`GTest::gtest`, `GTest::gtest_main`, `GTest::gmock`, and/or `GTest::gmock_main`.
+
+```cmake
+# note: we want the config mode since googletest packaged a very robust cmake macro
+#       for finding gtest and gmock
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(gtest-sample sample.cpp)
+target_include_directories(gtest-sample PRIVATE src)
+target_link_libraries(gtest-sample GTest::gtest GTest::gtest_main)
+```

--- a/googletest/plan.sh
+++ b/googletest/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=googletest
 pkg_origin=core
-pkg_version="1.8.0"
+pkg_version="1.8.1"
 pkg_description="$(cat << EOF
 Google C++ Testing Framework helps you write better C++ tests.
 EOF
@@ -8,7 +8,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd-3-clause')
 pkg_source="https://github.com/google/${pkg_name}/archive/release-${pkg_version}.tar.gz"
-pkg_shasum="58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8"
+pkg_shasum="9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
 pkg_upstream_url="https://github.com/google/googletest"
 pkg_dirname="${pkg_name}-release-${pkg_version}"
 
@@ -20,52 +20,45 @@ pkg_build_deps=(
   core/cmake
   core/gcc
   core/make
+  core/python2
 )
 
 pkg_include_dirs=(include)
-pkg_lib_dirs=(lib)
-pkg_pconfig_dirs=(lib/pkgconfig)
+pkg_lib_dirs=(lib64)
+pkg_pconfig_dirs=(lib64/pkgconfig)
 
-BUILDDIR="build"
+do_setup_environment() {
+  set_buildtime_env BUILD_DIR "build"
+}
 
 do_prepare() {
-  export GTEST_TARGET="${pkg_name}"
-  build_line "Plan Setting GTEST_TARGET=${GTEST_TARGET}"
+  mkdir -p "${BUILD_DIR}"
 
-  mkdir "${BUILDDIR}" || true
-  mkdir "${BUILDDIR}/${GTEST_TARGET}" || true
+  # patch version as it is suppose to be 1.8.1
+  sed -e "s/GOOGLETEST_VERSION 1.9.0/GOOGLETEST_VERSION ${pkg_version}/" -i CMakeLists.txt
 }
 
 do_build() {
-  cd "${BUILDDIR}/${GTEST_TARGET}" || exit
+  pushd "${BUILD_DIR}" || exit 1
   cmake -Dgtest_build_samples="${DO_CHECK}" \
-      -Dgmock_build_samples="${DO_CHECK}" \
       -Dgtest_build_tests="${DO_CHECK}" \
       -Dgmock_build_tests="${DO_CHECK}" \
       -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-      "../../${GTEST_TARGET}"
+      ..
   make
+  popd || exit 1
 }
 
 do_check() {
-  cd "${BUILDDIR}/${GTEST_TARGET}" || exit
+  pushd "${BUILD_DIR}" || exit 1
   CTEST_OUTPUT_ON_FAILURE=1 make test
+  popd || exit 1
 }
 
 do_install() {
-  cd "${BUILDDIR}/${GTEST_TARGET}" || exit
+  pushd "${BUILD_DIR}" || exit 1
   make install
-  cd ../.. || exit
+  popd || exit 1
 
-  install -Dm644 googletest/m4/gtest.m4 "${pkg_prefix}/share/aclocal"
-  install -Dm644 googletest/LICENSE "${pkg_prefix}/share/licenses/license.txt"
-
-  mkdir -p "${pkg_prefix}/lib/pkgconfig"
-  cat <<EOF > "${pkg_prefix}/lib/pkgconfig/libgtest.pc"
-Name: libgtest
-Description: ${pkg_description}
-Version: ${pkg_version}
-Cflags: -I${pkg_prefix}/include/gtest
-Libs: -L${pkg_prefix}/lib -lgtest -lgtest_main
-EOF
+  install -Dm644 LICENSE "${pkg_prefix}/share/licenses/license.txt"
 }


### PR DESCRIPTION
This PR has the following:

- bumps googletest to 1.8.1.
- deprecates googlemock since the project has move forward to fold both googlemock and googletest into one.
- update `README.md` to include an example for CMake users.

## Testing

This plan includes the tests inside the `do_check()`.

```bash
DO_CHECK=1 build googletest
```

### Expectation

```bash
...
   googletest: Running post-compile tests
/hab/cache/src/googletest-release-1.8.1/build /hab/cache/src/googletest-release-1.8.1 /hab/cache/src /src/core-plans/googletest
Running tests...
Test project /hab/cache/src/googletest-release-1.8.1/build
      Start  1: gmock-actions_test
 1/61 Test  #1: gmock-actions_test ......................   Passed    0.01 sec
      Start  2: gmock-cardinalities_test
 2/61 Test  #2: gmock-cardinalities_test ................   Passed    0.01 sec
      Start  3: gmock_ex_test
 3/61 Test  #3: gmock_ex_test ...........................   Passed    0.00 sec
      Start  4: gmock-generated-actions_test
 4/61 Test  #4: gmock-generated-actions_test ............   Passed    0.01 sec
      Start  5: gmock-generated-function-mockers_test
 5/61 Test  #5: gmock-generated-function-mockers_test ...   Passed    0.00 sec
      Start  6: gmock-generated-internal-utils_test
 6/61 Test  #6: gmock-generated-internal-utils_test .....   Passed    0.00 sec
      Start  7: gmock-generated-matchers_test
 7/61 Test  #7: gmock-generated-matchers_test ...........   Passed    0.01 sec
      Start  8: gmock-internal-utils_test
 8/61 Test  #8: gmock-internal-utils_test ...............   Passed    0.01 sec
      Start  9: gmock-matchers_test
 9/61 Test  #9: gmock-matchers_test .....................   Passed    1.23 sec
      Start 10: gmock-more-actions_test
...
56/61 Test #56: googletest-throw-on-failure-test ........   Passed    0.05 sec
      Start 57: googletest-uninitialized-test
57/61 Test #57: googletest-uninitialized-test ...........   Passed    0.03 sec
      Start 58: gtest_xml_outfiles_test
58/61 Test #58: gtest_xml_outfiles_test .................   Passed    0.06 sec
      Start 59: googletest-json-outfiles-test
59/61 Test #59: googletest-json-outfiles-test ...........   Passed    0.04 sec
      Start 60: gtest_xml_output_unittest
60/61 Test #60: gtest_xml_output_unittest ...............   Passed    0.08 sec
      Start 61: googletest-json-output-unittest
61/61 Test #61: googletest-json-output-unittest .........   Passed    0.06 sec

100% tests passed, 0 tests failed out of 61

Total Test time (real) =   5.63 sec
/hab/cache/src/googletest-release-1.8.1 /hab/cache/src /src/core-plans/googletest
...
```

Signed-off-by: Ben Dang <me@bdang.it>