### PR TITLE
[vault] Change backend to storage in configuration

### DIFF
--- a/vault/config/settings.hcl
+++ b/vault/config/settings.hcl
@@ -1,4 +1,4 @@
-backend "{{cfg.backend.storage}}" {
+storage "{{cfg.backend.storage}}" {
   address = "{{cfg.backend.location}}:{{cfg.backend.port}}"
   path = "{{cfg.backend.path}}"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #1897

Change `backend` to `storage` in configuration.