### PR TITLE
[filebeat] Update filebeat to 6.4.3, add tests

### DIFF
--- a/filebeat/plan.sh
+++ b/filebeat/plan.sh
@@ -1,7 +1,6 @@
-# shellcheck disable=SC2164
 pkg_name=filebeat
 pkg_origin=core
-pkg_version="6.3.1"
+pkg_version="6.4.3"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)
@@ -16,9 +15,8 @@ pkg_description="Lightweight shipper for logfiles"
 pkg_upstream_url="https://www.elastic.co/products/beats/filebeat"
 
 do_download() {
-  GOPATH=$(dirname "${HAB_CACHE_SRC_PATH}")
+  GOPATH="$(dirname "${HAB_CACHE_SRC_PATH}")"
   export GOPATH
-  build_line "Fetching Go sources."
   go get github.com/elastic/beats/filebeat
   pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/filebeat" > /dev/null
   git checkout "v${pkg_version}"

--- a/filebeat/tests/test.bats
+++ b/filebeat/tests/test.bats
@@ -1,0 +1,24 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v filebeat)" ]
+}
+
+@test "Version matches" {
+  result="$(filebeat version | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run filebeat --help
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "filebeat\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep -v "test" | grep filebeat | wc -l)"
+  [ "${result}" -eq 1 ]
+}

--- a/filebeat/tests/test.sh
+++ b/filebeat/tests/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static wc
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 5
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Testing

```
hab studio enter
./filebeat/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

5 tests, 0 failures
```
