### PR TITLE
[gocd-server] Upgrade gocd to 18.9.0

### DIFF
--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=gocd-server
 pkg_origin=core
-pkg_version="18.6.0"
-pkg_buildnumber="6883"
+pkg_version="18.9.0"
+pkg_buildnumber="7478"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://download.gocd.org/binaries/${pkg_version}-${pkg_buildnumber}/generic/go-server-${pkg_version}-${pkg_buildnumber}.zip"
-pkg_shasum="70aaba161e26ee1cef43740626a92aa39a70cf6bf81ae373102edddf157baae3"
+pkg_shasum="6a9de3f9a5a726d19946e1154d326c625c51ab371fcce5427a5819cfe9f143b2"
 pkg_description="GoCD is an open source tool which is used in software development to help teams and organizations automate the continuous delivery (CD) of software."
 pkg_upstream_url="https://www.gocd.org"
 pkg_filename="go-server-${pkg_version}-${pkg_buildnumber}.zip"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing from #1671 are the same:

```
# Run studio (with port forwarding)
HAB_DOCKER_OPTS="-p 8153:8153" hab studio enter

# Build / Run service
build gocd-server; source results/last_build.env; hab pkg install results/${pkg_artifact}; hab svc load ${pkg_ident}

# Wait about 60 seconds for startup to complete.

# Convenience
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat
hab pkg binlink core/busybox-static nc

# Confirm port open
netstat -peanut

# Confirm exit code is 0
nc -z localhost:8153
```