### PR TITLE
[scaffolding-chef] Use non-daemonized chef-client run

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -53,9 +53,10 @@ cd {{pkg.path}}
 
 exec 2>&1
 while true; do
-chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
+SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
+sleep \$SPLAY_DURATION
+chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.interval}}
 sleep {{cfg.interval}}
-sleep {{cfg.splay}}
 done
 EOF
   chown 0755 "$pkg_prefix/hooks/run"

--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -52,8 +52,11 @@ export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 cd {{pkg.path}}
 
 exec 2>&1
+while true; do
 chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once
-exec chef-client -z -i {{cfg.interval}} -s {{cfg.splay}} -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb
+sleep {{cfg.interval}}
+sleep {{cfg.splay}}
+done
 EOF
   chown 0755 "$pkg_prefix/hooks/run"
 }

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.1.3"
+pkg_version="0.1.4"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This modifies the method by which we run the chef-client, to ensure we aren't consuming unnecessary system resources. It also fixes an edge case where the chef-client could spawn multiple times if the habitat supervisor was restarted rapidly. This method instead will always give us a clean run, and will still respect the interval and splay options by using a simple `sleep`. It also ensures that Habitat's application lifecycle hook (the run hook) executes the chef-client directly, which is nice because you don't have to wait for the chef-client to execute. (This is why there were two calls to chef-client -z in the previous code).

This is a subtle but important change.

Would like some extra throughts from @jonlives before merging.