### PR TITLE
[cuda-libs] new plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -146,6 +146,11 @@ plan_path = "cppunit"
 plan_path = "cpputest"
 [cuda]
 plan_path = "cuda"
+[cuda-libs]
+plan_path = "cuda-libs"
+paths = [
+  "cuda/*"
+]
 [curator]
 plan_path = "curator"
 [curator4]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -121,6 +121,8 @@ cerebro @predominant
 concourse @echohack
 concourse-fly @echohack
 consul @defilan
+cuda @bdangit
+cuda-libs @bdangit
 dep @afiune @nellshamrell
 dotnet-47-dev-pack @mwrock
 dotnet-core-lts @mwrock

--- a/cuda-libs/README.md
+++ b/cuda-libs/README.md
@@ -1,0 +1,17 @@
+# cuda-libs
+
+Runtime libraries shipped by [NVIDIA CUDA](https://developer.nvidia.com/cuda-zone)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+* Ben Dang: <me@bdang.it>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+This package just contains the runtime libraries.  If you need to compile any cuda code, you will
+need to use `core/cuda`.  Refer to [Usage](../cuda/README.md) in `core/cuda`.

--- a/cuda-libs/plan.sh
+++ b/cuda-libs/plan.sh
@@ -1,0 +1,127 @@
+source ../cuda/plan.sh
+
+pkg_name=cuda-libs
+pkg_origin=core
+pkg_description="Runtime libraries shipped by Nvidia CUDA"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('custom')
+pkg_upstream_url="https://developer.nvidia.com/cuda-zone"
+
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+pkg_build_deps=(
+  "core/cuda/$pkg_version"
+  core/patchelf
+)
+
+pkg_bin_dirs=()
+pkg_include_dirs=()
+pkg_lib_dirs=(
+  lib64
+  lib64/stubs
+  nvvm/lib64
+)
+
+do_install() {
+  CUDA_RUN_PATH="${pkg_prefix}/lib64:${pkg_prefix}/nvvm/lib64:$(pkg_path_for gcc-libs)/lib:$(pkg_path_for glibc)/lib"
+
+  _cuda_libs=(
+    libOpenCL
+    libcufftw
+    libnppc
+    libnppif
+    libnppitc
+    libnvrtc-builtins
+    libaccinj64
+    libcuinj64
+    libnppial
+    libnppig
+    libnpps
+    libnvrtc
+    libcublas
+    libcurand
+    libnppicc
+    libnppim
+    libnvToolsExt
+    libcudart
+    libcusolver
+    libnppicom
+    libnppist
+    libnvblas
+    libcufft
+    libcusparse
+    libnppidei
+    libnppisu
+    libnvgraph
+  )
+  for lib in "${_cuda_libs[@]}"; do
+    cp -av "$(pkg_path_for core/cuda)/lib64/${lib}".* "${pkg_prefix}/lib64/"
+    patchelf --set-rpath "${CUDA_RUN_PATH}" "${pkg_prefix}/lib64/${lib}.so"
+  done
+
+  _cuda_stubs_libs=(
+    libcublas
+    libcurand
+    libnppial
+    libnppif
+    libnppisu
+    libnvidia-ml
+    libcuda
+    libcusolver
+    libnppicc
+    libnppig
+    libnppitc
+    libnvrtc
+    libcufft
+    libcusparse
+    libnppicom
+    libnppim
+    libnpps
+    libcufftw
+    libnppc
+    libnppidei
+    libnppist
+    libnvgraph
+  )
+  for lib in "${_cuda_stubs_libs[@]}"; do
+    cp -av "$(pkg_path_for core/cuda)/lib64/stubs/${lib}".* "${pkg_prefix}/lib64/stubs/"
+    patchelf --set-rpath "${CUDA_RUN_PATH}" "${pkg_prefix}/lib64/stubs/${lib}.so"
+  done
+
+  cp -av "$(pkg_path_for core/cuda)/nvvm/lib64/libnvvm".* "${pkg_prefix}/nvvm/lib64/"
+  patchelf --set-rpath "${CUDA_RUN_PATH}" "${pkg_prefix}/nvvm/lib64/libnvvm.so"
+
+  # Install EULA
+  mkdir -p "${pkg_prefix}/share/licenses"
+  cp -av "$(pkg_path_for core/cuda)/share/licenses/EULA.pdf" "${pkg_prefix}/share/licenses/EULA.pdf"
+}
+
+# Turn the remaining default phases into no-ops
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_strip() {
+  return 0
+}
+
+# We will rely on tests from `cuda`, so skip them here
+unset -f do_check


### PR DESCRIPTION
Signed-off-by: Ben Dang <me@bdang.it>

This allows cuda apps just to package the runtime libs.

---
## Build

```
hab studio build
source results/last_build.env
hab pkg install "results/${pkg_artifact}"
```

## Test 1

1. Build this test `plan.sh`

```bash
pkg_origin=bdangit
pkg_name=cuda-samples
pkg_version='9.2'
pkg_description="$(cat << EOF
  Samples for CUDA Developers which demonstrates features in CUDA Toolkit
EOF
)"
pkg_source="https://github.com/NVIDIA/${pkg_name}/archive/v${pkg_version}.tar.gz"
pkg_license=('custom')
pkg_maintainer='Ben Dang <me@bdang.it>'
pkg_upstream_url="https://github.com/NVIDIA/cuda-samples"
pkg_shasum="4b172847196d5b2ab645625dd7953ddf5cffa04b2a3c45689d33ef92fc953d90"
pkg_deps=(
  core/cuda-libs
  core/gcc-libs
  core/glibc
)
pkg_build_deps=(
  core/cuda
  core/make
)

pkg_bin_dirs=(bin)

do_build() {
  export CUDA_PATH=$(pkg_path_for core/cuda)
  make
}

do_install() {
  cp -av bin/x86_64/linux/release/* "${pkg_prefix}/bin/"
}
```

2. Execute `deviceQuery`

> Note: this requires you to have a NVIDIA cuda capable graphics card and drivers installed.

```
cd $(hab pkg path ${pkg_ident})/bin
LD_LIBRARY_PATH=/usr/lib64 ./deviceQuery
```

### Expected 

```bash
$ cd $(hab pkg path bdangit/cuda-samples)/bin
$ LD_LIBRARY_PATH=/usr/lib64 ./deviceQuery
./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "GRID K520"
  CUDA Driver Version / Runtime Version          9.2 / 9.2
  CUDA Capability Major/Minor version number:    3.0
  Total amount of global memory:                 4037 MBytes (4233363456 bytes)
  ( 8) Multiprocessors, (192) CUDA Cores/MP:     1536 CUDA Cores
  GPU Max Clock rate:                            797 MHz (0.80 GHz)
  Memory Clock rate:                             2500 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 524288 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(65536), 2D=(65536, 65536), 3D=(4096, 4096, 4096)
  Maximum Layered 1D Texture Size, (num) layers  1D=(16384), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(16384, 16384), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  2048
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Compute Preemption:            No
  Supports Cooperative Kernel Launch:            No
  Supports MultiDevice Co-op Kernel Launch:      No
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 3
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 9.2, CUDA Runtime Version = 9.2, NumDevs = 1
Result = PASS
```
