### PR TITLE
[hugo] Add missing core/glibc to pkg_deps

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -8,6 +8,9 @@ pkg_build_deps=(
   core/dep
   core/mage
 )
+pkg_deps=(
+  core/glibc
+)
 pkg_bin_dirs=(bin)
 pkg_source="https://github.com/gohugoio/hugo"
 pkg_upstream_url="https://gohugo.io"


### PR DESCRIPTION
`core/glibc` is dynamically linked in the hugo binary and needs to be added to `pkg_deps`, otherwise you get the following error using it

```
$ hab pkg exec core/hugo hugo
✗✗✗
✗✗✗ No such file or directory (os error 2)
✗✗✗
```

hugo binary info

```
$ file $(hab pkg path core/hugo)/bin/hugo
/hab/pkgs/core/hugo/0.46/20180810030420/bin/hugo: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /hab/pkgs/core/glibc/2.27/20180608041157/lib/ld-linux-x86-64.so.2, stripped
```

Signed-off-by: Will Fisher <wfisher@chef.io>