### PR TITLE
[dotnet-core] Updated version to 2.1.5

### DIFF
--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core"
 $pkg_origin="core"
-$pkg_version="2.0.6"
+$pkg_version="2.1.5"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/8/D/A/8DA04DA7-565B-4372-BBCE-D44C7809A467/dotnet-runtime-$pkg_version-win-x64.zip"
-$pkg_shasum="d10abca0c869e72fcb45fe75940b1f28aed5dbbb1d5b048737d71d732a7b6670"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/ce443d89-75f1-4122-aaa8-c094a9017b4a/255b06ace4207a8ee923758160ed01c3/dotnet-runtime-${pkg_version}-win-x64.zip"
+$pkg_shasum="bfee610814720072bf67d3cc5738345a83ebb517add66f4fdaea280f417e91ed"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=2.1.4
+pkg_version=2.1.5
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.microsoft.com/download/A/7/8/A78F1D25-8D5C-4411-B544-C7D527296D5E/dotnet-runtime-2.1.4-linux-x64.tar.gz"
-pkg_shasum=55e6d5c93ab5bb492c82b8d0d57d0d67ac720733f10c18605d8b93d26866adb2
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/05a71d80-3e59-4f1f-8298-2697013e261c/be191f2f4f4db74c29030008ed3632f0/dotnet-runtime-2.1.5-linux-x64.tar.gz"
+pkg_shasum=2962adbe0f52dc072e07f083ada37e5441a1981970196364612322f825c579d1
 pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Hey all,

This update brings both the Windows and Linux versions up to 2.1.5. To test this build, run the following commands in the hab studio:
```
./test/test.sh
```
You should see the following results:
```
 ✓ Version matches
 ✓ Help command
```

Please let me know if there are any questions. Thanks!!