### PR TITLE
[concourse] Rolled concourse and fly forward to 4.2.1

### DIFF
--- a/concourse-fly/plan.sh
+++ b/concourse-fly/plan.sh
@@ -7,6 +7,9 @@ pkg_description="Concourse CLI for interacting with the ATC API"
 pkg_upstream_url="https://concourse.ci"
 pkg_source="https://github.com/concourse/concourse.git"
 
+pkg_deps=(
+  core/glibc
+)
 pkg_build_deps=(
   core/cacerts
   core/gnupg
@@ -21,9 +24,10 @@ do_download() {
 
   REPO_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
   rm -rf "$REPO_PATH"
-  git clone --recursive "$pkg_source" "$REPO_PATH"
+  git clone "$pkg_source" "$REPO_PATH"
   pushd "$REPO_PATH" || return 1
-    git checkout "tags/v${pkg_version}"
+  git checkout "tags/v${pkg_version}"
+  git submodule update --init --recursive
   popd || return 1
 }
 

--- a/concourse-fly/plan.sh
+++ b/concourse-fly/plan.sh
@@ -1,13 +1,18 @@
 pkg_name=concourse-fly
 pkg_origin=core
-pkg_version="3.13.0"
+pkg_version="4.2.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_description="Concourse CLI for interacting with the ATC API"
 pkg_license=('Apache-2.0')
+pkg_description="Concourse CLI for interacting with the ATC API"
 pkg_upstream_url="https://concourse.ci"
-
 pkg_source="https://github.com/concourse/concourse.git"
-pkg_build_deps=("core/cacerts" "core/gnupg" "core/go" "core/git")
+
+pkg_build_deps=(
+  core/cacerts
+  core/gnupg
+  core/go
+  core/git
+)
 pkg_bin_dirs=(bin)
 
 do_download() {

--- a/concourse/plan.sh
+++ b/concourse/plan.sh
@@ -1,16 +1,21 @@
 pkg_name=concourse
 pkg_origin=core
-pkg_version="3.13.0"
+pkg_version="4.2.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}_linux_amd64"
-pkg_filename="${pkg_name}_linux_amd64"
-pkg_shasum="cd232c5dd7a47616f5c8037a90c7b945edae8c6588bf5df833dd632af08a1d4b"
-pkg_deps=(core/glibc)
-pkg_build_deps=(core/patchelf)
-pkg_bin_dirs=(bin)
 pkg_description="CI that scales with your project"
 pkg_upstream_url="https://concourse.ci"
+pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}_linux_amd64"
+pkg_filename="${pkg_name}_linux_amd64"
+pkg_shasum="e3cada9e536af9596cfb812dc4af37cbc9ff7e4ed6f3d3ee91a6b62a6356d02a"
+
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/patchelf
+)
+pkg_bin_dirs=(bin)
 
 do_unpack() {
   pushd "${HAB_CACHE_SRC_PATH}"


### PR DESCRIPTION
Rolled concourse and fly forward to 4.2.1
Converted deps to multi-line arrays
Added glibc as a dependency:
```
[17] concourse-fly(do_build)> ldd ./fly
        linux-vdso.so.1 (0x00007ffeeb3d9000)
        libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20180608041157/lib/libpthread.so.0 (0x00007fe943402000)
        libc.so.6 => /hab/pkgs/core/glibc/2.27/20180608041157/lib/libc.so.6 (0x00007fe94304e000)
        /hab/pkgs/core/glibc/2.27/20180608041157/lib/ld-linux-x86-64.so.2 => /hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007fe943620000)
```