### PR TITLE
[prometheus-cpp] Update version and add CMAKE_FIND_ROOT_PATH

### DIFF
--- a/prometheus-cpp/plan.sh
+++ b/prometheus-cpp/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=prometheus-cpp
 pkg_origin=core
-pkg_version=0.4.2
+pkg_version=0.5.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://github.com/jupp0r/prometheus-cpp"
 pkg_description="Prometheus Client Library for Modern C++"
@@ -18,12 +18,23 @@ pkg_build_deps=(
   core/ninja
   core/gcc
   core/git
+  core/pkg-config
 )
 
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib64)
 
-BUILDDIR="_build"
+do_begin() {
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_SEPARATOR=";"
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_TYPE="aggregate"
+}
+
+do_setup_environment() {
+  set_buildtime_env BUILDDIR "_build"
+
+  # this allows cmake users to utilize `CMAKE_FIND_ROOT_PATH` to find various cmake configs
+  push_runtime_env CMAKE_FIND_ROOT_PATH "${pkg_prefix}/lib64/cmake/prometheus-cpp"
+}
 
 do_download() {
   GIT_SSL_CAINFO="$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem"
@@ -65,23 +76,27 @@ do_build() {
   pushd "${BUILDDIR}" || exit 1
   cmake \
     -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
-    -DBUILD_TESTING="${DO_CHECK}" \
+    -DCMAKE_FIND_ROOT_PATH="${CMAKE_FIND_ROOT_PATH}" \
+    -DENABLE_COMPRESSION="OFF" \
+    -DENABLE_TESTING="${DO_CHECK}" \
     -DGoogleBenchmark_LIBRARY="${_BENCHMARK_PATH}/lib/libbenchmark.a" \
     -DGoogleBenchmark_INCLUDE_DIR="${_BENCHMARK_PATH}/include" \
     -DCURL_LIBRARY="${_CURL_PATH}/lib/libcurl.so" \
     -DCURL_INCLUDE_DIR="${_CURL_PATH}/include" \
     -G Ninja \
     ..
-
   ninja
+  popd || exit 1
 }
 
 do_check() {
   pushd "${BUILDDIR}" || exit 1
   LD_LIBRARY_PATH="$(pkg_path_for core/glibc)/lib:$(pkg_path_for core/gcc)/lib" ctest -V
+  popd || exit 1
 }
 
 do_install() {
   pushd "${BUILDDIR}" || exit 1
   ninja install
+  popd || exit 1
 }


### PR DESCRIPTION
- Update version to 0.5.0.
- This plan adds injecting paths of cmake configs to the CMAKE_FIND_ROOT_PATH to
allow cmake users have a better cmake experience. Just include
`-DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}` when calling `cmake`.

## Testing

```
hab studio enter
DO_CHECK=1 build prometheus-cpp
```
Signed-off-by: Ben Dang <me@bdang.it>