### PR TITLE
[vault] Updated vault to 0.11.4

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.11.3
+pkg_version=0.11.4
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=b921abf4ade14087dbc21b6b353aa65f0630fad3275f27641c48b3d36093af25
+pkg_shasum=3e44826ffcf3756a72d6802d96ea244e605dad362ece27d5c8f8839fb69a7079
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./vault/tests/test.sh
```

### Sample output

```
★ Binlinked vault from rakops/vault/0.11.4/20181025015044 to /bin/vault
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```