### PR TITLE
scaffolding-chef: secure ssl default

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -91,7 +91,7 @@ cache_path "$pkg_svc_data_path/cache"
 node_path "$pkg_svc_data_path/nodes"
 role_path "$pkg_svc_data_path/roles"
 
-ssl_verify_mode :verify_none
+ssl_verify_mode {{cfg.ssl_verify_mode}}
 chef_zero.enabled true
 EOF
 
@@ -117,6 +117,7 @@ interval = 1800
 splay = 180
 log_level = "warn"
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
+ssl_verify_mode = ":verify_peer"
 
 [data_collector]
 enable = false

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.1.2"
+pkg_version="0.1.3"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
We should use the safe and secure default of `:verify_peer` for the `ssl_verify_mode` in the configuration generated by the Chef scaffolding. This is in line with the default within Chef itself. End users can override this with `:verify_none` by changing the configuration passed into Habitat if they wish.