### PR TITLE
[vault] Update vault to 0.11.2

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.11.1
+pkg_version=0.11.2
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=eb8d2461d0ca249c1f91005f878795998bdeafccfde0b9bae82343541ce65996
+pkg_shasum=0d1c12fb26fc755cc94188e88a5b882bfeb74f0232fc32c7cf7769a3f4be2053
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
![tenor-127071524](https://user-images.githubusercontent.com/24568/46384093-d0a83200-c6ee-11e8-80e1-c72d117044c2.gif)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./vault/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```