### PR TITLE
[memcached] Update memcached to 1.5.12

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.10
+pkg_version=1.5.12
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
-pkg_source=http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=494c060dbd96d546c74ab85a3cc3984d009b4423767ac33e05dd2340c01f1c4b
+pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=c02f97d5685617b209fbe25f3464317b234d765b427d254c2413410a5c095b29
 pkg_deps=(
   core/glibc
   core/cyrus-sasl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./memcached/tests/test.io
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

6 tests, 0 failures
```