### PR TITLE
[go] bump 1.11.1 -> 1.11.2

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.11.1
+pkg_version=1.11.2
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=558f8c169ae215e25b81421596e8de7572bd3ba824b79add22fba6e284db1117
+pkg_shasum=042fba357210816160341f1002440550e952eb12678f7c9e7e9d389437942550
 pkg_dirname=go
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)


### PR DESCRIPTION
[Release notes](https://golang.org/doc/devel/release.html#go1.11.minor)