### PR TITLE
[scaffolding-chef] Add json attribute file to chef-client run

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -49,7 +49,7 @@ do_default_build_service() {
 
 chef_client_cmd()
 {
-  chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
+  chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb -j $pkg_svc_config_path/attributes.json --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
 }
 
 SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
@@ -132,6 +132,14 @@ data_collector.server_url "{{cfg.data_collector.server_url}}"
 {{/if ~}}
 EOF
   chown 0644 "$pkg_prefix/config/client-config.rb"
+
+  cat << EOF >> "$pkg_prefix/config/attributes.json"
+{{#if cfg.attributes ~}}
+{{toJson cfg.attributes}}
+{{else ~}}
+{}
+{{/if ~}}
+EOF
 
   ## Create config
   cat << EOF >> "$pkg_prefix/default.toml"


### PR DESCRIPTION
Signed-off-by: Sandra Tiffin <stiffin@chef.io>

It can be very useful to be able to override default node attributes defined within a Habitat Managed Chef package at run time.

Example use case that I created it for: an S3 bucket is defined as a Terraform variable. Terraform can then install the hab package and create a user.toml with an [attributes] section to override the value of the s3bucket node variable.

Sample toml file:
```
[attributes]
  [attributes.mycookbook]
  s3bucket = "mybucket"
```

recipe:
``log "s3bucket = #{node['mycookbook']['s3bucket']}"``

output:
``* log[s3bucket = mybucket] action write``

Tested and works with or without attributes defined in the toml configs.