### PR TITLE
[nginx] Update Nginx to 1.15.6 for Linux and Windows

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.15.5"
+$pkg_version="1.15.6"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="bc5582e8459ce9a56919f6b3a7db2ba666a5223f63e0f3dae58b3a82766172ef"
+$pkg_shasum="e3429c131c6062f292976516ecb21f691ed289dddb613f79b4dc8c3caf94e8fa"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.15.5
+pkg_version=1.15.6
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
-pkg_source=https://nginx.org/download/nginx-${pkg_version}.tar.gz
+pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=1a3a889a8f14998286de3b14cc1dd5b2747178e012d6d480a18aa413985dae6f
+pkg_shasum=a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6
 pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Version update
* Contains Fixes for:
 * [CVE-2018-16843](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16843)
 * [CVE-2018-16844](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16844)

### Testing

```
hab studio enter
./nginx/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

7 tests, 0 failures
```

![tenor-267376278](https://user-images.githubusercontent.com/24568/48106409-ac57ec00-e27e-11e8-8868-611af6d11219.gif)
