### PR TITLE
[prometheus] upgrade to 2.4.2, build from tarball release, and add tests

### DIFF
--- a/prometheus/hooks/run
+++ b/prometheus/hooks/run
@@ -2,6 +2,6 @@
 
 exec 2>&1
 
-exec prometheus -config.file={{pkg.svc_config_path}}/prometheus.yml \
- -web.listen-address ":{{cfg.listening_port}}" \
- -storage.local.path {{pkg.svc_data_path}}
+exec prometheus --config.file={{pkg.svc_config_path}}/prometheus.yml \
+ --web.listen-address ":{{cfg.listening_port}}" \
+ --storage.tsdb.path {{pkg.svc_data_path}}

--- a/prometheus/plan.sh
+++ b/prometheus/plan.sh
@@ -2,13 +2,12 @@ pkg_name=prometheus
 pkg_description="Prometheus monitoring"
 pkg_upstream_url=http://prometheus.io
 pkg_origin=core
-pkg_version=1.6.1
-pkg_maintainer="Lamont Lucas <lamont@fastrobot.com>"
+pkg_version=2.4.2
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-# not used, since I actually git clone the repo and checkout the pkg_version branch
 pkg_source="https://github.com/prometheus/prometheus/archive/v${pkg_version}.tar.gz"
-pkg_shasum=ecc9ce94fce45994c23b76eb0c5acbb1b942513be601872c8cd74d0821450c5e
+pkg_shasum=5e327347490410f6c5491971b8e24ac02cf19fdd787354bd0bab90ea89421b76
 prom_pkg_dir="$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}"
 prom_build_dir="${prom_pkg_dir}/src/${pkg_source}"
 pkg_build_deps=(
@@ -28,32 +27,27 @@ pkg_binds_optional=(
 )
 
 
-do_prepare() {
-  export GOPATH=$HAB_CACHE_SRC_PATH/$pkg_dirname
-}
-
-# since I'm cloning a git repo, override download and verify callbacks to do nothing
-do_download() {
-  return 0
-}
-
-do_verify () {
-  return 0
+do_setup_environment() {
+  export GOPATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
 }
 
 do_unpack() {
-  mkdir -p "$prom_pkg_dir/src/github.com/prometheus"
-  pushd "$prom_pkg_dir/src/github.com/prometheus"
-  git clone --branch v${pkg_version} https://github.com/prometheus/prometheus.git
-  popd
+  mkdir -p "$prom_pkg_dir/src/github.com/prometheus/prometheus"
+  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
+  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" --strip 1 --no-same-owner
+  popd || exit 1
 }
 
 do_build() {
-  pushd "${prom_pkg_dir}/src/github.com/prometheus/prometheus"
-  make build
-  "$GOPATH/bin/promu" build --prefix "$pkg_prefix/bin"
-  popd
-  return 0
+  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
+  PREFIX="$pkg_prefix/bin" make build
+  popd || exit 1
+}
+
+do_check() {
+  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
+  make test
+  popd || exit 1
 }
 
 do_install() {

--- a/prometheus/tests/test.bats
+++ b/prometheus/tests/test.bats
@@ -1,0 +1,15 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v prometheus)" ]
+  [ "$(command -v promtool)" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "prometheus\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 9090" {
+  result="$(netstat -peanut | grep prometheus | grep LISTEN | head -1 | awk '{print $4}' | awk -F':::' '{print $2}')"
+  [ "${result}" -eq 9090 ]
+}

--- a/prometheus/tests/test.sh
+++ b/prometheus/tests/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 6
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
- upgraded prometheus to 2.4.2, which means the hook had to be modified slightly
- build from tarball releases which now means we can verify the integrity via shasum
- add in do_check() for unit testing
- add in tests for functional testing

### Testing

```bash
hab studio enter
DO_CHECK=1 ./prometheus/tests/test.sh
```

### Sample Output

```
   prometheus: Running post-compile tests
/hab/cache/src/prometheus-2.4.2/src/github.com/prometheus/prometheus /hab/cache/src/prometheus-2.4.2 /hab/cache/src /src/prometheus
>> running all tests
go test -race ./...
ok      github.com/prometheus/prometheus/cmd/prometheus 19.989s
ok      github.com/prometheus/prometheus/cmd/promtool   1.120s
ok      github.com/prometheus/prometheus/config 1.541s
ok      github.com/prometheus/prometheus/discovery      7.560s
ok      github.com/prometheus/prometheus/discovery/azure        1.020s
?       github.com/prometheus/prometheus/discovery/config       [no test files]
ok      github.com/prometheus/prometheus/discovery/consul       1.062s
?       github.com/prometheus/prometheus/discovery/dns  [no test files]
?       github.com/prometheus/prometheus/discovery/ec2  [no test files]
ok      github.com/prometheus/prometheus/discovery/file 33.139s
?       github.com/prometheus/prometheus/discovery/gce  [no test files]
ok      github.com/prometheus/prometheus/discovery/kubernetes   11.852s
ok      github.com/prometheus/prometheus/discovery/marathon     1.054s
ok      github.com/prometheus/prometheus/discovery/openstack    1.163s
ok      github.com/prometheus/prometheus/discovery/targetgroup  1.028s
ok      github.com/prometheus/prometheus/discovery/triton       1.120s
?       github.com/prometheus/prometheus/discovery/zookeeper    [no test files]
?       github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter       [no test files]
?       github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter-usage [no test files]
?       github.com/prometheus/prometheus/documentation/examples/remote_storage/example_write_adapter    [no test files]
?       github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter   [no test files]
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/graphite  1.013s
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/influxdb  1.030s
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/opentsdb  1.023s
ok      github.com/prometheus/prometheus/notifier       1.220s
ok      github.com/prometheus/prometheus/pkg/labels     1.017s
?       github.com/prometheus/prometheus/pkg/pool       [no test files]
ok      github.com/prometheus/prometheus/pkg/relabel    1.067s
ok      github.com/prometheus/prometheus/pkg/rulefmt    1.042s
?       github.com/prometheus/prometheus/pkg/runtime    [no test files]
ok      github.com/prometheus/prometheus/pkg/textparse  1.017s
?       github.com/prometheus/prometheus/pkg/timestamp  [no test files]
?       github.com/prometheus/prometheus/pkg/value      [no test files]
?       github.com/prometheus/prometheus/prompb [no test files]
ok      github.com/prometheus/prometheus/promql 3.777s
ok      github.com/prometheus/prometheus/relabel        1.069s
ok      github.com/prometheus/prometheus/rules  1.324s
ok      github.com/prometheus/prometheus/scrape 5.737s
ok      github.com/prometheus/prometheus/storage        1.016s
ok      github.com/prometheus/prometheus/storage/remote 13.937s
?       github.com/prometheus/prometheus/storage/tsdb   [no test files]
ok      github.com/prometheus/prometheus/template       1.042s
ok      github.com/prometheus/prometheus/util/httputil  1.053s
ok      github.com/prometheus/prometheus/util/promlint  1.031s
ok      github.com/prometheus/prometheus/util/stats     1.051s
ok      github.com/prometheus/prometheus/util/strutil   1.013s
?       github.com/prometheus/prometheus/util/testutil  [no test files]
?       github.com/prometheus/prometheus/util/treecache [no test files]
ok      github.com/prometheus/prometheus/web    6.410s
ok      github.com/prometheus/prometheus/web/api/v1     1.485s
?       github.com/prometheus/prometheus/web/api/v2     [no test files]
...
 ✓ Command is on path
 ✓ Service is running
 ✓ Listening on port 9090

3 tests, 0 failures
```

Signed-off-by: Ben Dang <me@bdang.it>