### PR TITLE
[curl-static-musl] Update curl-static-musl to 7.62.0

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source ../curl/plan.sh
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.54.1
+pkg_version=7.62.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/


### PR DESCRIPTION
Refs #1956

Same version bump for musl build.

Signed-off-by: Graham Weldon <graham@grahamweldon.com>