### PR TITLE
[scaffolding-chef] add ability for other software to bind off chef_client_ident

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -47,16 +47,34 @@ do_default_build_service() {
   cat << EOF >> "$pkg_prefix/hooks/run"
 #!/bin/sh
 
+chef_client_cmd()
+{
+  chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
+}
+
+SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
+
 export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 
 cd {{pkg.path}}
 
+# After the first run of the chef-client,
+# export the new package ident so that
+# other software can bind to it.
+# For example, this is useful for InSpec
+# to execute its run hook immediately after
+# the chef-client run has finished.
+
 exec 2>&1
-while true; do
-SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
 sleep \$SPLAY_DURATION
-chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
+chef_client_cmd
+echo "chef_client_ident = \"{{pkg.ident}}\"" | hab config apply {{svc.service}}.{{svc.group}} $(date +'%s')
+
+while true; do
+
+sleep \$SPLAY_DURATION
 sleep {{cfg.interval}}
+chef_client_cmd
 done
 EOF
   chown 0755 "$pkg_prefix/hooks/run"

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.1.4"
+pkg_version="0.2.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>


This adds the ability for other software to run in reaction to the first converge of the chef-client after a package upgrade. For example, you could have your InSpec Habitat package have this in its plan:

```
pkg_binds_optional=(
  [chef]="chef_client_ident"
)
```

which will cause the package to re-run the run hook when the bind is updated. In our case, this bind is updated automatically in the chef-client package's run hook using `hab config apply`.

In fact, this is exactly the use case I've used to test this out, but I can see other software reacting to this value as well.


![original-3](https://user-images.githubusercontent.com/3253989/48373905-0e965f80-e678-11e8-9bf4-64000d3d1bf5.gif)


I currently have a test environment using an InSpec package that uses this bind all spun up. If you'd like to have access to the environment, please let me know and I'll get you credentials.