### PR TITLE
[vault] Update Vault to 0.11.5

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.11.4
+pkg_version=0.11.5
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=3e44826ffcf3756a72d6802d96ea244e605dad362ece27d5c8f8839fb69a7079
+pkg_shasum=5230377dd8c214b274261a1474ee484a43622cdfa162458311ef11bb8c31b5b8
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

![tenor-263268679](https://user-images.githubusercontent.com/24568/48525944-30d2ec00-e8c9-11e8-95d2-2a31be968499.gif)

### Testing

```
hab studio enter
./vault/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```
