### PR TITLE
[artifactory-pro] Updating version and adding tests

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.0.0
+pkg_version=6.5.2
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=4c5fa3a86e3b1d07979ff011af3b58481e519faa6ee27eb23622a6fe00d89935
+pkg_shasum=28a13ed7287bfecf27323b37b25a4366fc94b24424ccf4d20d68ab3cfb2edc49
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port

--- a/artifactory-pro/tests/helpers.bash
+++ b/artifactory-pro/tests/helpers.bash
@@ -1,0 +1,24 @@
+# Usage: test_listen <protocol> <port> [wait-duration]
+# protocol: tcp or udp
+# port: int
+# wait-duration: time in seconds
+test_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-3}
+  nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
+  return $?
+}
+
+wait_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-1}
+  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
+    sleep 1
+  done
+}

--- a/artifactory-pro/tests/test.bats
+++ b/artifactory-pro/tests/test.bats
@@ -1,0 +1,7 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+load helpers
+
+@test "Port Listen TCP/8081" {
+  test_listen tcp 8081
+  [ "$?" -eq 0 ]
+}

--- a/artifactory-pro/tests/test.sh
+++ b/artifactory-pro/tests/test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+source "${TESTDIR}/helpers.bash"
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+
+# Wait for supervisor to start
+echo "Waiting for supervisor to start"
+wait_listen tcp 9632 30
+
+source "${PLANDIR}/plan.sh"
+# Unload the service if its already loaded.
+hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+fi
+
+# Wait for 30 seconds on first check, to ensure service is up.
+echo "Waiting for Artifactory to start"
+wait_listen tcp 8081 60
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Hey all,

This is a simple version bump but with tests added in. To test this build:

```
hab studio enter
./tests/test.sh
```
The output should read:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Please let me know if you have any questions. 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>