### PR TITLE
[bats] Add sed to pkg_deps

### DIFF
--- a/bats/plan.sh
+++ b/bats/plan.sh
@@ -13,6 +13,7 @@ pkg_shasum="480d8d64f1681eee78d1002527f3f06e1ac01e173b761bc73d0cf33f4dc1d8d7"
 pkg_deps=(
   core/bash
   core/coreutils
+  core/sed
 )
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
This is a really hard one to test, as it only appears in failure cases when run under `hab pkg exec`.     I haven't found a good way to express 'I expect this failure case to not fail in its reporting'

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>