### PR TITLE
[openvpn] Fixes run and updates to 2.4.6

### DIFF
--- a/openvpn/hooks/run
+++ b/openvpn/hooks/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 #
-{{pkgPathFor "core/openvpn"}}/bin/openvpn --config {{pkg.svc_config_path}}/server.conf
+openvpn --config {{pkg.svc_config_path}}/server.conf

--- a/openvpn/plan.sh
+++ b/openvpn/plan.sh
@@ -1,22 +1,54 @@
 pkg_name=openvpn
 pkg_origin=core
-pkg_version=2.3.11
+pkg_version=2.4.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv2')
-pkg_source=https://swupdate.openvpn.org/community/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=9117a4434fd35e61cf94f9ee7ef84b7aecbc6fa556f779ff599560f219756163
-pkg_deps=(core/glibc core/openssl core/lzo)
-pkg_build_deps=(core/gcc core/coreutils core/make core/busybox-static)
-pkg_bin_dirs=(bin)
+pkg_license=('GPL-2.0')
+pkg_description="OpenVPN is an open source VPN daemon"
+pkg_upstream_url="https://openvpn.net/"
+pkg_source="https://swupdate.openvpn.org/community/releases/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="738dbd37fcf8eb9382c53628db22258c41ba9550165519d9200e8bebaef4cbe2"
+pkg_deps=(
+  core/glibc
+  core/lz4
+  core/lzo
+  core/openssl
+  core/zlib
+)
+pkg_build_deps=(
+  core/busybox-static
+  core/coreutils
+  core/cmake
+  core/file
+  core/gcc
+  core/git
+  core/make
+  core/pkg-config
+)
+pkg_bin_dirs=(sbin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
 
 do_build() {
   ./configure \
     --disable-plugin-auth-pam \
-    --prefix=${pkg_prefix} \
-    --exec-prefix=${pkg_prefix} \
-    --sbindir=${pkg_prefix}/bin \
+    --prefix"=${pkg_prefix}" \
     --enable-iproute2
   make
+}
+
+do_check() {
+  make check
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
 }


### PR DESCRIPTION
> Closes #1409 

Me again, this time the package is upgraded and I added the `do_check()` callback implementation.

I still don't know how to configure openvpn myself, but I think this PR will put the package in a better place.

The alternative would be to just remove it if no one knows how to test it since it's currently broken anyways...

Signed-off-by: Romain Sertelon <romain@sertelon.fr>