### PR TITLE
[dotnet-core-sdk] Updating Version and Adding Tests

### DIFF
--- a/dotnet-core-sdk/README.md
+++ b/dotnet-core-sdk/README.md
@@ -12,6 +12,10 @@
 
 Binary package
 
-## Usage
+## Testing
 
-*TODO: Add instructions for usage*
+To test the Linux package, log into the Habitat Studio and run:
+
+```
+./tests/test.sh
+```

--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="2.0.3"
+$pkg_version="2.1.403"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform

--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -7,8 +7,8 @@ $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="64556c5454be49388a73525518f372b003113d3a418b92ea41e1659f1734b045"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/28820b2a-0aec-4c24-a271-a14bcb3e2686/5e0ad8ae32f1497e8d0cace2447b9e01/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_shasum="6837e66804c2a782212e68546d19711718c93ee28a62807ab6d381a55583ab26"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=2.0.3
+pkg_version=2.1.403
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.microsoft.com/download/D/7/2/D725E47F-A4F1-4285-8935-A91AE2FCC06A/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=6c4223094b1e3e93a466c6d91d3aa1053a3b2aef99b63bf45023bda3fca1aede
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/e85de743-f80b-481b-b10e-d2e37f05a7ce/0bf3ff93417e19ad8d6b2d3ded84d664/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=0bc7b42450a6a35f83aa6a7dfdc9cf39f3e1c7488dc1cc085b2f2a84207a3fc5
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils

--- a/dotnet-core-sdk/tests/test.bats
+++ b/dotnet-core-sdk/tests/test.bats
@@ -1,11 +1,11 @@
 source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Version matches" {
-  result="$(dotnet --info | grep Version | awk '{print $2}')"
+  result="$(dotnet --version)"
   [ "$result" = "${pkg_version}" ]
 }
 
-@test "Help command" {
-  run dotnet --help
-  [ $status -eq 129 ]
+@test "Info command" {
+  run dotnet --info
+  [ $status -eq 0 ]
 }

--- a/dotnet-core-sdk/tests/test.bats
+++ b/dotnet-core-sdk/tests/test.bats
@@ -1,0 +1,11 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(dotnet --info | grep Version | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run dotnet --help
+  [ $status -eq 129 ]
+}

--- a/dotnet-core-sdk/tests/test.sh
+++ b/dotnet-core-sdk/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Hey all,

This update brings the dotnet-core-sdk to version 2.1.403. Tests were added as well.

To test the Linux plan, log into the Hab Studio and run the following commands:
```
./tests/test.sh
```

The results should be:
```
 ✓ Version matches
 ✓ Info command

2 tests, 0 failures
```