### PR TITLE
[glibc] Adds iana-etc files support

### DIFF
--- a/glibc/plan.sh
+++ b/glibc/plan.sh
@@ -15,6 +15,7 @@ pkg_license=('GPL-2.0' 'LGPL-2.0')
 pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
 pkg_shasum="5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72"
 pkg_deps=(
+  core/iana-etc
   core/linux-headers
 )
 pkg_build_deps=(
@@ -91,6 +92,13 @@ do_prepare() {
   # Adjust `scripts/test-installation.pl` to use our new dynamic linker
   sed -i "s|libs -o|libs -L${pkg_prefix}/lib -Wl,-dynamic-linker=${dynamic_linker} -o|" \
     scripts/test-installation.pl
+
+  # Use core/iana-etc's /etc/protocols and /etc/services
+  sed -i "s|/etc/protocols|$(pkg_path_for core/iana-etc)/etc/protocols|" resolv/netdb.h
+  sed -i "s|/etc/protocols|$(pkg_path_for core/iana-etc)/etc/protocols|" nss/db-Makefile
+  sed -i "s|/etc/services|$(pkg_path_for core/iana-etc)/etc/services|" resolv/netdb.h
+  sed -i "s|/etc/services|$(pkg_path_for core/iana-etc)/etc/services|" nss/db-Makefile
+  sed -i "s|/etc/services|$(pkg_path_for core/iana-etc)/etc/services|" nss/nss_files/files-init.c
 }
 
 do_build() {


### PR DESCRIPTION
> Closes #1646

This theoretically works, as it's a more complete version of #1442 

I say theoretically because it seems glibc does not build currently...

Signed-off-by: Romain Sertelon <romain@sertelon.fr>