### PR TITLE
[postgresql] Only chown data directories we create

### DIFF
--- a/postgresql/config/functions.sh
+++ b/postgresql/config/functions.sh
@@ -67,7 +67,7 @@ bootstrap_replica_via_pg_basebackup() {
 }
 
 ensure_dir_ownership() {
-  paths="{{pkg.svc_var_path}} {{pkg.svc_data_path}}"
+  paths="{{pkg.svc_var_path}} {{pkg.svc_data_path}}/pgdata {{pkg.svc_data_path}}/archive"
   if [[ $EUID -eq 0 ]]; then
     # if EUID is root, so we should chown to pkg_svc_user:pkg_svc_group
     ownership_command="chown -RL {{pkg.svc_user}}:{{pkg.svc_group}} $paths"

--- a/postgresql93/plan.sh
+++ b/postgresql93/plan.sh
@@ -1,5 +1,6 @@
 # shellcheck disable=SC2148,SC1091
-source ../postgresql/plan.sh
+PLANDIR=$(dirname "${BASH_SOURCE[0]}")
+source "${PLANDIR}/../postgresql/plan.sh"
 
 pkg_name=postgresql93
 pkg_version=9.3.23

--- a/postgresql94/config/functions.sh
+++ b/postgresql94/config/functions.sh
@@ -67,7 +67,7 @@ bootstrap_replica_via_pg_basebackup() {
 }
 
 ensure_dir_ownership() {
-  paths="{{pkg.svc_var_path}} {{pkg.svc_data_path}}"
+  paths="{{pkg.svc_var_path}} {{pkg.svc_data_path}}/pgdata {{pkg.svc_data_path}}/archive"
   if [[ $EUID -eq 0 ]]; then
     # if EUID is root, so we should chown to pkg_svc_user:pkg_svc_group
     ownership_command="chown -RL {{pkg.svc_user}}:{{pkg.svc_group}} $paths"

--- a/postgresql94/plan.sh
+++ b/postgresql94/plan.sh
@@ -1,5 +1,6 @@
 # shellcheck disable=SC2148,SC1091
-source ../postgresql/plan.sh
+PLANDIR=$(dirname "${BASH_SOURCE[0]}")
+source "${PLANDIR}/../postgresql/plan.sh"
 
 pkg_name=postgresql94
 pkg_version=9.4.18

--- a/postgresql94/tests/extra_data_files.bats
+++ b/postgresql94/tests/extra_data_files.bats
@@ -1,0 +1,29 @@
+NONHAB_FILE="/hab/svc/postgresql94/data/lost+found"
+
+function setup() {
+  touch "${NONHAB_FILE}"
+  chown root:root "${NONHAB_FILE}"
+  chmod 600 "${NONHAB_FILE}"
+}
+
+function teardown() {
+    rm -f ${NONHAB_FILE}
+}
+
+@test "Non-hab owned files in /data are allowed" {
+  ORIGIN=$(hab svc status |grep postgresql94| cut -f1 -d'/')
+  hab svc stop "${ORIGIN}/postgresql94"
+
+  hab svc start "${ORIGIN}/postgresql94"
+
+  # Wait for service to start
+  sleep 1
+
+  # We still have a non-hab owned file in data/
+  [ -f "${NONHAB_FILE}" ]
+  [ "root" == $(stat -c %U "${NONHAB_FILE}") ]
+  [ "root" == $(stat -c %G "${NONHAB_FILE}") ]
+  [ "-rw-------" == $(stat -c %A "${NONHAB_FILE}") ]
+
+  [ "$(hab svc status | grep "postgresql94.default" | awk '{print $4}' | grep up)" ]
+}

--- a/postgresql94/tests/test.bats
+++ b/postgresql94/tests/test.bats
@@ -1,0 +1,25 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v postgres)" ]
+}
+
+@test "Version matches, via --version" {
+  run postgres --version
+  [ "$status" -eq 0 ]
+  version="$(echo "${lines}" | cut -f3 -d' ')"
+  [ "${version}" == "${pkg_version}" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "postgresql94\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep "postgres -c config" | wc -l)"
+  [ "${result}" -eq 1 ]
+}
+
+@test "Listening on port 5432" {
+  [ "$(netstat -peanut | grep postgres | awk '{print $4}' | awk -F':' '{print $2}' | grep 5432)" ]
+}

--- a/postgresql94/tests/test.sh
+++ b/postgresql94/tests/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+set -x
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 5
+fi
+
+bats "${TESTDIR}"

--- a/postgresql95/plan.sh
+++ b/postgresql95/plan.sh
@@ -1,5 +1,6 @@
 # shellcheck disable=SC2148,SC1091
-source ../postgresql/plan.sh
+PLANDIR=$(dirname "${BASH_SOURCE[0]}")
+source "${PLANDIR}/../postgresql/plan.sh"
 
 pkg_name=postgresql95
 pkg_version=9.5.13

--- a/postgresql96/plan.sh
+++ b/postgresql96/plan.sh
@@ -1,5 +1,6 @@
 # shellcheck disable=SC2148,SC1091
-source ../postgresql/plan.sh
+PLANDIR=$(dirname "${BASH_SOURCE[0]}")
+source "${PLANDIR}/../postgresql/plan.sh"
 
 pkg_name=postgresql96
 pkg_version=9.6.9

--- a/postgresql96/tests/extra_data_files.bats
+++ b/postgresql96/tests/extra_data_files.bats
@@ -1,4 +1,6 @@
-NONHAB_FILE="/hab/svc/postgresql96/data/lost+found"
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+NONHAB_FILE="/hab/svc/${pkg_name}/data/lost+found"
 
 function setup() {
   touch "${NONHAB_FILE}"
@@ -11,10 +13,10 @@ function teardown() {
 }
 
 @test "Non-hab owned files in /data are allowed" {
-  ORIGIN=$(hab svc status |grep postgresql96| cut -f1 -d'/')
-  hab svc stop "${ORIGIN}/postgresql96"
+  ORIGIN=$(hab svc status |grep ${pkg_name}| cut -f1 -d'/')
+  hab svc stop "${ORIGIN}/${pkg_name}"
 
-  hab svc start "${ORIGIN}/postgresql96"
+  hab svc start "${ORIGIN}/${pkg_name}"
 
   # Wait for service to start
   sleep 1
@@ -25,5 +27,5 @@ function teardown() {
   [ "root" == $(stat -c %G "${NONHAB_FILE}") ]
   [ "-rw-------" == $(stat -c %A "${NONHAB_FILE}") ]
 
-  [ "$(hab svc status | grep "postgresql96.default" | awk '{print $4}' | grep up)" ]
+  [ "$(hab svc status | grep "${pkg_name}.default" | awk '{print $4}' | grep up)" ]
 }

--- a/postgresql96/tests/extra_data_files.bats
+++ b/postgresql96/tests/extra_data_files.bats
@@ -1,0 +1,29 @@
+NONHAB_FILE="/hab/svc/postgresql96/data/lost+found"
+
+function setup() {
+  touch "${NONHAB_FILE}"
+  chown root:root "${NONHAB_FILE}"
+  chmod 600 "${NONHAB_FILE}"
+}
+
+function teardown() {
+    rm -f ${NONHAB_FILE}
+}
+
+@test "Non-hab owned files in /data are allowed" {
+  ORIGIN=$(hab svc status |grep postgresql96| cut -f1 -d'/')
+  hab svc stop "${ORIGIN}/postgresql96"
+
+  hab svc start "${ORIGIN}/postgresql96"
+
+  # Wait for service to start
+  sleep 1
+
+  # We still have a non-hab owned file in data/
+  [ -f "${NONHAB_FILE}" ]
+  [ "root" == $(stat -c %U "${NONHAB_FILE}") ]
+  [ "root" == $(stat -c %G "${NONHAB_FILE}") ]
+  [ "-rw-------" == $(stat -c %A "${NONHAB_FILE}") ]
+
+  [ "$(hab svc status | grep "postgresql96.default" | awk '{print $4}' | grep up)" ]
+}

--- a/postgresql96/tests/test.bats
+++ b/postgresql96/tests/test.bats
@@ -12,7 +12,7 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 }
 
 @test "Service is running" {
-  [ "$(hab svc status | grep "postgresql96\.default" | awk '{print $4}' | grep up)" ]
+  [ "$(hab svc status | grep "${pkg_name}\.default" | awk '{print $4}' | grep up)" ]
 }
 
 @test "A single process" {

--- a/postgresql96/tests/test.bats
+++ b/postgresql96/tests/test.bats
@@ -1,0 +1,25 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v postgres)" ]
+}
+
+@test "Version matches, via --version" {
+  run postgres --version
+  [ "$status" -eq 0 ]
+  version="$(echo "${lines}" | cut -f3 -d' ')"
+  [ "${version}" == "${pkg_version}" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "postgresql96\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep "postgres -c config" | wc -l)"
+  [ "${result}" -eq 1 ]
+}
+
+@test "Listening on port 5432" {
+  [ "$(netstat -peanut | grep postgres | awk '{print $4}' | awk -F':' '{print $2}' | grep 5432)" ]
+}

--- a/postgresql96/tests/test.sh
+++ b/postgresql96/tests/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+set -x
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 5
+fi
+
+bats "${TESTDIR}"


### PR DESCRIPTION
If you mount the data volume for postgres (e.g. via k8s) there will be
the usual `lost+found` directory owned by root.  We were trying to chown
it, failing and then postgres wouldn't start.

This PR changes the permissions setting logic in the init hook to only
cheange the permissions on the 2 data directories we create (`pgdata`
and `archive`)

Testing
```
hab studio enter
cd postgresql96
./tests/tests.sh
```
Exact same process works for `postgresql94` too.

Sample output
```
 ✓ Non-hab owned files in /data are allowed
 ✓ Command is on path
 ✓ Version matches, via --version
 ✓ Service is running
 ✓ A single process
 ✓ Listening on port 5432

6 tests, 0 failures
```

Signed-off-by: James Casey <james@chef.io>