### PR TITLE
[packer] Update packer to 1.3.0

### DIFF
--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.2.5
+pkg_version=1.3.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="bc58aa3f3db380b76776e35f69662b49f3cf15cf80420fc81a15ce971430824c"
+pkg_shasum="0512af351124e63f8079458391e7f7b316e4b3ac4dc40e6f18058fd924f1b24a"
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build packer
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
packer --version
```

### Sample output

```
1.3.0
```