### PR TITLE
Convert to unix-style line endings

### DIFF
--- a/node6/plan.ps1
+++ b/node6/plan.ps1
@@ -6,4 +6,3 @@ $pkg_version="6.14.3"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
 $pkg_shasum="f67a3f3e24c25859c429fbd576d6d89301c74b5fff70533f4bcc97351df6dc02"
-


### PR DESCRIPTION
We are running into issues with scripting that uses the core plans directory manifest because the node 6 plan.ps1 file has Windows line endings.  This fix converts the line endings to Unix style. This conforms with other Windows ps1 files (eg, node10).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-138747032](https://user-images.githubusercontent.com/13542112/48030461-fcf80980-e105-11e8-814a-2757495f7613.gif)
