### PR TITLE
[libsasl2] New plan for libsasl2

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -629,6 +629,8 @@ plan_path = "libressl-musl"
 paths = [
   "libressl/*",
 ]
+[libsasl2]
+plan_path = "libsasl2"
 [libscrypt]
 plan_path = "libscrypt"
 [libseccomp]

--- a/libsasl2/README.md
+++ b/libsasl2/README.md
@@ -1,0 +1,9 @@
+# Habitat package: libsasl
+
+## Description
+
+Provide a brief description of the `libsasl` plan / purpose.
+
+## Usage
+
+Describe the general usage for the `libsasl` plan

--- a/libsasl2/README.md
+++ b/libsasl2/README.md
@@ -1,9 +1,21 @@
-# Habitat package: libsasl
+# libsasl2
 
-## Description
+Simple Authentication and Security Layer library.
 
-Provide a brief description of the `libsasl` plan / purpose.
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
 
 ## Usage
 
-Describe the general usage for the `libsasl` plan
+Include this package as a build or runtime dependency as required:
+
+```
+pkg_deps=(
+  core/libsasl2
+)
+```

--- a/libsasl2/plan.sh
+++ b/libsasl2/plan.sh
@@ -1,0 +1,17 @@
+pkg_name=libsasl2
+pkg_distname=cyrus-sasl
+pkg_origin=core
+pkg_version="2.1.26"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_source="ftp://ftp.cyrusimap.org/cyrus-sasl/${pkg_distname}-${pkg_version}.tar.gz"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_shasum="8fbc5136512b59bb793657f36fadda6359cae3b08f01fd16b3d406f1345b7bc3"
+pkg_deps=(core/glibc core/openssl)
+pkg_build_deps=(core/make core/gcc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+pkg_description="Simple Authentication and Security Layer library."
+pkg_upstream_url="https://www.cyrusimap.org/sasl/index.html"
+

--- a/libsasl2/plan.sh
+++ b/libsasl2/plan.sh
@@ -14,4 +14,3 @@ pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 pkg_description="Simple Authentication and Security Layer library."
 pkg_upstream_url="https://www.cyrusimap.org/sasl/index.html"
-

--- a/libsasl2/plan.sh
+++ b/libsasl2/plan.sh
@@ -3,14 +3,20 @@ pkg_distname=cyrus-sasl
 pkg_origin=core
 pkg_version="2.1.26"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=("Apache-2.0")
+pkg_license=("custom")
 pkg_source="ftp://ftp.cyrusimap.org/cyrus-sasl/${pkg_distname}-${pkg_version}.tar.gz"
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_shasum="8fbc5136512b59bb793657f36fadda6359cae3b08f01fd16b3d406f1345b7bc3"
 pkg_deps=(core/glibc core/openssl)
 pkg_build_deps=(core/make core/gcc)
 pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
 pkg_include_dirs=(include)
-pkg_bin_dirs=(bin)
+pkg_bin_dirs=(sbin)
 pkg_description="Simple Authentication and Security Layer library."
 pkg_upstream_url="https://www.cyrusimap.org/sasl/index.html"
+
+do_install() {
+  do_default_install
+  install -Dm644 COPYING "${pkgdir}/share/COPYING"
+}


### PR DESCRIPTION
Refs #1808

Testing is tricky, as its a library.

### Testing

```
hab studio enter
build libsasl2
source results/last_build.env
hab pkg install results/${pkg_artifact}
```

Confirm that the libraries are available:

```
ls -la /hab/pkgs/${pkg_ident}/lib/
```

### Sample output

```
-rwxr-xr-x 1 root root    833 Sep 14 00:22 libsasl2.la
lrwxrwxrwx 1 root root     17 Sep 14 00:22 libsasl2.so -> libsasl2.so.3.0.0
lrwxrwxrwx 1 root root     17 Sep 14 00:22 libsasl2.so.3 -> libsasl2.so.3.0.0
-rwxr-xr-x 1 root root 139248 Sep 14 00:22 libsasl2.so.3.0.0
drwxr-xr-x 2 root root   4096 Sep 14 00:22 pkgconfig
drwxr-xr-x 2 root root   4096 Sep 14 00:22 sasl2
```