### PR TITLE
[opa] add OPA v0.10.0

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -918,6 +918,8 @@ plan_path = "ocaml"
 plan_path = "ocamlbuild"
 [omniORB]
 plan_path = "omniORB"
+[opa]
+plan_path = "opa"
 [opam]
 plan_path = "opam"
 [openjpeg]

--- a/opa/README.md
+++ b/opa/README.md
@@ -1,0 +1,47 @@
+# Open Policy Agent (OPA)
+
+OPA is a lightweight general-purpose policy engine that can be co-located with your service.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+Install the package, and load the OPA service:
+
+```
+hab pkg install core/opa
+hab svc load core/opa
+```
+
+This will start OPA with the default configuration.
+
+It is started with its default settings -- more complex configuration
+should be done in configuration plans.
+
+## CLI usage
+
+The service binary can also be used interactively:
+
+```
+# hab pkg exec core/opa opa run
+OPA 0.10.0 (commit dbf54cde-dirty, built at 2018-10-26T07:58:50Z)
+
+Run 'help' to see a list of commands.
+
+> 2+2 == 5
+false
+>
+```
+
+## Bindings
+
+This package exposes the service's address, which can be either
+`ip:port`, or a UNIX socket address.
+
+* address

--- a/opa/default.toml
+++ b/opa/default.toml
@@ -1,0 +1,6 @@
+[service]
+address = "127.0.0.1:8181"
+
+[log]
+level = "info" # debug, info, error
+format = "text" # text, json

--- a/opa/hooks/run
+++ b/opa/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+exec opa run -s \
+  -l {{cfg.log.level}} \
+  --log-format {{cfg.log.format}} \
+  -a {{cfg.service.address}}

--- a/opa/plan.sh
+++ b/opa/plan.sh
@@ -1,0 +1,47 @@
+gopkg="github.com/open-policy-agent/opa"
+pkg_name=opa
+pkg_description="Open Policy Agent (OPA) is a lightweight general-purpose policy engine that can be co-located with your service."
+pkg_origin=core
+pkg_version="0.10.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_source="https://$gopkg"
+pkg_upstream_url="https://www.openpolicyagent.org/"
+pkg_build_deps=(core/bash)
+pkg_exports=(
+  [address]=service.address
+)
+pkg_deps=()
+pkg_bin_dirs=(bin)
+pkg_scaffolding=core/scaffolding-go
+scaffolding_go_base_path=github.com/open-policy-agent
+scaffolding_go_build_deps=()
+
+do_prepare() {
+  pushd "${scaffolding_go_gopath:?}/src/${gopkg}"
+    sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" -i build/*.sh
+    sed -e "s#hostname -f#echo \"bldr.habitat.sh\"#" -i build/get-build-hostname.sh
+  popd
+}
+
+do_download() {
+  # `-d`: don't let go build it, we'll have to build this ourselves
+  build_line "go get -d ${gopkg}"
+  go get -d "$gopkg"
+
+  pushd "${scaffolding_go_gopath:?}/src/${gopkg}"
+    build_line "checking out $pkg_version"
+    git reset --hard "v${pkg_version}"
+  popd
+}
+
+do_build() {
+  pushd "${scaffolding_go_gopath:?}/src/${gopkg}"
+    PATH="${scaffolding_go_gopath:?}/bin:$PATH" make deps build
+  popd
+}
+
+do_install() {
+  build_line "copying binary"
+  cp "${scaffolding_go_gopath:?}/src/${gopkg}/opa_linux_amd64" "${pkg_prefix}/bin/opa"
+}

--- a/opa/tests/helpers.bash
+++ b/opa/tests/helpers.bash
@@ -1,0 +1,24 @@
+# Usage: test_listen <protocol> <port> [wait-duration]
+# protocol: tcp or udp
+# port: int
+# wait-duration: time in seconds
+test_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-3}
+  nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
+  return $?
+}
+
+wait_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-1}
+  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
+    sleep 1
+  done
+}

--- a/opa/tests/test.bats
+++ b/opa/tests/test.bats
@@ -1,0 +1,17 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+load helpers
+
+@test "Port Listen TCP/8181" {
+  test_listen tcp 8181
+  [ "$?" -eq 0 ]
+}
+
+@test "/v1/data/system/version endpoint returns version" {
+  curl -f http://127.0.0.1:8181/v1/data/system/version |
+    jq -e --arg vsn "$pkg_version" '.result.Version == $vsn'
+}
+
+@test "/v1/query endpoint returns an answer" {
+  curl -f http://127.0.0.1:8181/v1/query -d '{"query": "truth := 2+2 == 5"}' |
+    jq -e '.result[] | .truth == false'
+}

--- a/opa/tests/test.sh
+++ b/opa/tests/test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+source "${TESTDIR}/helpers.bash"
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+hab pkg install -b core/jq-static core/curl
+
+# Wait for supervisor to start
+echo "Waiting for supervisor to start"
+wait_listen tcp 9632 30
+
+source "${PLANDIR}/plan.sh"
+# Unload the service if its already loaded.
+hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  popd > /dev/null
+  set +e
+fi
+
+source "${PLANDIR}/results/last_build.env"
+hab pkg install --binlink --force "${PLANDIR}/results/${pkg_artifact}"
+hab svc load "${pkg_ident}"
+
+# Wait for 5 seconds on first check, to ensure service is up.
+echo "Waiting for opa to start (5s)"
+wait_listen tcp 8181 5
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
OPA is https://openpolicyagent.org/. v0.10.0 is [hot off the press](https://github.com/open-policy-agent/opa/releases/tag/v0.10.0).

The included configuration is minimal, I assumed that was how a core-plan should be. Also, I mostly want this (right now) for using the CLI tool, which is part of the package (it's one binary to be used in a myriad of ways).

Includes a README and some tests. 😃 (With the latter modeled after dex's tests, the former after gnatsd's README.)