### PR TITLE
[cppcheck] new plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -140,6 +140,8 @@ paths = [
 plan_path = "cpanminus"
 [cpio]
 plan_path = "cpio"
+[cppcheck]
+plan_path = "cppcheck"
 [cppunit]
 plan_path = "cppunit"
 [cpputest]

--- a/cppcheck/README.md
+++ b/cppcheck/README.md
@@ -1,0 +1,15 @@
+# cppcheck
+
+Cppcheck is a static analysis tool for C/C++ code. It provides unique code analysis to detect bugs and focuses on detecting undefined behaviour and dangerous coding constructs. The goal is to detect only real errors in the code (i.e. have very few false positives).
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+binary package
+
+## Usage
+
+Place `core/cppcheck` into your `pkg_build_deps` and you will have `cppcheck` on the `PATH`.

--- a/cppcheck/plan.sh
+++ b/cppcheck/plan.sh
@@ -1,0 +1,57 @@
+pkg_name=cppcheck
+pkg_origin=core
+pkg_version=1.84
+pkg_description="static analysis of C/C++ code"
+pkg_upstream_url="http://cppcheck.sourceforget.net"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("GPL-3.0")
+pkg_source="https://github.com/danmar/cppcheck/archive/${pkg_version}.tar.gz"
+pkg_filename="${pkg_version}.tar.gz"
+pkg_shasum=aaa6293d91505fc6caa6982ca3cd2d949fa1aac603cabad072b705fdda017fc5
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/pcre
+)
+pkg_build_deps=(
+  core/pkg-config
+  core/cmake
+  core/ninja
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  export BUILDDIR="_build"
+}
+
+do_prepare() {
+  mkdir -p "${BUILDDIR}"
+}
+
+do_build() {
+  _PCRE_PATH="$(pkg_path_for pcre)"
+
+  pushd "${BUILDDIR}" || exit 1
+  cmake \
+    -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
+    -DBUILD_TESTS="${DO_CHECK}" \
+    -DHAVE_RULES="yes" \
+    -DPCRE="${_PCRE_PATH}/lib" \
+    -G Ninja \
+    ..
+  ninja
+  popd || exit 1
+}
+
+do_check() {
+  pushd "${BUILDDIR}" || exit 1
+  ctest -V
+  popd || exit 1
+}
+
+do_install() {
+  pushd "${BUILDDIR}" || exit 1
+  ninja install
+  popd || exit 1
+}

--- a/cppcheck/tests/test.bats
+++ b/cppcheck/tests/test.bats
@@ -1,0 +1,15 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v cppcheck)" ]
+}
+
+@test "Version matches" {
+  result="$(cppcheck --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run cppcheck --help
+  [ $status -eq 0 ]
+}

--- a/cppcheck/tests/test.sh
+++ b/cppcheck/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Testing

```bash
hab studio enter
DO_CHECK=1 ./cppcheck/tests/test.sh
```

### Output

```bash
...
test 1
    Start 1: testrunner

1: Test command: /hab/cache/src/cppcheck-1.84/_build/bin/testrunner
1: Test timeout computed to be: 9.99988e+06
1: Test64BitPortability::novardecl
1: Test64BitPortability::functionpar
1: Test64BitPortability::structmember
1: Test64BitPortability::ptrcompare
...
1: Testing Complete
1: Number of tests: 3224
1: Number of todos: 207
1: Tests failed: 0
1:
1/1 Test #1: testrunner .......................   Passed   35.57 sec

100% tests passed, 0 tests failed out of 1
...
★ Binlinked cppcheck from bdangit/cppcheck/1.84/20181006230920 to /bin/cppcheck
 ✓ Command is on path
 ✓ Version matches
 ✓ Help Command Check

3 tests, 0 failures
```

Signed-off-by: Ben Dang <me@bdang.it>