### PR TITLE
[netdata] add missing runtime shell dependencies

### DIFF
--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -20,6 +20,8 @@ pkg_build_deps=(
 
 pkg_deps=(
   core/bash
+  core/curl
+  core/gawk
   core/glibc
   core/python
   core/util-linux


### PR DESCRIPTION
Some of the stock collector scripts need `curl` and `awk`, this PR fixes some of them and eliminates error log noise in environments that don't otherwise provide them