### PR TITLE
Upgrade Jenkins to 2.138.3

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.138.2
+pkg_version=2.138.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="d8ed5a7033be57aa9a84a5342b355ef9f2ba6cdb490db042a6d03efb23ca1e83"
+pkg_shasum="953e4dda2d3065284c0016b3e8279e097f830c128b1f712d84780ff2b0751e7d"
 pkg_deps=(core/jre8 core/curl)
 pkg_exports=(
   [port]=jenkins.http.port


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./jenkins/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 80 (HTTP)

4 tests, 0 failures
```