### PR TITLE
[memcached] Added SASL support to memcached, and added tests

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -7,8 +7,16 @@ pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=494c060dbd96d546c74ab85a3cc3984d009b4423767ac33e05dd2340c01f1c4b
-pkg_deps=(core/glibc core/libevent)
-pkg_build_deps=(core/git core/gcc core/make)
+pkg_deps=(
+  core/glibc
+  core/libevent
+  core/libsasl2
+)
+pkg_build_deps=(
+  core/git
+  core/gcc
+  core/make
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -17,3 +25,10 @@ pkg_exports=(
   [port]=port
 )
 pkg_exposes=(port)
+
+do_build() {
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --enable-sasl
+  make
+}

--- a/memcached/tests/test.bats
+++ b/memcached/tests/test.bats
@@ -1,0 +1,29 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v memcached)" ]
+}
+
+@test "Version matches" {
+  result="$(memcached --version 2>&1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run memcached --help
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "memcached\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 11211" {
+  result="$(netstat -peanut | grep memcached | head -1 | awk '{print $4}' | awk -F':' '{print $2}')"
+  [ "${result}" -eq 11211 ]
+}
+
+@test "Contains SASL support" {
+  memcached --help | grep "enable-sasl"
+  [ $? -eq 0 ]
+}

--- a/memcached/tests/test.sh
+++ b/memcached/tests/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+hab pkg binlink core/busybox-static uniq
+
+source "${PLANDIR}/plan.sh"
+# Unload the service if its already loaded.
+hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 3
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
![tenor-178325740](https://user-images.githubusercontent.com/24568/45525248-233bb000-b80d-11e8-8ec2-30f908ff4e51.gif)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #1808 

**Note:** This PR requires that #1849 is merged, built and promoted first.

### Testing

```
hab studio enter
./memcached/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

6 tests, 0 failures
```