### PR TITLE
[node] Updated NodeJS to v11. Fixed Windows v10 to same version as Linux

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -902,6 +902,11 @@ plan_path = "node10"
 paths = [
   "node/*",
 ]
+[node11]
+plan_path = "node11"
+paths = [
+  "node/*",
+]
 [node_exporter]
 plan_path = "node_exporter"
 [npth]

--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="10.8.0"
+$pkg_version="11.0.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="9d03d6bc78d7375fa549005c9b12cf5da4b01ee52b60834107f5f603d82a68f2"
+$pkg_shasum="a4be82fad7610131a68507aad93db4bb5809025af499b667e8201c93ee85aea4"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=10.11.0
+pkg_version=11.0.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz
-pkg_shasum=f721552552fb11ef99aba290fc6e696a8647adc98d643db6651e81ed07c4037e
+pkg_shasum=1f7e67f8d713e6a0c3b786d3b3d2eb03b7825cfbed395a5a9565e3c606caea3d
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node11/README.md
+++ b/node11/README.md
@@ -1,0 +1,15 @@
+# node10
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node11/plan.ps1
+++ b/node11/plan.ps1
@@ -1,8 +1,8 @@
 . "..\node\plan.ps1"
 
-$pkg_name="node10"
+$pkg_name="node11"
 $pkg_origin="core"
-$pkg_version="10.11.0"
+$pkg_version="11.0.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="46cc9fe075db65a081607a8c803d098deccbb0f1ab3b3dafb9651ec9c0ac853f"
+$pkg_shasum="a4be82fad7610131a68507aad93db4bb5809025af499b667e8201c93ee85aea4"

--- a/node11/plan.sh
+++ b/node11/plan.sh
@@ -1,0 +1,12 @@
+source "../node/plan.sh"
+
+pkg_name=node11
+pkg_origin=core
+pkg_version=11.0.0
+pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
+pkg_license=('MIT')
+pkg_upstream_url=https://nodejs.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
+pkg_shasum=1f7e67f8d713e6a0c3b786d3b3d2eb03b7825cfbed395a5a9565e3c606caea3d
+pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build node
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
node --version
node --help
```

Node versions should be 11.0.0, and both version and help commands run successfully.