### PR TITLE
[yarn] Update yarn to 1.9.4, add tests

### DIFF
--- a/yarn/plan.sh
+++ b/yarn/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=yarn
 pkg_origin=core
-pkg_version=1.7.0
+pkg_version=1.9.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don’t ever have to worry."
 pkg_upstream_url=https://yarnpkg.com/
 pkg_license=('BSD-2-Clause')
-pkg_source="https://yarnpkg.com/downloads/$pkg_version/yarn-v$pkg_version.tar.gz"
-pkg_shasum=e7720ee346b2bd7ec32b7e04517643c38648f5022c7981168321ba1636f2dca3
+pkg_source="https://yarnpkg.com/downloads/${pkg_version}/yarn-v${pkg_version}.tar.gz"
+pkg_shasum=7667eb715077b4bad8e2a832e7084e0e6f1ba54d7280dc573c8f7031a7fb093e
 pkg_bin_dirs=(bin)
 pkg_build_deps=()
 pkg_deps=(
@@ -17,10 +17,9 @@ pkg_deps=(
 
 # Yarn unpacks into dist, so fix that
 do_unpack() {
-  build_line "Unpacking $pkg_filename"
-  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
-    mkdir -pv "$pkg_dirname"
-    tar --strip-components=1 --directory="$pkg_dirname" -xf "$pkg_filename"
+  pushd "${HAB_CACHE_SRC_PATH}" > /dev/null
+    mkdir -pv "${pkg_dirname}"
+    tar --strip-components=1 --directory="${pkg_dirname}" -xf "${pkg_filename}"
   popd > /dev/null
 }
 
@@ -30,11 +29,11 @@ do_build() {
 
 do_install() {
   find bin -type f | while read -r f; do
-    install -D -m 0755 "$f" "$pkg_prefix/$f"
+    install -D -m 0755 "${f}" "${pkg_prefix}/${f}"
   done
-  rm -rf "$pkg_prefix/bin"/*.cmd
+  rm -rf "${pkg_prefix}/bin"/*.cmd
 
   find lib LICENSE package.json -type f | while read -r f; do
-    install -D -m 0644 "$f" "$pkg_prefix/$f"
+    install -D -m 0644 "${f}" "${pkg_prefix}/${f}"
   done
 }

--- a/yarn/tests/test.bats
+++ b/yarn/tests/test.bats
@@ -1,0 +1,11 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(yarn --version)"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run yarn --Help
+  [ "$status" -eq 0 ]
+}

--- a/yarn/tests/test.sh
+++ b/yarn/tests/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab pkg install --binlink --force core/node
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-194325073](https://user-images.githubusercontent.com/24568/45724782-a8024180-bbf2-11e8-801c-357aa5c7a4da.gif)

### Testing

```
hab studio enter
./yarn/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```