### PR TITLE
[ansible] Update to 2.6.6, add tests

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version="2.4.3.0-1"
+pkg_version="2.6.6"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="0bcb583f2abaa580c337462a81903ff3f925d10c367da466c2c0354479432683"
+pkg_shasum="dbfa7e263d88caf222c070a25b3fb7e5cf2f558470f5a953e712c4b88c1f9d71"
 pkg_deps=(
   core/libffi
   core/python2
@@ -18,10 +18,7 @@ pkg_build_deps=(
   core/openssl
 )
 pkg_bin_dirs=(bin)
-pkg_description="Ansible is a radically simple IT automation platform that makes your applications \
-and systems easier to deploy. Avoid writing scripts or custom code to deploy and update your \
-applications— automate in a language that approaches plain English, using SSH, with no agents to \
-install on remote systems."
+pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."
 pkg_upstream_url="https://www.ansible.com/"
 
 do_setup_environment() {

--- a/ansible/tests/test.bats
+++ b/ansible/tests/test.bats
@@ -1,0 +1,11 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(ansible --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help Command" {
+  run ansible --help
+  [ $status -eq 0 ]
+}

--- a/ansible/tests/test.sh
+++ b/ansible/tests/test.sh
@@ -18,7 +18,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 fi
 
-PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path ${pkg_origin}/ansible)/lib/python2.7/site-packages"
+PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path "${pkg_origin}/ansible")/lib/python2.7/site-packages"
 export PYTHONPATH
 
 bats "${TESTDIR}/test.bats"

--- a/ansible/tests/test.sh
+++ b/ansible/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+export PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path ${pkg_origin}/ansible)/lib/python2.7/site-packages"
+
+bats "${TESTDIR}/test.bats"

--- a/ansible/tests/test.sh
+++ b/ansible/tests/test.sh
@@ -18,6 +18,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 fi
 
-export PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path ${pkg_origin}/ansible)/lib/python2.7/site-packages"
+PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path ${pkg_origin}/ansible)/lib/python2.7/site-packages"
+export PYTHONPATH
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio run ansible/tests/test.sh
```

### Sample output

```
1..2
ok 1 Version matches
ok 2 Help Command
```