### PR TITLE
[sbt] Update sbt to 1.2.4

### DIFF
--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=sbt
-pkg_version=1.1.6
+pkg_version=1.2.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A build tool for Scala, Java, and more"
 pkg_upstream_url="https://www.scala-sbt.org"
 pkg_license=("BSD-3-Clause")
 pkg_source=https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz
-pkg_shasum=f545b530884e3abbca026df08df33d5a15892e6d98da5b8c2297413d1c7b68c1
+pkg_shasum=36db5a4cbad1d39fb01978a09007b9d833c9172d9cd4a3b08180c24c6a0dfb1b
 pkg_dirname="$pkg_name-$pkg_version"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

Testing is manual at the moment:

```
hab studio enter
build sbt
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
hab pkg install --binlink core/jre8

sbt --help
```

Performs some downloads / maven package resolution as expected.