### PR TITLE
[memcached] Change to use core/cyrus-sasl

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -9,8 +9,8 @@ pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=494c060dbd96d546c74ab85a3cc3984d009b4423767ac33e05dd2340c01f1c4b
 pkg_deps=(
   core/glibc
+  core/cyrus-sasl
   core/libevent
-  core/libsasl2
 )
 pkg_build_deps=(
   core/git


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

It turns out `core/cyrus-sasl` has existed for a while, and so I should not have created `core/libsasl2`. This commit changes the dependency. Following this merge, and promotion, all builds of memcached that use core/libsasl2 should be demoted from stable, and libsasl2 should be deprecated.

### Testing

```
hab studio enter
./memcached/tests/test.sh
```

### Sample output

```
The rakops/memcached/1.5.10/20180927000454 service was successfully loaded
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

6 tests, 0 failures
```

![tenor-210080820](https://user-images.githubusercontent.com/24568/46116007-d1475100-c234-11e8-946e-b043628d4a36.gif)
