### PR TITLE
[php] Add gcc-libs to pkg_deps

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -23,6 +23,7 @@ pkg_deps=(
   core/readline
   core/zip
   core/zlib
+  core/gcc-libs
 )
 pkg_build_deps=(
   core/autoconf
@@ -38,11 +39,7 @@ pkg_include_dirs=(include)
 pkg_interpreters=(bin/php)
 
 do_build() {
-  # The configuration scripts unset LD_RUN_PATH when testing linking for configured options,
-  # so the resulting 'conftest' binaries cannot run due to being unable to find libstdc++.so
-  # This allows those binaries to execute while limiting the scope of LD_LIBRARY_PATH
-  # to the execution of `./configure`.
-  LD_LIBRARY_PATH="$(pkg_path_for gcc)/lib" ./configure --prefix="${pkg_prefix}" \
+  ./configure --prefix="${pkg_prefix}" \
     --enable-exif \
     --enable-fpm \
     --with-fpm-user=hab \

--- a/php/test/libzip_support.php
+++ b/php/test/libzip_support.php
@@ -1,0 +1,5 @@
+<?
+  # The below will exit with a fatal error if libzip is not supported.
+  $za = new ZipArchive;
+  echo("Libzip is supported.\n");
+?>

--- a/php/test/test.sh
+++ b/php/test/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash 
+
+set -euo pipefail 
+
+if [[ -z "${1:-}" ]]; then 
+	echo "Usage: test.sh <fully qualified package ident>"
+	echo 
+	echo "ex: test.sh core/php/7.2.8/20181108151533"
+	exit 1
+fi
+
+pkg_ident=${1}
+
+# This depends on the package being present on the depot OR
+# in your local cache. If you're testing locally this is a 
+# reasonably safe assumption to make, as long as the cache 
+# isn't cleaned aggressively 
+hab pkg install $pkg_ident 
+
+hab pkg exec $pkg_ident php "$(dirname $0)"/libzip_support.php 
+

--- a/php/test/test.sh
+++ b/php/test/test.sh
@@ -1,10 +1,10 @@
-#!/bin/bash 
+#!/bin/bash
 
-set -euo pipefail 
+set -euo pipefail
 
-if [[ -z "${1:-}" ]]; then 
+if [[ -z "${1:-}" ]]; then
 	echo "Usage: test.sh <fully qualified package ident>"
-	echo 
+	echo
 	echo "ex: test.sh core/php/7.2.8/20181108151533"
 	exit 1
 fi
@@ -12,10 +12,9 @@ fi
 pkg_ident=${1}
 
 # This depends on the package being present on the depot OR
-# in your local cache. If you're testing locally this is a 
-# reasonably safe assumption to make, as long as the cache 
-# isn't cleaned aggressively 
-hab pkg install $pkg_ident 
+# in your local cache. If you're testing locally this is a
+# reasonably safe assumption to make, as long as the cache
+# isn't cleaned aggressively
+hab pkg install "$pkg_ident"
 
-hab pkg exec $pkg_ident php "$(dirname $0)"/libzip_support.php 
-
+hab pkg exec "$pkg_ident" php "$(dirname "$0")"/libzip_support.php


### PR DESCRIPTION
This PR resolves downstream build errors in Drupal

https://bldr.habitat.sh/#/pkgs/core/drupal/jobs/1103619923366256640

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>