### PR TITLE
Add windows native plans for hab direct dependencies.

### DIFF
--- a/bzip2/plan.ps1
+++ b/bzip2/plan.ps1
@@ -1,0 +1,25 @@
+$pkg_name="bzip2"
+$pkg_origin="core"
+$pkg_version="1.0.6"
+$pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
+$pkg_description="bzip2 is a free and open-source file compression program that uses the Burrows–Wheeler algorithm. It only compresses single files and is not a file archiver."
+$pkg_upstream_url="http://www.bzip.org/"
+$pkg_license=("bzip2")
+$pkg_source="https://github.com/nemequ/$pkg_name/archive/v${pkg_version}.zip"
+$pkg_shasum="1ac730150d4c13a6933101c8d21acc6de258503ae8a6a049e948a47749ddcc81"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015")
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+$pkg_include_dirs=@("include")
+
+function Invoke-Build {
+    cd "$pkg_name-$pkg_version"
+    nmake -f makefile.msc
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzip2.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzip2recover.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzlib.h" "$pkg_prefix\include\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\libbz2.lib" "$pkg_prefix\lib\" -Force
+}

--- a/dmake/plan.ps1
+++ b/dmake/plan.ps1
@@ -1,0 +1,13 @@
+$pkg_name="dmake"
+$pkg_origin="core"
+$pkg_version="4.12.2.2"
+$pkg_description="dmake"
+$pkg_upstream_url="https://metacpan.org/release/dmake"
+$pkg_license=@("gpl")
+$pkg_source="https://cpan.metacpan.org/authors/id/S/SH/SHAY/dmake-$pkg_version.zip"
+$pkg_shasum="c9dbffda19df70585cd4b83652085426f4dea874fd7480f2c4cb95d0b82f64c4"
+$pkg_bin_dirs=@(".")
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_dirname\dmake\*" "$pkg_prefix" -Recurse -Force
+}

--- a/libarchive/plan.ps1
+++ b/libarchive/plan.ps1
@@ -1,0 +1,30 @@
+$pkg_name="libarchive"
+$pkg_origin="core"
+$pkg_version="3.3.2"
+$pkg_description="Multi-format archive and compression library"
+$pkg_upstream_url="https://www.libarchive.org"
+$pkg_license=@("BSD")
+$pkg_source="http://www.libarchive.org/downloads/${pkg_name}-${pkg_version}.zip"
+$pkg_shasum="94e5fe36ea658b2ac91e036b178930735c537f14dcb54434a05530d2a14435ee"
+$pkg_deps=@(
+    "core/openssl",
+    "core/bzip2"
+)
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/cmake", "core/zlib")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Build {
+    cd "$pkg_name-$pkg_version"
+
+    $bzip_lib = "$(Get-HabPackagePath bzip2)\lib\libbz2.lib"
+    $bzip_includedir = "$(Get-HabPackagePath bzip2)\include"
+    $zlib_libdir = "$(Get-HabPackagePath zlib)\lib\zlibwapi.lib"
+    $zlib_includedir = "$(Get-HabPackagePath zlib)\include"
+
+    cmake -G "Visual Studio 14 2015 Win64" -T "v140" -DCMAKE_SYSTEM_VERSION="8.1" -DCMAKE_INSTALL_PREFIX="${prefix_path}\libarchive" -DBZIP2_LIBRARY_RELEASE="${bzip_lib}" -DBZIP2_INCLUDE_DIR="${bzip_includedir}" -DZLIB_LIBRARY_RELEASE="${zlib_libdir}" -DZLIB_INCLUDE_DIR="${zlib_includedir}"
+    msbuild /p:Configuration=Release /p:Platform=x64 "ALL_BUILD.vcxproj"
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\$pkg_name\Release\*.lib" "$pkg_prefix\lib\" -Force
+}

--- a/libsodium/plan.ps1
+++ b/libsodium/plan.ps1
@@ -1,0 +1,21 @@
+$pkg_name="libsodium"
+$pkg_origin="core"
+$pkg_version="1.0.13"
+$_pkg_version_text=($pkg_version).Replace(".", "_")
+$pkg_description="Sodium is a new, easy-to-use software library for encryption, decryption, signatures, password hashing and more. It is a portable, cross-compilable, installable, packageable fork of NaCl, with a compatible API, and an extended API to improve usability even further."
+$pkg_upstream_url="https://github.com/jedisct1/libsodium"
+$pkg_license=@("ISC")
+$pkg_source="https://github.com/jedisct1/libsodium/archive/$pkg_version.zip"
+$pkg_shasum="1a9d20aa5f06ad208dee765fd6ce7a2b06eab067ed5ca15f9caaf247f4358e67"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Build {
+    cd "$pkg_name-$pkg_version"
+    cd builds/msvc
+    msbuild.exe /m /p:Configuration=StaticRelease /p:Platform=x64 vs2015\libsodium.sln
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bin\x64\Release\v140\static\*" "$pkg_prefix\lib\" -Force
+}

--- a/nasm/plan.ps1
+++ b/nasm/plan.ps1
@@ -1,0 +1,15 @@
+$pkg_name="nasm"
+$pkg_distname="$pkg_name"
+$pkg_origin="core"
+$pkg_version="2.12.02"
+$pkg_description="The Netwide Assembler, NASM, is an 80x86 and x86-64 assembler designed for portability and modularity."
+$pkg_upstream_url="http://www.nasm.us/"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@("BSD-2-Clause")
+$pkg_source="http://www.nasm.us/pub/$pkg_distname/releasebuilds/${pkg_version}/win64/$pkg_distname-${pkg_version}-win64.zip"
+$pkg_shasum="6dc3a56979b2618f6bf9cc4e148f7dc99334b2e2c1aea0a9f2094128c950ca26"
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/$pkg_name-$pkg_version/*" "$pkg_prefix/bin" -Recurse -Force
+}

--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -1,0 +1,30 @@
+$pkg_name="openssl"
+$pkg_origin="core"
+$pkg_version="1.0.2n"
+$_pkg_version_text=($pkg_version).Replace(".", "_")
+$pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
+$pkg_upstream_url="https://www.openssl.org"
+$pkg_license=@("OpenSSL")
+$pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
+$pkg_shasum="2afd08c5347b35d3ea3a8791fa0c22c0951180ed010f5db28a34b06175a9379b"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
+$pkg_bin_dirs=@("bin")
+$pkg_include_dirs=@("include")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Build {
+    cd "$pkg_name-OpenSSL_$_pkg_version_text"
+    perl Configure VC-WIN64A --prefix=$pkg_prefix
+    ms\do_win64a
+    nmake -f ms\ntdll.mak
+}
+
+function Invoke-Install {
+    cd "$pkg_name-OpenSSL_$_pkg_version_text"
+    ms\do_win64a
+    nmake -f ms\ntdll.mak install
+}
+function Invoke-Check {
+    cd "$pkg_name-OpenSSL_$_pkg_version_text"
+    nmake -f ms\ntdll.mak test
+}

--- a/perl/plan.ps1
+++ b/perl/plan.ps1
@@ -1,0 +1,26 @@
+$pkg_name="perl"
+$pkg_origin="core"
+$pkg_version="5.26.1"
+$pkg_description="Safe, concurrent, practical language"
+$pkg_upstream_url="https://www.rust-lang.org/"
+$pkg_upstream_url="http://www.perl.org/"
+$pkg_license=@("gpl", "perlartistic")
+$pkg_source="https://github.com/Perl/perl5/archive/v$pkg_version.zip"
+$pkg_shasum="2b3747deadea0510ef9e567e6a8b692e7dd4ecad024f1a5a6108b971093a95fd"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/dmake")
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Build {
+    $Env:CCTYPE="MSVC140"
+    $Env:INST_TOP="$pkg_prefix"
+    cd perl5-$pkg_version\win32
+    dmake
+    dmake install
+}
+
+function Invoke-Check {
+    $Env:CCTYPE="MSVC140"
+    cd perl5-$pkg_version\win32
+    dmake test
+}

--- a/visual-cpp-build-tools-2015/plan.ps1
+++ b/visual-cpp-build-tools-2015/plan.ps1
@@ -31,6 +31,24 @@ $pkg_include_dirs=@(
   "Windows Kits\NETFXSDK\4.6\Include\um"
 )
 
+function Invoke-SetupEnvironment {
+  Push-RuntimeEnv "VCTargetsPath" "$pkg_prefix\Program Files\MSBuild\Microsoft.Cpp\v4.0\v140"
+  Push-RuntimeEnv "VcInstallDir" "$pkg_prefix\Program Files\Microsoft Visual Studio 14.0\VC"
+  Push-RuntimeEnv "WindowsSdkDir_81" "$pkg_prefix\Windows Kits\8.1"
+
+  Push-RuntimeEnv "CLTrackerSdkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "CLTrackerFrameworkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "LinkTrackerSdkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "LinkTrackerFrameworkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "LibTrackerSdkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "LibTrackerFrameworkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "RCTrackerSdkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+  Push-RuntimeEnv "RCTrackerFrameworkPath" "$pkg_prefix\Program Files\MSBuild\14.0\bin\amd64"
+
+  Push-RuntimeEnv "DisableRegistryUse" "true"
+  Push-RuntimeEnv "UseEnv" "true"
+}
+
 function Invoke-Unpack {
   Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/passive /layout $HAB_CACHE_SRC_PATH/$pkg_dirname"
   Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/zlib/plan.ps1
+++ b/zlib/plan.ps1
@@ -1,0 +1,24 @@
+$pkg_name="zlib"
+$pkg_origin="core"
+$pkg_version="1.2.11"
+$pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
+$pkg_description="Compression library implementing the deflate compression method found in gzip and PKZIP."
+$pkg_upstream_url="http://www.zlib.net/"
+$pkg_license=("zlib")
+$pkg_source="http://zlib.net/$pkg_file_name.zip"
+$pkg_shasum="d7510a8ee1918b7d0cad197a089c0a2cd4d6df05fee22389f67f115e738b178d"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015")
+$pkg_lib_dirs=@("lib")
+$pkg_include_dirs=@("include")
+
+function Invoke-Build {
+    cd "$pkg_name-$pkg_version"
+    msbuild /p:Configuration=Release /p:Platform=x64 "contrib\vstudio\vc14\zlibvc.sln"
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\contrib\vstudio\vc14\x64\ZlibDllRelease\zlibwapi.dll" "$pkg_prefix\lib\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\contrib\vstudio\vc14\x64\ZlibDllRelease\zlibwapi.lib" "$pkg_prefix\lib\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\zlib.h" "$pkg_prefix\include\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\zconf.h" "$pkg_prefix\include\" -Force
+}


### PR DESCRIPTION
this adds windows native plans for libsodium, perl, openssl, zlib,and more (see diff for all files) as well as update the environment variables for the visual studio 2015 plan, so native compilation will just work in any downstream plans.

Signed-off-by: Scott Hain <shain@chef.io>