### PR TITLE
[ghc] Added ghc86 plan for GHC 8.6.1 now that it is stable

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -336,6 +336,11 @@ plan_path = "ghc84"
 paths = [
   "ghc/*",
 ]
+[ghc86]
+plan_path = "ghc86"
+paths = [
+  "ghc/*",
+]
 [giflib]
 plan_path = "giflib"
 [gifsicle]

--- a/ghc/plan.sh
+++ b/ghc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ghc
 pkg_origin=core
-pkg_version=8.4.3
+pkg_version=8.6.1
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-src.tar.xz"
-pkg_shasum="ae47afda985830de8811243255aa3744dfb9207cb980af74393298b2b62160d6"
+pkg_shasum="2c25c26d1e5c47c7cbb2a1d8e6456524033e7a71409184dd3125e3fc5a3c7036"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
@@ -26,7 +26,7 @@ pkg_deps=(
 pkg_build_deps=(
   core/binutils
   core/diffutils
-  core/ghc82
+  core/ghc84
   core/make
   core/patch
   core/sed

--- a/ghc86/README.md
+++ b/ghc86/README.md
@@ -1,0 +1,15 @@
+# ghc86
+
+The Glasgow Haskell Compiler
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ghc86/plan.sh
+++ b/ghc86/plan.sh
@@ -1,24 +1,15 @@
 # shellcheck disable=SC2148,SC1091
 source ../ghc/plan.sh
 
-pkg_name=ghc84
+pkg_name=ghc86
 pkg_origin=core
-pkg_version=8.4.3
+pkg_version=8.6.1
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-src.tar.xz"
-pkg_shasum="ae47afda985830de8811243255aa3744dfb9207cb980af74393298b2b62160d6"
+pkg_shasum="2c25c26d1e5c47c7cbb2a1d8e6456524033e7a71409184dd3125e3fc5a3c7036"
 pkg_dirname="ghc-${pkg_version}"
 
 pkg_include_dirs=(lib/ghc-${pkg_version}/include)
-
-pkg_build_deps=(
-  core/binutils
-  core/diffutils
-  core/ghc82
-  core/make
-  core/patch
-  core/sed
-)


### PR DESCRIPTION
- Added ghc86 plan for GHC 8.6.1 now that it is stable
- Updated based ghc plan to for 8.6.1
- Updated ghc84 plan to build 8.4 properly after rolling base ghc plan forward