### PR TITLE
e.g. not i.e.

### DIFF
--- a/README_TEMPLATE_FOR_PLANS.md
+++ b/README_TEMPLATE_FOR_PLANS.md
@@ -10,9 +10,9 @@ Names of core plans maintainers (The Habitat Maintainers humans@habitat.sh is us
 
 This should state whether the package is a service package or a binary package.
 
-A service package is something that will be run by the Habitat supervisor (i.e. core/postgresql).  A service package must always have a run file or define pkg_svc_run in the plan.sh file.
+A service package is something that will be run by the Habitat supervisor (e.g. core/postgresql).  A service package must always have a run file or define pkg_svc_run in the plan.sh file.
 
-A binary package is something that packages up a standalone binary, something that does not need to run under the Habitat supervisor (i.e. core/dep). They are often used as dependencies of other packages. Binary packages do not have a run file and do not need to define pkg_svc_run in the plan.sh file.
+A binary package is something that packages up a standalone binary, something that does not need to run under the Habitat supervisor (e.g. core/dep). They are often used as dependencies of other packages. Binary packages do not have a run file and do not need to define pkg_svc_run in the plan.sh file.
 
 ## Usage
 


### PR DESCRIPTION
I think it should read "for example", not "that is".

Signed-off-by: David Somers-Harris <david@somers-harris.com>