### PR TITLE
[strace] Update strace to 4.25

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=4.24
+pkg_version=4.25
 pkg_license=("BSD-3-Clause-LBNL")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=1f4e59fc1edfa2bfb4adf2a748623dc25b105ec79713dd84404199f91b0b0634
+pkg_shasum=d685f8e65470b7832c3aff60c57ab4459f26ff89f07c10f92bd70ee89efac701
 pkg_deps=(
   core/glibc
   core/libunwind


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./strace/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```
