### PR TITLE
[dex] bump v2.12.0 -> v2.13.0; minor fixes to plan and tests

### DIFF
--- a/dex/plan.sh
+++ b/dex/plan.sh
@@ -2,7 +2,7 @@ gopkg="github.com/dexidp/dex"
 pkg_name=dex
 pkg_description="OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors"
 pkg_origin=core
-pkg_version="v2.12.0"
+pkg_version="2.13.0"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_source="https://$gopkg"
@@ -19,8 +19,8 @@ scaffolding_go_base_path=github.com/dexidp
 scaffolding_go_build_deps=()
 
 do_prepare() {
-  build_line "GO_LDFLAGS=\"-w -X $gopkg/version.Version=$pkg_version\""
-  export GO_LDFLAGS="-w -X $gopkg/version.Version=$pkg_version"
+  build_line "GO_LDFLAGS=\"-w -X $gopkg/version.Version=v$pkg_version\""
+  export GO_LDFLAGS="-w -X $gopkg/version.Version=v$pkg_version"
 }
 
 do_download() {
@@ -30,7 +30,7 @@ do_download() {
 
   pushd "${scaffolding_go_gopath:?}/src/$gopkg"
     build_line "checking out $pkg_version"
-    git reset --hard $pkg_version
+    git reset --hard "v$pkg_version"
   popd
 }
 

--- a/dex/tests/test.bats
+++ b/dex/tests/test.bats
@@ -11,6 +11,10 @@ load helpers
 }
 
 @test "OpenID Connect discovery document is returned with issuer set" {
-  curl http://127.0.0.1:5556/dex/.well-known/openid-configuration |
-    jq -e '.issuer | test("https://localhost/dex")'
+  jq -ne --argjson doc "$(curl http://127.0.0.1:5556/dex/.well-known/openid-configuration)" \
+    '$doc.issuer | test("https://localhost/dex")'
+}
+
+@test "'dex version' returns the correct version" {
+  dex version | grep -q "dex Version: v${pkg_version}"
 }

--- a/dex/tests/test.sh
+++ b/dex/tests/test.sh
@@ -28,8 +28,8 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 fi
 
-source results/last_build.env
-hab pkg install --binlink --force "results/${pkg_artifact}"
+source "${PLANDIR}/results/last_build.env"
+hab pkg install --binlink --force "${PLANDIR}/results/${pkg_artifact}"
 hab svc load "${pkg_ident}"
 
 # Wait for 5 seconds on first check, to ensure service is up.


### PR DESCRIPTION
- plan.sh now contains pkg_version=2.13.0, not pkg_version=v2.13.0
- tests/test.sh should work from dex/ and top-level
- added a test for asserting the version as reported by the CLI
------
I had promised to update these test files when the same issue came up in #1942  -- so, finally. 😄 