### PR TITLE
[mage] Update mage to 1.7.0, move tests into test directory

### DIFF
--- a/mage/plan.sh
+++ b/mage/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=mage
 pkg_origin=core
-pkg_version="1.2.4"
+pkg_version="1.7.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets."

--- a/mage/tests/test.bats
+++ b/mage/tests/test.bats
@@ -1,4 +1,4 @@
-source ./plan.sh
+source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Binlink dependencies" {
   run hab pkg binlink core/go

--- a/mage/tests/test.sh
+++ b/mage/tests/test.sh
@@ -1,16 +1,21 @@
 #!/bin/sh
 
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
 SKIPBUILD=${SKIPBUILD:-0}
 
 hab pkg install --binlink core/bats
-source ./plan.sh
+
+source "${PLANDIR}/plan.sh"
 
 if [ "${SKIPBUILD}" -eq 0 ]; then
   set -e
+  pushd "${PLANDIR}" > /dev/null
   build
   source results/last_build.env
   hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
   set +e
 fi
 
-bats test.bats
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./mage/tests/test.sh
```

### Sample output

```
 ✓ Binlink dependencies
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Mage init works

5 tests, 0 failures
```

![tenor-178842662](https://user-images.githubusercontent.com/24568/46877732-7d677980-ce7c-11e8-8d67-fab68b90a3f9.gif)
