### PR TITLE
[rust] Update to Rust 1.29.1.

### DIFF
--- a/rust/plan.ps1
+++ b/rust/plan.ps1
@@ -1,12 +1,12 @@
 ﻿$pkg_name="rust"
 $pkg_origin="core"
-$pkg_version="1.28.0"
+$pkg_version="1.29.1"
 $pkg_description="Safe, concurrent, practical language"
 $pkg_upstream_url="https://www.rust-lang.org/"
 $pkg_license=@("Apache-2.0", "MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://static.rust-lang.org/dist/rust-$pkg_version-x86_64-pc-windows-msvc.msi"
-$pkg_shasum="e714b02fdf05b92f7be7547eb2e13a252e86a5de51c3fb477a792c82c1ec6ba4"
+$pkg_shasum="a3dc8c09736fb7086fcfb004f0f04d82941dd261afdb5db10ebbce33aebde2eb"
 $pkg_deps=@("core/visual-cpp-redist-2013", "core/visual-cpp-build-tools-2015")
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")

--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.29.0
+pkg_version=1.29.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Rust is a systems programming language that runs blazingly fast, prevents \
@@ -8,9 +8,9 @@ segfaults, and guarantees thread safety.\
 "
 pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
-_url_base="http://static.rust-lang.org/dist"
+_url_base="https://static.rust-lang.org/dist"
 pkg_source="$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz"
-pkg_shasum="09f99986c17b1b6b1bfbc9dd8785e0e4693007c5feb67915395d115c1a3aea9d"
+pkg_shasum="b36998aea6d58525f25d89f1813b6bfd4cad6ff467e27bd11e761a20dde43745"
 pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu"
 pkg_deps=(
   core/glibc
@@ -33,7 +33,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-    f45012af49d05990b0917c465a7986be466d2dcf6fb82100903ba0dc7f63469c
+    7ef498c2c817afc7843d301431015931323af1759d325f46b4379bf4dccec331
 )
 
 do_download() {


### PR DESCRIPTION
https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html

Note that the download URL for Linux was updated from an `http://`
scheme to `https://` as the distribution server is now issuing
`HTTP/301` redirects to the TLS-enabled URL.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>