### PR TITLE
[scaffolding-chef] bugfix to add default value for bind in default.toml

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -139,6 +139,7 @@ interval = 1800
 splay = 180
 run_lock_timeout = 1800
 log_level = "warn"
+chef_client_ident = "" # this is blank by default so it can be populated from the bind
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 ssl_verify_mode = ":verify_peer"
 

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.2.0"
+pkg_version="0.2.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

Shortly after merging #1985, I realized that some people are deleting their default.toml, and it was required by the scaffolding to provide a default for `chef_client_ident`. In this case, empty string is the best option, since we don't want to assume any previous values.


Thank you @robbkidd for the additional details here:

- In #1985, chef_client_ident is set to the pkg.ident of the package using the Chef scaffolding.
- pkg.ident is the fully qualified identifier for a Habitat package—origin/name/version/release—so this is expected to change whenever a new release of a Chef package has started up in an existing service group.
- The config version_number advances and the value of the chef_client_ident bind changes when the scaffold-generated run hook fires which will be the trigger for a bound Habitat service to restart and rerun its own run hook.
