### PR TITLE
[rabbitmq] Fix log path issue and Elixir dependency, Add tests

### DIFF
--- a/rabbitmq/config/env
+++ b/rabbitmq/config/env
@@ -7,6 +7,7 @@ export RABBITMQ_ENABLED_PLUGINS_FILE="{{pkg.svc_var_path}}/enabled_plugins"
 export RABBITMQ_HOME="{{pkg.svc_var_path}}"
 export RABBITMQ_GENERATED_CONFIG_DIR="{{pkg.svc_var_path}}"
 export RABBITMQ_SCHEMA_DIR="{{pkg.svc_var_path}}"
+export RABBITMQ_LOG_BASE="{{pkg.svc_var_path}}/logs"
 export HOME="{{pkg.svc_var_path}}"
 export RABBITMQ_LOGS=-
 export RABBITMQ_SASL_LOGS=-

--- a/rabbitmq/hooks/init
+++ b/rabbitmq/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+mkdir -p {{pkg.svc_var_path}}/logs

--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=rabbitmq
 pkg_distname="${pkg_name}-server"
 pkg_origin=core
-pkg_version=3.7.7
+pkg_version=3.7.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL')
 pkg_description="Open source multi-protocol messaging broker"
 pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source="https://github.com/rabbitmq/rabbitmq-server/releases/download/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz"
-pkg_shasum=3549963ba562768387095eddeb2e69b6885fb11c7f4a3b8f53250694b4265431
+pkg_shasum=bed39fd72b8c932fe5f356fbbc7d30a19d651213e1667d81f084bc31468f5a02
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/coreutils

--- a/rabbitmq/tests/test.bats
+++ b/rabbitmq/tests/test.bats
@@ -1,0 +1,19 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v rabbitmqctl)" ]
+  [ "$(command -v rabbitmq-server)" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "rabbitmq\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 4369, 5672, 25672" {
+  result="$(netstat -peanut | grep 4369 | grep LISTEN)"
+  [ "$?" -eq 0 ]
+  result="$(netstat -peanut | grep 5672 | grep LISTEN)"
+  [ "$?" -eq 0 ]
+  result="$(netstat -peanut | grep 25672 | grep LISTEN)"
+  [ "$?" -eq 0 ]
+}

--- a/rabbitmq/tests/test.sh
+++ b/rabbitmq/tests/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 6
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
![tenor-124279672](https://user-images.githubusercontent.com/24568/46391535-758b3500-c718-11e8-93eb-d44deff9db61.gif)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Refs: #1871 - Fixes the log error issue.

Fixed dependency on elixir, by restricting dependency to core/elixir/1.6.5. Was failing build due to:

```
==> rabbitmqctl
** (Mix) You're trying to run :rabbitmqctl on Elixir v1.7.3 but it has declared in its mix.exs file it supports only Elixir ~> 1.6.0
```

### Testing

```
hab studio enter
./rabbitmq/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Service is running
 ✓ Listening on port 4369, 5672, 25672

3 tests, 0 failures
```