### PR TITLE
[httpd] Update to 2.4.35, add tests

### DIFF
--- a/httpd/plan.sh
+++ b/httpd/plan.sh
@@ -1,14 +1,32 @@
 pkg_name=httpd
 pkg_origin=core
-pkg_version=2.4.27
+pkg_version=2.4.35
 pkg_description="The Apache HTTP Server"
 pkg_upstream_url="http://httpd.apache.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://archive.apache.org/dist/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=346dd3d016ae5d7101016e68805150bdce9040a8d246c289aa70e68a7cd86b66
-pkg_deps=(core/apr core/apr-util core/bash core/expat core/gcc-libs core/glibc core/libiconv core/openssl core/pcre core/perl core/zlib)
-pkg_build_deps=(core/patch core/make core/gcc)
+pkg_shasum=31c2c82c9cd34749cbb60d04619d9aa3fb0814ab22246ad588d2426dde90c72c
+pkg_deps=(
+  core/apr
+  core/apr-util
+  core/bash
+  core/expat
+  core/gcc-libs
+  core/glibc
+  core/libiconv
+  core/openssl
+  core/pcre
+  core/perl
+  core/zlib
+  core/sed
+  core/grep
+)
+pkg_build_deps=(
+  core/patch
+  core/make
+  core/gcc
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_exports=(

--- a/httpd/tests/test.bats
+++ b/httpd/tests/test.bats
@@ -1,0 +1,31 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v httpd)" ]
+}
+
+@test "Version matches" {
+  result="$(httpd -v | head -1 | awk '{print $3}')"
+  [ "$result" = "Apache/${pkg_version}" ]
+}
+
+@test "Help command" {
+  run httpd -h
+  # httpd help command exits with status 1, for some reason
+  [ $status -eq 1 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "httpd\.default" | awk '{print $4}' | grep up)" ]
+}
+
+# Check for processes, exclude grep, and test.bats processes
+@test "Multiple processes" {
+  result="$(ps aux | grep -v grep | grep -v "test\.bats" | grep httpd | wc -l)"
+  [ "${result}" -gt 1 ]
+}
+
+@test "Listening on port 80" {
+  result="$(netstat -peanut | grep httpd | awk '{print $4}' | awk -F':' '{print $2}')"
+  [ "${result}" -eq 80 ]
+}

--- a/httpd/tests/test.sh
+++ b/httpd/tests/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+hab pkg binlink core/busybox-static uniq
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 3
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
httpd/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Multiple processes
 ✓ Listening on port 80

6 tests, 0 failures
```