### PR TITLE
[scaffolding-chef] Expose run_lock_timeout

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -55,7 +55,7 @@ exec 2>&1
 while true; do
 SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
 sleep \$SPLAY_DURATION
-chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.interval}}
+chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
 sleep {{cfg.interval}}
 done
 EOF
@@ -119,6 +119,7 @@ EOF
   cat << EOF >> "$pkg_prefix/default.toml"
 interval = 1800
 splay = 180
+run_lock_timeout = 1800
 log_level = "warn"
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 ssl_verify_mode = ":verify_peer"


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This exposes the `--run_lock_timeout` option as its own configuration option in the default.toml. We set it to 1800 seconds (30 minutes) by default (which is how interval was previously set) so this is not a breaking change.