### PR TITLE
[ansible] Update ansible to 2.7.1

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version="2.6.6"
+pkg_version="2.7.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="dbfa7e263d88caf222c070a25b3fb7e5cf2f558470f5a953e712c4b88c1f9d71"
+pkg_shasum="354f3fcf5fa837d48a8cd9bff7c74db0c85a2031d608109481c467a7d57cc3b9"
 pkg_deps=(
   core/libffi
   core/python2


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./ansible/tests/test.sh
```

### Sample Output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
```