### PR TITLE
[hugo] Update hugo to 0.49.2, add tests

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,39 +1,35 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.46"
+pkg_version="0.49.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_build_deps=(
-  core/dep
-  core/mage
+  core/go
+  core/git
+  core/gcc
 )
 pkg_deps=(
-  core/glibc
+  # core/glibc
 )
 pkg_bin_dirs=(bin)
-pkg_source="https://github.com/gohugoio/hugo"
+pkg_repository="https://github.com/gohugoio/hugo.git"
 pkg_upstream_url="https://gohugo.io"
-pkg_scaffolding="core/scaffolding-go"
-
-scaffolding_go_build_deps=(
-  github.com/magefile/mage
-)
-
-do_download() {
-  scaffolding_go_download
-  pushd "${scaffolding_go_pkg_path}" > /dev/null
-  git reset --hard "v${pkg_version}"
-  popd > /dev/null
-}
 
 do_build() {
-  pushd "${scaffolding_go_pkg_path}" > /dev/null
-  mage vendor
-  mage install
+  local hugo_dir="${HAB_CACHE_SRC_PATH}/hugo-${pkg_version}"
+  git clone \
+    --depth 1 \
+    --branch "v${pkg_version}" \
+    --config advice.detachedHead=false \
+    "${pkg_repository}" \
+    "${hugo_dir}"
+  pushd "${hugo_dir}" > /dev/null
+  go install --tags extended
+  go build -o hugo main.go
   popd > /dev/null
 }
 
 do_install() {
-  cp "${GOPATH}/bin/hugo" "${pkg_prefix}/bin/hugo"
+  cp "${HAB_CACHE_SRC_PATH}/hugo-${pkg_version}/hugo" "${pkg_prefix}/bin/"
 }

--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -10,7 +10,7 @@ pkg_build_deps=(
   core/gcc
 )
 pkg_deps=(
-  # core/glibc
+  core/glibc
 )
 pkg_bin_dirs=(bin)
 pkg_repository="https://github.com/gohugoio/hugo.git"

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(hugo version | awk '{print $5}')"
+  [ "$result" = "v${pkg_version}" ]
+}

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Its finally done. New hugo, new build process, new tests. Shiny.

![tenor-239485940](https://user-images.githubusercontent.com/24568/46876501-7854fb00-ce79-11e8-8026-393f0fe5a69e.gif)

### Testing

```
hab studio enter
./hugo/tests/test.sh
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```