### PR TITLE
[elasticsearch5] Update elasticsearch5 to 5.6.13, fix missing deps, added tests

### DIFF
--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -9,6 +9,7 @@ pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_
 pkg_shasum=b26e3546784b39ce3eacc10411e68ada427c5764bcda3064e9bb284eca907983
 pkg_deps=(
   core/coreutils-static
+  core/busybox-static
   core/glibc
   core/jre8
   core/wget

--- a/elasticsearch5/README.md
+++ b/elasticsearch5/README.md
@@ -1,0 +1,41 @@
+# Elasticsearch5
+
+Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+Install the package, and load the serivce:
+
+```
+hab pkg install core/elasticsearch5
+hab svc load core/elasticsearch5
+```
+
+## Bindings
+
+Services consuming Elasticsearch can bind via:
+
+```
+hab start origin/package --bind elastic:elasticsearch5.default
+```
+
+Elasticsearch's contract presents the following ports to bind to:
+
+* `http-port`
+* `transport-port`
+
+## Topologies
+
+Currently this plan supports standalone topology. Pull requests to ease the leader-follower story are welcomed!
+
+## Update Strategies
+
+No update strategy or at-once update strategy works fine in a single-node installation.

--- a/elasticsearch5/plan.sh
+++ b/elasticsearch5/plan.sh
@@ -1,47 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../elasticsearch/plan.sh"
+
 pkg_name=elasticsearch5
+pkg_distname=elasticsearch
 pkg_origin=core
-pkg_version=5.6.4
+pkg_version=5.6.13
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Open Source, Distributed, RESTful Search Engine"
 pkg_upstream_url="https://elastic.co"
 pkg_license=('Revised BSD')
-pkg_source=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz
-pkg_shasum=1098fc776fae8c74e65f8e17cf2ea244c1d07c4e6711340c9bb9f6df56aa45b0
+pkg_source=https://artifacts.elastic.co/downloads/${pkg_distname}/${pkg_distname}-${pkg_version}.tar.gz
+pkg_shasum=6800471e65cf18f3580a5d88f1f9dac79c220408aef4bf18cccf295a5211b6b3
 pkg_dirname="elasticsearch-${pkg_version}"
-pkg_deps=(
-  core/busybox-static
-  core/glibc
-  core/jre8
-)
-pkg_bin_dirs=(es/bin)
-pkg_binds_optional=(
-  [elasticsearch]="http-port transport-port"
-)
-pkg_lib_dirs=(es/lib)
-pkg_exports=(
-  [http-port]=network.port
-  [transport-port]=transport.port
-)
-pkg_exposes=(http-port transport-port)
-
-do_build() {
-  return 0
-}
-
-do_install() {
-  install -vDm644 README.textile "${pkg_prefix}/README.textile"
-  install -vDm644 LICENSE.txt "${pkg_prefix}/LICENSE.txt"
-  install -vDm644 NOTICE.txt "${pkg_prefix}/NOTICE.txt"
-
-  # Elasticsearch is greedy when grabbing config files from /bin/..
-  # so we need to put the untemplated config dir out of reach
-  mkdir -p "${pkg_prefix}/es"
-  cp -a ./* "${pkg_prefix}/es"
-
-  # jvm.options needs to live relative to the binary.
-  # mkdir -p mkdir -p "$pkg_prefix/es/config"
-  # install -vDm644 config/jvm.options "$pkg_prefix/es/config/jvm.options"
-
-  # Delete unused binaries to save space
-  rm "${pkg_prefix}/es/bin/"*.bat "${pkg_prefix}/es/bin/"*.exe
-}

--- a/elasticsearch5/tests/test.bats
+++ b/elasticsearch5/tests/test.bats
@@ -1,0 +1,29 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v elasticsearch)" ]
+}
+
+@test "Version matches" {
+  result="$(elasticsearch --version | awk -F',' '{print $1}')"
+  [ "$result" = "Version: ${pkg_version}" ]
+}
+
+@test "Help command" {
+  run elasticsearch --help
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "elasticsearch5\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep -v "test" | grep elasticsearch5 | wc -l)"
+  [ "${result}" -eq 1 ]
+}
+
+@test "Listening on ports 9200, 9300" {
+  [ "$(netstat -peanut | grep java | awk '{print $4}' | awk -F':' '{print $2}' | grep 9200)" ]
+  [ "$(netstat -peanut | grep java | awk '{print $4}' | awk -F':' '{print $2}' | grep 9300)" ]
+}

--- a/elasticsearch5/tests/test.bats
+++ b/elasticsearch5/tests/test.bats
@@ -27,3 +27,9 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   [ "$(netstat -peanut | grep java | awk '{print $4}' | awk -F':' '{print $2}' | grep 9200)" ]
   [ "$(netstat -peanut | grep java | awk '{print $4}' | awk -F':' '{print $2}' | grep 9300)" ]
 }
+
+@test "Healthy response from status endpoint" {
+  local endpoint=$(netstat -peanut | grep 9200 | grep LISTEN | awk '{print $4}')
+  run curl -s -o /dev/null -w "%{http_code}" http://${endpoint} 
+  [ "$output" = "200" ]
+}

--- a/elasticsearch5/tests/test.bats
+++ b/elasticsearch5/tests/test.bats
@@ -30,6 +30,6 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Healthy response from status endpoint" {
   local endpoint=$(netstat -peanut | grep 9200 | grep LISTEN | awk '{print $4}')
-  run curl -s -o /dev/null -w "%{http_code}" http://${endpoint} 
+  run curl -s -o /dev/null -w "%{http_code}" http://${endpoint}
   [ "$output" = "200" ]
 }

--- a/elasticsearch5/tests/test.sh
+++ b/elasticsearch5/tests/test.sh
@@ -28,7 +28,9 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 
   # Give some time for the service to start up
-  sleep 5
+  local _seconds=15
+  echo "Waiting for ${pkg_name} to start up (${_seconds} seconds)"
+  sleep ${_seconds}
 fi
 
 bats "${TESTDIR}/test.bats"

--- a/elasticsearch5/tests/test.sh
+++ b/elasticsearch5/tests/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install --binlink core/coreutils-static
+hab pkg install --binlink core/glibc
+hab pkg install --binlink core/jre8
+hab pkg install --binlink core/wget
+hab pkg install --binlink core/busybox-static
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 5
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/elasticsearch5/tests/test.sh
+++ b/elasticsearch5/tests/test.sh
@@ -4,14 +4,6 @@ TESTDIR="$(dirname "${0}")"
 PLANDIR="$(dirname "${TESTDIR}")"
 SKIPBUILD=${SKIPBUILD:-0}
 
-hab pkg install --binlink core/bats
-
-hab pkg install --binlink core/coreutils-static
-hab pkg install --binlink core/glibc
-hab pkg install --binlink core/jre8
-hab pkg install --binlink core/wget
-hab pkg install --binlink core/busybox-static
-
 source "${PLANDIR}/plan.sh"
 
 if [ "${SKIPBUILD}" -eq 0 ]; then
@@ -28,9 +20,18 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 
   # Give some time for the service to start up
-  local _seconds=15
+  local _seconds=20
   echo "Waiting for ${pkg_name} to start up (${_seconds} seconds)"
   sleep ${_seconds}
 fi
+
+hab pkg install --binlink core/coreutils-static
+hab pkg install --binlink core/glibc
+hab pkg install --binlink core/jre8
+hab pkg install --binlink core/wget
+hab pkg install --binlink core/curl
+hab pkg install --binlink core/busybox-static
+
+hab pkg install --binlink core/bats
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This does a number of things:

* Restructure plan to source the `elasticsearch` plan to avoid duplication
* Upgrade to 5.6.13
* Add tests
* Add missing deps (elasticsearch binary was complaining about missing commands)

### Testing

```
hab studio enter
./elasticsearch5/tests/test.sh
```

If you get failures related to the process or ports, it can be caused by a slow startup of Elasticsearch. While the delay to check has been increased to 15 seconds, it may be necessary to wait a little longer, and retry the tests without building it again:

```
SKIPBUILD=1 ./elasticsearch5/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 9200, 9300

6 tests, 0 failures
```

![tenor-164784287](https://user-images.githubusercontent.com/24568/48105011-15d4fc00-e279-11e8-94b1-0b3e1fe29ae8.gif)
