### PR TITLE
[node/node10] Update node/node10 to 10.12.0 on Linux and Windows

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="10.8.0"
+$pkg_version="10.12.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="9d03d6bc78d7375fa549005c9b12cf5da4b01ee52b60834107f5f603d82a68f2"
+$pkg_shasum="21fcc88b9af133b0ecdf03a0cdf965ad5f2a547759096fb3b050be4ca871de8f"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=10.11.0
+pkg_version=10.12.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=f721552552fb11ef99aba290fc6e696a8647adc98d643db6651e81ed07c4037e
+pkg_shasum=c6552b95062f5e9f3a27da6fdb57914ab4b27a9aa2e783fb050791166554d059
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node10/plan.ps1
+++ b/node10/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node10"
 $pkg_origin="core"
-$pkg_version="10.8.0"
+$pkg_version="10.12.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="9d03d6bc78d7375fa549005c9b12cf5da4b01ee52b60834107f5f603d82a68f2"
+$pkg_shasum="21fcc88b9af133b0ecdf03a0cdf965ad5f2a547759096fb3b050be4ca871de8f"

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node10
 pkg_origin=core
-pkg_version=10.11.0
+pkg_version=10.12.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=f721552552fb11ef99aba290fc6e696a8647adc98d643db6651e81ed07c4037e
+pkg_shasum=c6552b95062f5e9f3a27da6fdb57914ab4b27a9aa2e783fb050791166554d059
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build node
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
node --version
```

### Sample output

```
# node --version
v10.12.0
```