### PR TITLE
[Artifactory-Pro] Updating 6.5.3

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.5.2
+pkg_version=6.5.3
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=28a13ed7287bfecf27323b37b25a4366fc94b24424ccf4d20d68ab3cfb2edc49
+pkg_shasum=89364bd4c76a5a50658e7dc1b1e59cf28cf16950ab00670bb0863223d106cbcd
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hey all,

Just a version bump this time. Nothing fancy. I tested this locally, build looks good. To test the build, enter the studio and run 
```
./tests/test.sh
```

Expected output:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>