### PR TITLE
[gifsicle] Upgrade gifsicle to 1.91, add tests

### DIFF
--- a/gifsicle/plan.sh
+++ b/gifsicle/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=gifsicle
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_origin=core
-pkg_version=1.88
+pkg_version=1.91
 pkg_license=('GPLv2')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://www.lcdf.org/gifsicle/gifsicle-${pkg_version}.tar.gz
-pkg_shasum=4585d2e683d7f68eb8fcb15504732d71d7ede48ab5963e61915201f9e68305be
+pkg_shasum=0a4ee602aa244cdcdd86a250a6b39c94d8343cf526b8fae862d8a0efc337a800
 pkg_bin_dirs=(bin)
 pkg_deps=(core/zlib core/glibc)
 pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc)

--- a/gifsicle/plan.sh
+++ b/gifsicle/plan.sh
@@ -9,3 +9,5 @@ pkg_shasum=0a4ee602aa244cdcdd86a250a6b39c94d8343cf526b8fae862d8a0efc337a800
 pkg_bin_dirs=(bin)
 pkg_deps=(core/zlib core/glibc)
 pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc)
+pkg_description="Gifsicle is a command-line tool for creating, editing, and getting information about GIF images and animations."
+pkg_upstream_url="https://www.lcdf.org/gifsicle/"

--- a/gifsicle/tests/test.bats
+++ b/gifsicle/tests/test.bats
@@ -1,0 +1,15 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v gifsicle)" ]
+}
+
+@test "Version matches" {
+  result="$(gifsicle --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run gifsicle --help
+  [ $status -eq 0 ]
+}

--- a/gifsicle/tests/test.sh
+++ b/gifsicle/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-95716780](https://user-images.githubusercontent.com/24568/46251769-c7715800-c497-11e8-90ae-b20f779e1d92.gif)

### Testing

```
hab studio enter
./gifsicle/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help Command Check

3 tests, 0 failures
```