### PR TITLE
[googletest] Add CMAKE_FIND_ROOT_PATH to make cmake ux better

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -19,8 +19,8 @@ Static C++ Library and Include Headers
 ## Usage
 
 If you require `gtest` and `gmock` just include `core/googletest` preferably in `pkg_build_deps`.  
-Habitat will then update `CFLAGS`, `CXXFLAGS`, `CPPFLAGS`, `LDFLAGS` and `PKG_CONFIG_PATH` with
-paths to the libs and includes.
+Habitat will then update `CFLAGS`, `CXXFLAGS`, `CPPFLAGS`, `LDFLAGS`, `PKG_CONFIG_PATH` and
+`CMAKE_FIND_ROOT_PATH` with paths to the libs and includes.
 
 ### CMake
 
@@ -55,12 +55,9 @@ do_prepare() {
 
 do_build() {
   pushd "${BUILD_DIR}" > /dev/null
-
-  _GTEST_PATH="$(pkg_path_for core/googletest)"
-
   cmake \
     -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
-    -DGTest_DIR="${_GTEST_PATH}/lib64/cmake/GTest" \
+    -DCMAKE_FIND_ROOT_PATH="${CMAKE_FIND_ROOT_PATH}" \
     ..
   make
 

--- a/googletest/plan.sh
+++ b/googletest/plan.sh
@@ -27,31 +27,41 @@ pkg_include_dirs=(include)
 pkg_lib_dirs=(lib64)
 pkg_pconfig_dirs=(lib64/pkgconfig)
 
+do_begin() {
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_SEPARATOR=";"
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_TYPE="aggregate"
+}
+
 do_setup_environment() {
   set_buildtime_env BUILD_DIR "build"
+
+  # this allows cmake users to utilize `CMAKE_FIND_ROOT_PATH` to find various cmake configs
+  push_runtime_env CMAKE_FIND_ROOT_PATH "${pkg_prefix}/lib64/cmake/GTest"
 }
 
 do_prepare() {
   mkdir -p "${BUILD_DIR}"
 
   # patch version as it is suppose to be 1.8.1
+  # ref: https://github.com/google/googletest/issues/1816
   sed -e "s/GOOGLETEST_VERSION 1.9.0/GOOGLETEST_VERSION ${pkg_version}/" -i CMakeLists.txt
 }
 
 do_build() {
   pushd "${BUILD_DIR}" || exit 1
-  cmake -Dgtest_build_samples="${DO_CHECK}" \
-      -Dgtest_build_tests="${DO_CHECK}" \
-      -Dgmock_build_tests="${DO_CHECK}" \
-      -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-      ..
-  make
+  cmake \
+    -Dgtest_build_samples="${DO_CHECK}" \
+    -Dgtest_build_tests="${DO_CHECK}" \
+    -Dgmock_build_tests="${DO_CHECK}" \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    ..
+  make -j"$(nproc --ignore=1)"
   popd || exit 1
 }
 
 do_check() {
   pushd "${BUILD_DIR}" || exit 1
-  CTEST_OUTPUT_ON_FAILURE=1 make test
+  CTEST_OUTPUT_ON_FAILURE=1 make test -j"$(nproc --ignore=1)"
   popd || exit 1
 }
 


### PR DESCRIPTION
This plan adds injecting paths of cmake configs to the CMAKE_FIND_ROOT_PATH to
allow cmake users have a better cmake experience. Just include
`-DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}` when calling `cmake`.

## Testing

```
hab studio enter
DO_CHECK=1 build googletest
```

Signed-off-by: Ben Dang <me@bdang.it>