### PR TITLE
[postgresql] bump 9.6.9 -> 9.6.11

### DIFF
--- a/postgresql-client/plan.ps1
+++ b/postgresql-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql-client"
 $pkg_origin="core"
-$pkg_version="9.6.9"
+$pkg_version="9.6.11"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="052e6dc45c6a63784c165032d6472bb01b5276b99e38b1ff17fb16b758c587fd"
+$pkg_shasum="39df7a8212df8ce86ebae7f728cac7327a5e9ab821e351ac623ce33de6ed2b1a"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"

--- a/postgresql-client/plan.sh
+++ b/postgresql-client/plan.sh
@@ -2,14 +2,14 @@ source ../postgresql/plan.sh
 
 pkg_name=postgresql-client
 # Default to version/shasum from sourced postgresql plan
-pkg_version=${pkg_version:-9.6.9}
+pkg_version=${pkg_version:-9.6.11}
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="${pkg_shasum:-b97952e3af02dc1e446f9c4188ff53021cc0eed7ed96f254ae6daf968c443e2e}"
+pkg_shasum="${pkg_shasum:-38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530}"
 pkg_dirname="postgresql-${pkg_version}"
 
 # No exports/exposes for client

--- a/postgresql/plan.sh
+++ b/postgresql/plan.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=SC2164
 pkg_name=postgresql
-pkg_version=9.6.9
+pkg_version=9.6.11
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="b97952e3af02dc1e446f9c4188ff53021cc0eed7ed96f254ae6daf968c443e2e"
+pkg_shasum="38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530"
 
 pkg_deps=(
   core/bash

--- a/postgresql96-client/plan.ps1
+++ b/postgresql96-client/plan.ps1
@@ -2,10 +2,10 @@
 
 $pkg_name="postgresql96-client"
 $pkg_origin="core"
-$pkg_version="9.6.9"
+$pkg_version="9.6.11"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="052e6dc45c6a63784c165032d6472bb01b5276b99e38b1ff17fb16b758c587fd"
+$pkg_shasum="39df7a8212df8ce86ebae7f728cac7327a5e9ab821e351ac623ce33de6ed2b1a"

--- a/postgresql96-client/plan.sh
+++ b/postgresql96-client/plan.sh
@@ -2,14 +2,14 @@ source ../postgresql96/plan.sh
 
 pkg_name=postgresql96-client
 # Default to version/shasum from sourced postgresql96 plan
-pkg_version=${pkg_version:-9.6.9}
+pkg_version=${pkg_version:-9.6.11}
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="${pkg_shasum:-b97952e3af02dc1e446f9c4188ff53021cc0eed7ed96f254ae6daf968c443e2e}"
+pkg_shasum="${pkg_shasum:-38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530}"
 pkg_dirname="postgresql-${pkg_version}"
 
 # No exports/exposes for client

--- a/postgresql96/plan.sh
+++ b/postgresql96/plan.sh
@@ -3,14 +3,14 @@ PLANDIR=$(dirname "${BASH_SOURCE[0]}")
 source "${PLANDIR}/../postgresql/plan.sh"
 
 pkg_name=postgresql96
-pkg_version=9.6.9
+pkg_version=9.6.11
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="b97952e3af02dc1e446f9c4188ff53021cc0eed7ed96f254ae6daf968c443e2e"
+pkg_shasum="38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530"
 pkg_dirname="postgresql-${pkg_version}"
 
 # Copy service files (hooks, config, default.toml) from the postgresql plan


### PR DESCRIPTION
Release Notes for 9.6.11: https://www.postgresql.org/docs/9.6/release-9-6-11.html

(where also those other version skipped here are listed)


So many pg plans... 💭 _Did I catch them all?_