### PR TITLE
[pngquant] Fix library deps, Upgrade to 2.12.0, add tests

### DIFF
--- a/pngquant/plan.sh
+++ b/pngquant/plan.sh
@@ -1,20 +1,20 @@
 pkg_name=pngquant
 pkg_origin=core
-pkg_version="2.11.7"
+pkg_version="2.12.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-only")
 pkg_source="https://github.com/kornelski/${pkg_name}/archive/${pkg_version}.tar.gz"
-pkg_shasum="0ca09a1f253b264e5aab8477b7f0e3cde51d9f88ed668b38ae057ced24076bda"
+pkg_shasum="53721387e1aa1729ccf20ff8faaf2587ebe4d03faaa0f6235a63070e08105967"
 pkg_deps=(
   core/coreutils
+  core/libpng
+  core/libimagequant
+  core/zlib
 )
 pkg_build_deps=(
   core/make
   core/gcc
-  core/libpng
-  core/zlib
   core/pkg-config
-  core/libimagequant
 )
 pkg_bin_dirs=(bin)
 pkg_description="Lossy PNG compressor"

--- a/pngquant/tests/test.bats
+++ b/pngquant/tests/test.bats
@@ -1,0 +1,15 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v pngquant)" ]
+}
+
+@test "Version matches" {
+  result="$(pngquant --version | head -1 | awk '{print $1}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run pngquant --help
+  [ $status -eq 0 ]
+}

--- a/pngquant/tests/test.sh
+++ b/pngquant/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-2728374](https://user-images.githubusercontent.com/24568/46251897-cb52a980-c49a-11e8-86c2-58452dfee6e3.gif)

### Testing

```
hab studio enter
./pngquant/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help Command Check

3 tests, 0 failures
```