### PR TITLE
[curl] Update curl to 7.62.0

### DIFF
--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.54.1
+pkg_version=7.62.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=cd404b808b253512dafec4fed0fb2cc98370d818a7991826c3021984fc27f9d0
+pkg_shasum=55ccd5b5209f8cc53d4250e2a9fd87e6f67dd323ae8bd7d06b072cfcbb7836cb
 pkg_deps=(
   core/cacerts
   core/glibc


### PR DESCRIPTION
Addresses security vulnerabilities:

[CVE-2018-16839](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16839)
[CVE-2018-16840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840)
[CVE-2018-16842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16842)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>