### PR TITLE
[llvm] Upgrade llvm to 7.0.0 and implement RFC3

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -742,6 +742,16 @@ plan_path = "linux-headers-musl"
 plan_path = "linux-pam"
 [llvm]
 plan_path = "llvm"
+[llvm5]
+plan_path = "llvm5"
+paths = [
+  "llvm/*"
+]
+[llvm7]
+plan_path = "llvm7"
+paths = [
+  "llvm/*"
+]
 [local-lib]
 plan_path = "local-lib"
 [logback]

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -1,6 +1,6 @@
 # llvm
 
-This package provides the llvm libraries and binaries.
+This package provides the llvm libraries and binaries. This package tracks the latest major version of llvm.
 
 ## Usage
 

--- a/llvm/tests/test.bats
+++ b/llvm/tests/test.bats
@@ -1,0 +1,20 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v llvm-config)" ]
+}
+
+@test "Version matches" {
+  result="$(llvm-config --version)"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Check libLTO.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libLTO.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libLTO.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libLTO.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/llvm/tests/test.sh
+++ b/llvm/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/llvm5/README.md
+++ b/llvm5/README.md
@@ -1,0 +1,10 @@
+# llvm5
+
+This package provides the llvm 5.x libraries and binaries.
+
+## Usage
+
+Typically this is a build dependency that can be added to your
+plan.sh:
+
+    pkg_build_deps=(core/llvm5)

--- a/llvm5/plan.sh
+++ b/llvm5/plan.sh
@@ -1,0 +1,12 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../llvm/plan.sh"
+
+pkg_name=llvm5
+pkg_origin=core
+pkg_version=5.0.1
+pkg_license=('NCSA')
+pkg_description="Next-gen compiler infrastructure"
+pkg_upstream_url="http://llvm.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="llvm-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/llvm-${pkg_version}.src.tar.xz"
+pkg_shasum="5fa7489fc0225b11821cab0362f5813a05f2bcf2533e8a4ea9c9c860168807b0"

--- a/llvm5/tests/test.bats
+++ b/llvm5/tests/test.bats
@@ -1,0 +1,20 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v llvm-config)" ]
+}
+
+@test "Version matches" {
+  result="$(llvm-config --version)"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Check libLTO.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libLTO.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libLTO.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libLTO.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/llvm5/tests/test.sh
+++ b/llvm5/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/llvm7/README.md
+++ b/llvm7/README.md
@@ -1,0 +1,10 @@
+# llvm7
+
+This package provides the llvm 7.x libraries and binaries.
+
+## Usage
+
+Typically this is a build dependency that can be added to your
+plan.sh:
+
+    pkg_build_deps=(core/llvm7)

--- a/llvm7/plan.sh
+++ b/llvm7/plan.sh
@@ -1,0 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../llvm/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../llvm/plan.sh"
+
+pkg_name=llvm7
+pkg_origin=core
+pkg_version=7.0.0
+pkg_license=('NCSA')
+pkg_description="Next-gen compiler infrastructure"
+pkg_upstream_url="http://llvm.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="llvm-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/llvm-${pkg_version}.src.tar.xz"
+pkg_shasum="8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222"

--- a/llvm7/tests/test.bats
+++ b/llvm7/tests/test.bats
@@ -1,0 +1,20 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v llvm-config)" ]
+}
+
+@test "Version matches" {
+  result="$(llvm-config --version)"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Check libLTO.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libLTO.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libLTO.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libLTO.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/llvm7/tests/test.sh
+++ b/llvm7/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
- switched to ninja
- enable rtti and ffi
- install llvm utils which is used by clang
- add in tests
- add CMAKE_FIND_ROOT_PATH for better cmake ux
- implement RFC3 to track major versions in parallel

## Testing

```
hab studio enter
DO_CHECK=1 ./llvm/tests/test.sh
DO_CHECK=1 ./llvm5/tests/test.sh
DO_CHECK=1 ./llvm7/tests/test.sh
```

> note: building this plan takes awhile - should be ~60 minutes with tests each.

## Notes

`core/libcxx` and `libcxxabi` depends on this package and I have rebuilt them locally.  The plan as in master works just as fine.

Signed-off-by: Ben Dang <me@bdang.it>