### PR TITLE
[dotnet-asp-core] Adding ASP.NET Core Plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -197,6 +197,8 @@ plan_path = "docker-compose"
 plan_path = "docutils"
 [dosfstools]
 plan_path = "dosfstools"
+[dotnet-asp-core]
+path_plan = "dotnet-asp-core"
 [dotnet-core]
 plan_path = "dotnet-core"
 [dotnet-core-lts]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -123,6 +123,7 @@ concourse-fly @echohack
 consul @defilan
 dep @afiune @nellshamrell
 dotnet-47-dev-pack @mwrock
+dotnet-asp-core @defilan
 dotnet-core-lts @mwrock
 dotnet-core-sdk-lts @mwrock
 dotnet-core-sdk-preview @mwrock

--- a/dotnet-asp-core/README.md
+++ b/dotnet-asp-core/README.md
@@ -1,8 +1,6 @@
-# dotnet-core
+# dotnet-asp-core
 
-.NET Core is a blazing fast, lightweight and modular platform
-  for creating web applications and services that run on Windows,
-  Linux and Mac.
+ASP.NET Core is a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications.
 
 ## Maintainers
 
@@ -12,6 +10,8 @@
 
 Binary package
 
-## Usage
-
-*TODO: Add instructions for usage*
+## Testing
+To test the Linux package run the following command from the Habitat Studio:
+```
+./tests/test.sh
+```

--- a/dotnet-asp-core/README.md
+++ b/dotnet-asp-core/README.md
@@ -1,0 +1,17 @@
+# dotnet-core
+
+.NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/dotnet-asp-core/plan.ps1
+++ b/dotnet-asp-core/plan.ps1
@@ -1,15 +1,13 @@
-$pkg_name="dotnet-core"
+$pkg_name="dotnet-asp-core"
 $pkg_origin="core"
-$pkg_version="2.0.6"
+$pkg_version="2.1.5"
 $pkg_license=('MIT')
-$pkg_upstream_url="https://www.microsoft.com/net/core"
-$pkg_description=".NET Core is a blazing fast, lightweight and modular platform
-  for creating web applications and services that run on Windows,
-  Linux and Mac."
+$pkg_upstream_url="https://docs.microsoft.com/en-us/aspnet/core"
+$pkg_description="ASP.NET Core is a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-$pkg_version-win-x64.zip"
-$pkg_shasum="d10abca0c869e72fcb45fe75940b1f28aed5dbbb1d5b048737d71d732a7b6670"
-$pkg_filename="dotnet-win-x64.$pkg_version.zip"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/6abfd5c4-f9e2-41fb-9363-fd60e3f9132f/1a5d3c82408f5e27b0e83be8c7f1ae42/aspnetcore-runtime-$pkg_version-win-x64.zip"
+$pkg_shasum="5b15819d68fe5a3ea1b181e1e3c33cce9884b80182256492eb4c10836b7b9dce"
+$pkg_filename="asp-dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-asp-core/plan.ps1
+++ b/dotnet-asp-core/plan.ps1
@@ -1,0 +1,17 @@
+$pkg_name="dotnet-core"
+$pkg_origin="core"
+$pkg_version="2.0.6"
+$pkg_license=('MIT')
+$pkg_upstream_url="https://www.microsoft.com/net/core"
+$pkg_description=".NET Core is a blazing fast, lightweight and modular platform
+  for creating web applications and services that run on Windows,
+  Linux and Mac."
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_source="https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-$pkg_version-win-x64.zip"
+$pkg_shasum="d10abca0c869e72fcb45fe75940b1f28aed5dbbb1d5b048737d71d732a7b6670"
+$pkg_filename="dotnet-win-x64.$pkg_version.zip"
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Install {
+  Copy-Item * "$pkg_prefix/bin" -Recurse -Force
+}

--- a/dotnet-asp-core/plan.sh
+++ b/dotnet-asp-core/plan.sh
@@ -1,0 +1,57 @@
+pkg_name=dotnet-asp-core
+pkg_origin=core
+pkg_version=2.1.5
+pkg_license=('MIT')
+pkg_upstream_url=https://docs.microsoft.com/en-us/aspnet/core
+pkg_description="ASP.NET Core is a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/97fce50e-e736-41c3-a700-d83d43178197/4c00b063affdbc940dd16f62c68d1505/aspnetcore-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=775bcb800f186461b54f2ca0dc858c2a34dc82f95ad060681e8f440c48c2b291
+pkg_filename="asp-dotnet-debian-x64.${pkg_version}.tar.gz"
+pkg_deps=(
+  core/curl
+  core/gcc-libs
+  core/glibc
+  core/icu52
+  core/krb5
+  core/libunwind
+  core/lttng-ust
+  core/openssl
+  core/util-linux
+  core/zlib
+)
+pkg_build_deps=(
+  core/patchelf
+)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  # Extract into $pkg_dirname instead of straight into $HAB_CACHE_SRC_PATH.
+  mkdir -p "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
+  tar xf "${HAB_CACHE_SRC_PATH}/${pkg_filename}" \
+    -C "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" \
+    --no-same-owner
+}
+
+do_prepare() {
+  find . -type f -name 'dotnet' \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
+  find . -type f -name '*.so*' \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  cp -a . "${pkg_prefix}/bin"
+  chmod o+r -R "${pkg_prefix}/bin"
+  # Move text files out of bin directory
+  mv "${pkg_prefix}/bin/LICENSE.txt" "${pkg_prefix}/LICENSE.txt"
+  mv "${pkg_prefix}/bin/ThirdPartyNotices.txt" "${pkg_prefix}/ThirdPartyNotices.txt"
+}
+
+do_strip() {
+  return 0
+}

--- a/dotnet-asp-core/tests/test.bats
+++ b/dotnet-asp-core/tests/test.bats
@@ -1,0 +1,16 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(dotnet --info | grep Version | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run dotnet --help
+  [ $status -eq 129 ]
+}
+
+@test "ASP check" {
+  result="$(dotnet --info | grep Microsoft.AspNetCore.All| awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/dotnet-asp-core/tests/test.sh
+++ b/dotnet-asp-core/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Hey all,

This is a new plan for asp.net core. I have added and tested both the Linux and Windows builds. Here is how to test the Linux plan:

``` 
hab studio enter
./tests/test.sh
```
Response:
```
 ✓ Version matches
 ✓ Help command
 ✓ ASP check

3 tests, 0 failures
```

All reports should come back happy if all is well :) 