### PR TITLE
[libmemcached] Add package

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -638,6 +638,8 @@ plan_path = "libimagequant"
 plan_path = "libjpeg-turbo"
 [libksba]
 plan_path = "libksba"
+[libmemcached]
+plan_path = "libmemcached"
 [libmpc]
 plan_path = "libmpc"
 [libnsl]

--- a/libmemcached/README.md
+++ b/libmemcached/README.md
@@ -1,0 +1,36 @@
+# Memcached
+
+Free & open source, high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+Simple usage:
+
+```
+hab pkg install core/memcached
+hab svc load core/memcached
+```
+
+Memcached is now available on port `11211` (default).
+
+## Topologies
+
+Memcached server nodes are not aware of each other.
+
+As such, `standalone` is the recommended topology.
+
+## Update Strategies
+
+Update strategies depend on how your application(s) depend on Memcached for operation. Both `at-once` and `rolling` would be appropriate, however the rolling requirement is that a leader-follower topology be used.
+
+## Monitoring
+
+Any network capable monitoring system can connect to the exposed port `11211` (by default) and issue the command `stats` to view basic system information for monitoring purposes.

--- a/libmemcached/patches/gcc7-build.patch
+++ b/libmemcached/patches/gcc7-build.patch
@@ -1,0 +1,21 @@
+diff -up ./clients/memflush.cc.old ./clients/memflush.cc
+--- ./clients/memflush.cc.old	2017-02-12 10:12:59.615209225 +0100
++++ ./clients/memflush.cc	2017-02-12 10:13:39.998382783 +0100
+@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
+ {
+   options_parse(argc, argv);
+ 
+-  if (opt_servers == false)
++  if (!opt_servers)
+   {
+     char *temp;
+ 
+@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
+       opt_servers= strdup(temp);
+     }
+ 
+-    if (opt_servers == false)
++    if (!opt_servers)
+     {
+       std::cerr << "No Servers provided" << std::endl;
+       exit(EXIT_FAILURE);

--- a/libmemcached/plan.sh
+++ b/libmemcached/plan.sh
@@ -1,0 +1,61 @@
+pkg_origin=core
+pkg_name=libmemcached
+pkg_version=1.0.18
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Distributed memory object caching system"
+pkg_upstream_url="https://libmemcached.org/"
+pkg_license=('BSD')
+pkg_source="https://launchpad.net/libmemcached/1.0/${pkg_version}/+download/libmemcached-${pkg_version}.tar.gz"
+pkg_shasum="e22c0bb032fde08f53de9ffbc5a128233041d9f33b5de022c0978a2149885f82"
+pkg_deps=(
+  core/cyrus-sasl
+  core/gcc-libs
+  core/glibc
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/file
+  core/make
+  core/patch
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_prepare() {
+  # Can be removed once https://bugs.launchpad.net/libmemcached/+bug/1663985 is fixed upstream
+  patch -p1 < "${PLAN_CONTEXT}/patches/gcc7-build.patch"
+
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for "core/file")/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
+
+do_build() {
+  export LDFLAGS
+  LDFLAGS="-L$(pkg_path_for "core/gcc-libs")/lib ${LDFLAGS}"
+  do_default_build
+}
+
+do_check() {
+  if [[ ! -r /bin/echo ]]; then
+    ln -sv "$(pkg_path_for "core/coreutils")/bin/echo" /bin/echo
+    _clean_echo=true
+  fi
+
+  make check LDFLAGS="$LDFLAGS -lstdc++"
+
+  if [[ -n "$_clean_echo" ]]; then
+    rm -fv /bin/echo
+  fi
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}


### PR DESCRIPTION
> Closes #1809

Note that there are two problems with the current plan (I'm seeking for advice/help):

* Binaries link to `core/gcc` instead of `core/gcc-libs`
* One test fails (`libtest/unittest`), apparently because of bad linking with `libstdc++`

Signed-off-by: Romain Sertelon <romain@sertelon.fr>