### PR TITLE
Fix chef scaffolding to default to verify_peer in bootstrap config

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -113,7 +113,6 @@ cache_path "$pkg_svc_data_path/cache"
 node_path "$pkg_svc_data_path/nodes"
 role_path "$pkg_svc_data_path/roles"
 
-ssl_verify_mode ":verify_peer"
 chef_zero.enabled true
 EOF
 
@@ -124,6 +123,7 @@ EOF
 
   cp "$pkg_prefix/.chef/config.rb" "$pkg_prefix/config/client-config.rb"
   cat << EOF >> "$pkg_prefix/config/client-config.rb"
+ssl_verify_mode {{cfg.ssl_verify_mode}}
 ENV['PATH'] = "{{cfg.env_path_prefix}}:#{ENV['PATH']}"
 
 {{#if cfg.data_collector.enable ~}}

--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -113,7 +113,7 @@ cache_path "$pkg_svc_data_path/cache"
 node_path "$pkg_svc_data_path/nodes"
 role_path "$pkg_svc_data_path/roles"
 
-ssl_verify_mode {{cfg.ssl_verify_mode}}
+ssl_verify_mode ":verify_peer"
 chef_zero.enabled true
 EOF
 

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.2.1"
+pkg_version="0.2.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
The bootstrap-config.rb configuration file is designed to be run via ```hab pkg exec``` when provisioning instances (ie, the habitat package is installed but not started) so we can't use config macros here. This commit changes the default to verify_peer, and keeps the existing config macro for the rendered client-config.rb.

Signed-off-by: Jon Cowie <jonlives@gmail.com>