### PR TITLE
[dsc-core] wait for LCM before changing LCM refresh state

### DIFF
--- a/dsc-core/DSCCore.psm1
+++ b/dsc-core/DSCCore.psm1
@@ -41,9 +41,9 @@ function Start-DscCore {
             $conf = Get-LcmMetaConfig
             $currentRefreshMode = $conf.RefreshMode
             try {
-                Set-LcmRefreshMode "Push"
                 # Now that we have the lock, check once more just in case
                 Wait-LCMReady
+                Set-LcmRefreshMode "Push"
                 Write-Output "Applying DSC configuration for $Path ..."
                 Invoke-CimMethod    -ComputerName localhost `
                                     -Namespace "root/Microsoft/Windows/DesiredStateConfiguration" `
@@ -53,6 +53,7 @@ function Start-DscCore {
                                     -ErrorAction Stop | Out-Null
             }
             finally {
+                Wait-LCMReady
                 Set-LcmRefreshMode $currentRefreshMode
             }
         }

--- a/dsc-core/plan.ps1
+++ b/dsc-core/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="dsc-core"
 $pkg_origin="core"
-$pkg_version="0.2.0"
+$pkg_version="0.2.1"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Apache-2.0")
 $pkg_description="Compiles and applies DSC configurations in Powershell Core"


### PR DESCRIPTION
If a DSC Apply fails, the reseting of the LCM refresh state may fail because the LCM is still busy. This adds a wait for it to be available before changing its refresh state. Validated this with user.

Signed-off-by: mwrock <matt@mattwrock.com>