### PR TITLE
[clang] upgrade clang to 7.0.0 and implement RFC3

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -111,8 +111,16 @@ plan_path = "certstrap"
 plan_path = "check"
 [clang]
 plan_path = "clang"
-[clang-tools-extra]
-plan_path = "clang-tools-extra"
+[clang5]
+plan_path = "clang5"
+paths = [
+  "clang/*"
+]
+[clang7]
+plan_path = "clang7"
+paths = [
+  "clang/*"
+]
 [clens]
 plan_path = "clens"
 [clingo]

--- a/clang-tools-extra/README.md
+++ b/clang-tools-extra/README.md
@@ -1,4 +1,6 @@
-# clang-tools-extra
+# clang-tools-extra (deprecated)
+
+**Deprecation Notice**: This plan is folded into the `core/clang` package as that is what the normal way to build as defined [here](https://clang.llvm.org/get_started.html)
 
 Clang Tools are standalone command line (and potentially GUI) tools designed for use by C++
 developers who are already using and enjoying Clang as their compiler. These tools provide

--- a/clang/plan.sh
+++ b/clang/plan.sh
@@ -1,30 +1,48 @@
 pkg_name=clang
 pkg_origin=core
-pkg_version=5.0.1
+pkg_version=7.0.0
 pkg_license=('NCSA')
 pkg_description="LLVM native C/C++/Objective-C compiler"
 pkg_upstream_url="http://clang.llvm.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_filename="${pkg_name}-${pkg_version}.src.tar.xz"
+pkg_filename="cfe-${pkg_version}.src.tar.xz"
 pkg_source="http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz"
-pkg_shasum="135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff"
+pkg_shasum="550212711c752697d2f82c648714a7221b1207fd9441543ff4aa9e3be45bba55"
+clang_tools_extra_shasum="937c5a8c8c43bc185e4805144744799e524059cac877a44d9063926cd7a19dbe"
 pkg_deps=(
+  core/coreutils
   core/gcc-libs
   core/glibc
+  core/python
   core/zlib
+  core/perl
+  core/gcc
 )
 pkg_build_deps=(
   core/llvm
+  core/perl
   core/cmake
-  core/coreutils
   core/diffutils
-  core/gcc
-  core/make
-  core/python2
+  core/ninja
 )
 pkg_lib_dirs=(lib)
-pkg_include_dirs=(include)
+pkg_include_dirs=(
+  include
+  "lib/clang/${pkg_version}/include"
+)
 pkg_bin_dirs=(bin)
+
+do_begin() {
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_SEPARATOR=";"
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_TYPE="aggregate"
+}
+
+do_setup_environment() {
+  set_buildtime_env BUILD_DIR "_build"
+
+  # this allows cmake users to utilize `CMAKE_FIND_ROOT_PATH` to find various cmake configs
+  push_runtime_env CMAKE_FIND_ROOT_PATH "${pkg_prefix}/lib/cmake/clang"
+}
 
 do_unpack() {
   # The tarball's structure has `.src` as part of the base directory.
@@ -32,8 +50,8 @@ do_unpack() {
   # add `--strip` to the tar command.
   # There may be some more awesome way to do this - I don't know that yet.
   build_line "Unpacking $pkg_filename to custom cache dir"
-  local source_file=$HAB_CACHE_SRC_PATH/$pkg_filename
-  local unpack_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
+  local source_file="$HAB_CACHE_SRC_PATH/$pkg_filename"
+  local unpack_dir="$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}"
   mkdir -p "$unpack_dir"
   pushd "$unpack_dir" > /dev/null || exit
   # Per tar's help output:
@@ -42,27 +60,83 @@ do_unpack() {
   #
   # The llvm package has some files owned by specific UIDs that we
   # can't be sure exist on the builder or target system.
-  tar xf "$source_file" --strip 1 --no-same-owner
-  popd > /dev/null || exit
+  tar xf "${source_file}" --strip 1 --no-same-owner
+  popd > /dev/null || exit 1
+
+  # Download clang-tools-extra (intended to be built together with clang)
+  download_file http://llvm.org/releases/$pkg_version/clang-tools-extra-$pkg_version.src.tar.xz \
+    clang-tools-extra-$pkg_version.src.tar.xz \
+    "${clang_tools_extra_shasum}"
+  build_line "Unpacking clang-tools-extra to custom cache dir"
+  local clang_tools_extra_src_dir="$unpack_dir/tools/extra"
+  mkdir -p "$clang_tools_extra_src_dir"
+  pushd "$clang_tools_extra_src_dir" > /dev/null || exit 1
+  tar xf "$HAB_CACHE_SRC_PATH/clang-tools-extra-$pkg_version.src.tar.xz" --strip 1 --no-same-owner
+  popd > /dev/null || exit 1
+}
+
+do_prepare() {
+  mkdir -p "${BUILD_DIR}"
+
+  _fix_interpreter_in_path "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" '*.py' core/python bin/python
+  _fix_interpreter_in_path "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" '*.py' core/coreutils bin/env
+  _fix_interpreter_in_path "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" '*.sh' core/coreutils bin/env
 }
 
 do_build() {
-  mkdir -p build
-  cd build || exit
+  pushd "${BUILD_DIR}" || exit 1
   cmake \
-    -DCMAKE_INSTALL_PREFIX:PATH="$pkg_prefix" \
+    -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
+    -DCLANG_BUILD_EXAMPLES=ON \
     -DCMAKE_BUILD_TYPE=Release \
-    -G "Unix Makefiles" \
-    ../
-  make -j"$(nproc)"
+    -G "Ninja" \
+    ..
+
+  # ninja defaults to using 8 jobs. on machines with limited resources this becomes
+  # problematic causing things not to be built and run.
+  ninja -j"$(nproc --ignore=1)"
+  popd || exit 1
 }
 
 do_check() {
-  cd build || exit
-  make test
+  pushd "${BUILD_DIR}" || exit 1
+
+  # ninja defaults to using 8 jobs. on machines with limited resources this becomes
+  # problematic causing things not to be built and run.
+  ninja -j"$(nproc --ignore=1)" check-clang
+  popd || exit 1
 }
 
 do_install() {
-  cd build || exit
-  make install
+  pushd "${BUILD_DIR}" || exit 1
+  ninja install
+  popd || exit 1
+
+  fix_interpreter "${pkg_prefix}/bin/git-clang-format" core/coreutils bin/env
+  fix_interpreter "${pkg_prefix}/bin/hmaptool" core/coreutils bin/env
+  fix_interpreter "${pkg_prefix}/bin/scan-build" core/coreutils bin/env
+  fix_interpreter "${pkg_prefix}/bin/scan-view" core/coreutils bin/env
+  fix_interpreter "${pkg_prefix}/libexec/c++-analyzer" core/coreutils bin/env
+  fix_interpreter "${pkg_prefix}/libexec/ccc-analyzer" core/coreutils bin/env
+}
+
+# private #
+_fix_interpreter_in_path() {
+  local path=$1
+  local fileending=$2
+  local pkg=$3
+  local int=$4
+
+  # shellcheck disable=SC2016
+  # I need these to be evaluated at exec time
+  find "${path}" -name "${fileending}" -type f \
+    -exec grep -Iq . {} \; \
+    -exec sh -c 'head -n 1 "$1" | grep -q "$2"' _ {} "${int}" \; \
+    -exec sh -c 'echo "$1"' _ {} \; > /tmp/fix_interpreter_in_path_list
+
+  grep -v '^ *#' < /tmp/fix_interpreter_in_path_list | while IFS= read -r line
+  do
+    fix_interpreter "${line}" "${pkg}" "${int}"
+  done
+  rm -rf /tmp/fix_interpreter_in_path_list
 }

--- a/clang/tests/test.bats
+++ b/clang/tests/test.bats
@@ -1,0 +1,34 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v clang)" ]
+  [ "$(command -v clang++)" ]
+  [ "$(command -v clang-format)" ]
+  [ "$(command -v clang-tidy)" ]
+}
+
+@test "Version matches" {
+  result="$(clang --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+
+  result="$(clang++ --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run clang --help
+  [ $status -eq 0 ]
+
+  run clang++ --help
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libclang.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libclang.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/clang/tests/test.sh
+++ b/clang/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/clang5/README.md
+++ b/clang5/README.md
@@ -1,4 +1,4 @@
-# clang
+# clang5
 
 LLVM native C/C++/Objective-C compiler
 
@@ -12,5 +12,5 @@ Binary package
 
 ## Usage
 
-Include `core/clang` if you need any of the libraries, includes, clang tools and clang-tools-extra.  For additional
+Include `core/clang5` if you need any of the libraries, includes, clang tools and clang-tools-extra.  For additional
 usage, refer to the [`pkg_upstream_url`](http://clang.llvm.org/)

--- a/clang5/plan.sh
+++ b/clang5/plan.sh
@@ -1,0 +1,21 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../clang/plan.sh"
+
+pkg_name=clang5
+pkg_origin=core
+pkg_version=5.0.1
+pkg_license=('NCSA')
+pkg_description="LLVM native C/C++/Objective-C compiler"
+pkg_upstream_url="http://clang.llvm.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="cfe-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz"
+pkg_shasum="135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff"
+clang_tools_extra_shasum="9aada1f9d673226846c3399d13fab6bba4bfd38bcfe8def5ee7b0ec24f8cd225"
+
+pkg_build_deps=(
+  core/llvm5
+  core/perl
+  core/cmake
+  core/diffutils
+  core/ninja
+)

--- a/clang5/tests/test.bats
+++ b/clang5/tests/test.bats
@@ -1,0 +1,34 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v clang)" ]
+  [ "$(command -v clang++)" ]
+  [ "$(command -v clang-format)" ]
+  [ "$(command -v clang-tidy)" ]
+}
+
+@test "Version matches" {
+  result="$(clang --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+
+  result="$(clang++ --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run clang --help
+  [ $status -eq 0 ]
+
+  run clang++ --help
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libclang.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libclang.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/clang5/tests/test.sh
+++ b/clang5/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/clang7/README.md
+++ b/clang7/README.md
@@ -1,4 +1,4 @@
-# clang
+# clang7
 
 LLVM native C/C++/Objective-C compiler
 
@@ -12,5 +12,5 @@ Binary package
 
 ## Usage
 
-Include `core/clang` if you need any of the libraries, includes, clang tools and clang-tools-extra.  For additional
+Include `core/clang7` if you need any of the libraries, includes, clang tools and clang-tools-extra.  For additional
 usage, refer to the [`pkg_upstream_url`](http://clang.llvm.org/)

--- a/clang7/plan.sh
+++ b/clang7/plan.sh
@@ -1,0 +1,21 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../clang/plan.sh"
+
+pkg_name=clang7
+pkg_origin=core
+pkg_version=7.0.0
+pkg_license=('NCSA')
+pkg_description="LLVM native C/C++/Objective-C compiler"
+pkg_upstream_url="http://clang.llvm.org/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_filename="cfe-${pkg_version}.src.tar.xz"
+pkg_source="http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz"
+pkg_shasum="550212711c752697d2f82c648714a7221b1207fd9441543ff4aa9e3be45bba55"
+clang_tools_extra_shasum="937c5a8c8c43bc185e4805144744799e524059cac877a44d9063926cd7a19dbe"
+
+pkg_build_deps=(
+  core/llvm7
+  core/perl
+  core/cmake
+  core/diffutils
+  core/ninja
+)

--- a/clang7/tests/test.bats
+++ b/clang7/tests/test.bats
@@ -1,0 +1,34 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Commands are on path" {
+  [ "$(command -v clang)" ]
+  [ "$(command -v clang++)" ]
+  [ "$(command -v clang-format)" ]
+  [ "$(command -v clang-tidy)" ]
+}
+
+@test "Version matches" {
+  result="$(clang --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+
+  result="$(clang++ --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command Check" {
+  run clang --help
+  [ $status -eq 0 ]
+
+  run clang++ --help
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so exists" {
+  run file "/hab/pkgs/${pkg_ident}/lib/libclang.so"
+  [ $status -eq 0 ]
+}
+
+@test "Check libclang.so does not have any \"not found\" shared libs" {
+  run bash -c "ldd \"/hab/pkgs/${pkg_ident}/lib/libclang.so\" | grep \"not found\""
+  [ $status -eq 1 ]
+}

--- a/clang7/tests/test.sh
+++ b/clang7/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
This plan ugrades clang to 7.0.0 and with that we implement RFC3 to
include versions for clang5 and clang7.  We also include the
clang-tools-extra bins into this plan, which means `core/clang-tools-extra` is deprecated.

Furthermore, we append cmake configs into CMAKE_FIND_ROOT_PATH for better cmake ux.

Depends on #1918 to be merged in before this.

## Testing

```
hab studio enter
DO_CHECK=1 ./clang/tests/test.sh
DO_CHECK=1 ./clang5/tests/test.sh
DO_CHECK=1 ./clang7/tests/test.sh
```

> note: building these plans takes awhile - should be 60-70 minutes **each** pending on the machine.

Signed-off-by: Ben Dang <me@bdang.it>