### PR TITLE
[vault] Change default storage to filesystem

### DIFF
--- a/vault/config/settings.hcl
+++ b/vault/config/settings.hcl
@@ -1,6 +1,5 @@
 storage "{{cfg.backend.storage}}" {
-  address = "{{cfg.backend.location}}:{{cfg.backend.port}}"
-  path = "{{cfg.backend.path}}"
+  path = "{{pkg.svc_data_path}}/{{cfg.backend.path}}"
 }
 
 listener "{{cfg.listener.type}}" {

--- a/vault/config/settings.hcl
+++ b/vault/config/settings.hcl
@@ -1,4 +1,4 @@
-backend "{{cfg.backend.storage}}" {
+storage "{{cfg.backend.storage}}" {
   address = "{{cfg.backend.location}}:{{cfg.backend.port}}"
   path = "{{cfg.backend.path}}"
 }

--- a/vault/default.toml
+++ b/vault/default.toml
@@ -4,9 +4,7 @@
 mode = true
 
 [backend]
-storage = "consul"
-location = "127.0.0.1"
-port = "8500"
+storage = "file"
 path = "vault"
 
 [listener]

--- a/vault/hooks/init
+++ b/vault/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+mkdir -p "{{pkg.svc_data_path}}/{{cfg.backend.path}}"


### PR DESCRIPTION
@Defilan hear me out .. :)

This changes the default storage to filesystem, meaning that if you're running this in devmode, there are no dependencies apart from Vault itself. Should make this easier to consume, and doesn't prevent people from making configuration/wrapper plans to override the storage provider.

Should be merged after #1972 if accepted.