### PR TITLE
[mage] Update to 1.7.1

### DIFF
--- a/mage/plan.sh
+++ b/mage/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=mage
 pkg_origin=core
-pkg_version="1.7.0"
+pkg_version="1.7.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets."


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Minor version bump for Mage to 1.7.1

### Testing

```
$ hab studio run mage/tests/test.sh

. . .
1..5
ok 1 Binlink dependencies
ok 2 Command is on path
ok 3 Version matches
ok 4 Help command
ok 5 Mage init works
```

![tenor-166856202](https://user-images.githubusercontent.com/24568/47124298-287e9580-d2b8-11e8-9e6e-0122a29bd401.gif)
