### PR TITLE
[benchmark] Update version and add CMAKE_FIND_ROOT_PATH

### DIFF
--- a/benchmark/plan.sh
+++ b/benchmark/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=benchmark
 pkg_origin=core
-pkg_version=1.4.0
+pkg_version=1.4.1
 pkg_description="Google's microbenchmark support library"
 pkg_upstream_url=https://github.com/google/benchmark
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/google/benchmark/archive/v${pkg_version}.tar.gz"
 pkg_filename="v${pkg_version}.tar.gz"
-pkg_shasum=616f252f37d61b15037e3c2ef956905baf9c9eecfeab400cb3ad25bae714e214
+pkg_shasum=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
 pkg_deps=(
   core/gcc-libs
   core/glibc
@@ -19,37 +19,52 @@ pkg_build_deps=(
   core/gcc
   core/git
   core/googletest
-  core/googlemock
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
-BUILDDIR="build"
+do_begin() {
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_SEPARATOR=";"
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_TYPE="aggregate"
+}
+
+do_setup_environment() {
+  set_buildtime_env BUILD_DIR "_build"
+
+  # this allows cmake users to utilize `CMAKE_FIND_ROOT_PATH` to find various cmake configs
+  push_runtime_env CMAKE_FIND_ROOT_PATH "${pkg_prefix}/lib/cmake/benchmark"
+}
 
 do_prepare() {
-  mkdir -p "$BUILDDIR"
+  mkdir -p "${BUILD_DIR}"
 }
 
 do_build() {
   GTEST_DIR="$(pkg_path_for core/googletest)"
 
-  cd "$BUILDDIR" || exit
+  pushd "${BUILD_DIR}" || exit 1
+
   cmake \
-    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DBENCHMARK_ENABLE_TESTING="${DO_CHECK}" \
+    -DBENCHMARK_ENABLE_GTEST_TESTS="${DO_CHECK}" \
+    -DGTEST_LIBRARY="${GTEST_DIR}/lib64/libgtest.a" \
+    -DGTEST_MAIN_LIBRARY="${GTEST_DIR}/lib64/libgtest_main.a" \
+    -DGTEST_INCLUDE_DIR="${GTEST_DIR}/include" \
     -DCMAKE_BUILD_TYPE="RELEASE" \
-    -DGTEST_LIBRARY="$GTEST_DIR/lib/libgtest.a" \
-    -DGTEST_MAIN_LIBRARY="$GTEST_DIR/lib/libgtest_main.a" \
-    -DGTEST_INCLUDE_DIR="$GTEST_DIR/include" \
     ..
-  make
+  make -j"$(nproc --ignore=1)"
+  popd || exit 1
 }
 
 do_check() {
-  cd "$BUILDDIR" || exit
-  make test
+  pushd "${BUILD_DIR}" || exit 1
+  make test -j"$(nproc --ignore=1)"
+  popd || exit 1
 }
 
 do_install() {
-  cd "$BUILDDIR" || exit
+  pushd "${BUILD_DIR}" || exit 1
   make install
+  popd || exit 1
 }


### PR DESCRIPTION
- Patch update for google benchmark.
- This plan adds injecting paths of cmake configs to the CMAKE_FIND_ROOT_PATH to
allow cmake users have a better cmake experience. Just include
`-DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}` when calling `cmake`.

## Testing

```
hab studio enter
DO_CHECK=1 build benchmark
```

## NOTE

This commit depends on #1925.

Signed-off-by: Ben Dang <me@bdang.it>