### PR TITLE
[clang] Remove an include that shouldn't be there

### DIFF
--- a/clang/plan.sh
+++ b/clang/plan.sh
@@ -26,10 +26,7 @@ pkg_build_deps=(
   core/ninja
 )
 pkg_lib_dirs=(lib)
-pkg_include_dirs=(
-  include
-  "lib/clang/${pkg_version}/include"
-)
+pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
 do_begin() {


### PR DESCRIPTION
Need to a remove an include since these are built-in headers that `clang` knows how to get too.  An example of how this conflicts is when you have both `gcc` and `clang` in the same plan, gcc will complain about pthread missing.

Signed-off-by: Ben Dang <me@bdang.it>