### PR TITLE
[packer] Upgrade packer to 1.3.1, add simple test

### DIFF
--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.3.0
+pkg_version=1.3.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="0512af351124e63f8079458391e7f7b316e4b3ac4dc40e6f18058fd924f1b24a"
+pkg_shasum="254cf648a638f7ebd37dc1b334abe940da30b30ac3465b6e0a9ad59829932fa3"
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)

--- a/packer/tests/test.bats
+++ b/packer/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(packer version | head -1 | awk '{print $2}')"
+  [ "$result" = "v${pkg_version}" ]
+}

--- a/packer/tests/test.sh
+++ b/packer/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./packer/tests/test.sh
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```