### PR TITLE
[libsasl2] Deprecate libsasl2

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -629,8 +629,6 @@ plan_path = "libressl-musl"
 paths = [
   "libressl/*",
 ]
-[libsasl2]
-plan_path = "libsasl2"
 [libscrypt]
 plan_path = "libscrypt"
 [libseccomp]

--- a/libsasl2/README.md
+++ b/libsasl2/README.md
@@ -1,5 +1,7 @@
 # libsasl2
 
+**Deprecation Notice**: This plan has been deprecated in favor of `core/cyrus-sasl` which provides the same functionality. If you want libsasl2, you probably want cyrus-sasl.
+
 Simple Authentication and Security Layer library.
 
 ## Maintainers


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

`core/libsasl2` was added recently, however `core/cyrus-sasl` provides the same libraries, and has existed for some time. This deprecates libsasl2 in favor of cyrus-sasl.

Followup steps to perform post-merge (per [RFC](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0007-deprecating-packages.md)):

* Delist the package by setting to private
* Disconnect plan from builder

![tenor-175919748](https://user-images.githubusercontent.com/24568/46116284-4d8e6400-c236-11e8-9fc3-f2257a14b15a.gif)
