### PR TITLE
[kubernetes-apiserver] Add config flags for requestheaders

### DIFF
--- a/kubernetes-apiserver/default.toml
+++ b/kubernetes-apiserver/default.toml
@@ -12,6 +12,10 @@ kubelet-certificate-authority = ""
 kubelet-client-certificate = ""
 kubelet-client-key = ""
 
+requestheader-client-ca-file = ""
+requestheader-group-headers = ""
+requestheader-username-headers = ""
+
 service-account-key-file = ""
 service-cluster-ip-range = "10.32.0.0/24"
 service-node-port-range = "30000-32767"

--- a/kubernetes-apiserver/hooks/run
+++ b/kubernetes-apiserver/hooks/run
@@ -31,6 +31,9 @@ exec kube-apiserver \
   --kubelet-client-certificate="{{cfg.kubelet-client-certificate}}" \
   --kubelet-client-key="{{cfg.kubelet-client-key}}" \
   --kubelet-https=true \
+  --requestheader-client-ca-file="{{cfg.requestheader-client-ca-file}}" \
+  --requestheader-group-headers="{{cfg.requestheader-group-headers}}" \
+  --requestheader-username-headers="{{cfg.requestheader-username-headers}}" \
   --runtime-config=api/all \
   --service-account-key-file="{{cfg.service-account-key-file}}" \
   --service-cluster-ip-range="{{cfg.service-cluster-ip-range}}" \


### PR DESCRIPTION
# Testing:

**Prerequisites**

* Linux or MacOS on the host (Windows is not supported)
* [Vagrant](https://www.vagrantup.com/downloads.html)
* [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
* [cfssl](https://github.com/cloudflare/cfssl#installation) (with cfssljson)
* [jq](https://stedolan.github.io/jq/download/) Command-line JSON processor

**Steps**

```
$ git clone https://github.com/kinvolk/kubernetes-the-hab-way.git
$ git checkout origin/indradhanush/configure-requestheader-client
```

This branch has the necessary changes required that uses the config flags added in this PR. To test the changes I had build the package and uploaded under my personal origin at: `indradhanush/kubernetes-apiserver`. As a result, it uses this package instead of the `core/kubernetes-apiserver` package at the moment.

If you'd like to test with another origin, please run the following command from the project root:

```
$ sed -i 's|indradhanush|<your-origin-here>|g' scripts/setup
```

Which should produce the following diff if the origin is `core` for example:

```
diff --git a/scripts/setup b/scripts/setup
index 232ccc3..32c391a 100755
--- a/scripts/setup
+++ b/scripts/setup
@@ -42,7 +42,7 @@ vagrant ssh node-0 -- sudo mkdir -p /var/run/kubernetes
 vagrant ssh node-0 -- sudo chown hab:hab /var/run/kubernetes
 
 # set up kube-apiserver
-vagrant ssh node-0 -- sudo hab svc load indradhanush/kubernetes-apiserver --channel "${channel}"
+vagrant ssh node-0 -- sudo hab svc load core/kubernetes-apiserver --channel "${channel}"
```


Now set up the cluster and wait for the script to complete:

```
$ ./scripts/setup
```

**Verify that the configuration related to requestheaders was applied:**

```
$ vagrant ssh node-0
$ sudo su -
```

Your package name may have a different `origin`. Modify it accordingly in the following commands:

```
# hab svc stop indradhanush/kubernetes-apiserver
# hab svc start indradhanush/kubernetes-apiserver
# journalctl -xef | grep requestheader
```

And the output shows the configuration flags being used by the `kubernetes-apiserver`:

```
Sep 14 14:09:06 node-0 hab[4507]: kubernetes-apiserver.default(O): I0914 14:09:06.643838   13347 flags.go:27] FLAG: --requestheader-allowed-names="[]"
Sep 14 14:09:06 node-0 hab[4507]: kubernetes-apiserver.default(O): I0914 14:09:06.643846   13347 flags.go:27] FLAG: --requestheader-client-ca-file="files/requestheader-ca.pem"
Sep 14 14:09:06 node-0 hab[4507]: kubernetes-apiserver.default(O): I0914 14:09:06.643852   13347 flags.go:27] FLAG: --requestheader-extra-headers-prefix="[]"
Sep 14 14:09:06 node-0 hab[4507]: kubernetes-apiserver.default(O): I0914 14:09:06.643859   13347 flags.go:27] FLAG: --requestheader-group-headers="[X-Remote-Group]"
Sep 14 14:09:06 node-0 hab[4507]: kubernetes-apiserver.default(O): I0914 14:09:06.643867   13347 flags.go:27] FLAG: --requestheader-username-headers="[X-Remote-User]"
```

Get out of the vagrant box and return to the host machine and for additional e2e testing continue.

**Verify the 3 nodes are up and ready:**

$ kubectl get nodes
Output should look like this:

NAME      STATUS    ROLES     AGE       VERSION
node-0    Ready     <none>    23m       v1.8.2
node-1    Ready     <none>    23m       v1.8.2
node-2    Ready     <none>    23m       v1.8.2

Test the setup by creating a Nginx deployment, expose it and send a request to the service IP:

**On Linux**
```
$ sudo route add -net 10.32.0.0/24 gw 192.168.222.10
```

**On macOS**
```
$ sudo route -n add -net 10.32.0.0/24 192.168.222.10
```

**Run the smoke test**
```
$ ./scripts/smoke-test
```

**Clean up**
```
$ vagrant destroy -f 
```

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>