### PR TITLE
[etcd] Update to 3.3.10 w/tests

### DIFF
--- a/etcd/plan.sh
+++ b/etcd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=etcd
 pkg_description="Distributed reliable key-value store for the most critical data of a distributed system"
 pkg_origin=core
-pkg_version="v3.3.9"
+pkg_version="v3.3.10"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/coreos/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}-linux-amd64.tar.gz"
 pkg_upstream_url=https://github.com/coreos/etcd/
-pkg_shasum=7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1
+pkg_shasum=1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45
 pkg_dirname="${pkg_name}-${pkg_version}-linux-amd64"
 pkg_deps=(core/curl)
 pkg_build_deps=(core/gnupg)
@@ -24,7 +24,7 @@ do_download() {
 
   download_file "https://github.com/coreos/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
 	        "${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
-	        "b8532c7166acde5d9da62cdf4ef7c5123c0a7cb718118dab8d9a524b02e80ebe"
+                "cc4bdd4f0a83efa46a34b590544ba7bb3ad494d07d43cf3f85933b660b97638a"
   download_file "https://coreos.com/dist/pubkeys/app-signing-pubkey.gpg" \
 	        "app-signing-pubkey.gpg" \
                 "16b93904e4b3133fe4b5f95f46e3db998c3b2f9d9cee6d4c2eb531f98028bcb3"
@@ -34,7 +34,7 @@ do_verify() {
   do_default_verify
 
   verify_file "${pkg_name}-${pkg_version}-linux-amd64.tar.gz.asc" \
-	      "b8532c7166acde5d9da62cdf4ef7c5123c0a7cb718118dab8d9a524b02e80ebe"
+              "cc4bdd4f0a83efa46a34b590544ba7bb3ad494d07d43cf3f85933b660b97638a"
   verify_file "app-signing-pubkey.gpg" \
 	      "16b93904e4b3133fe4b5f95f46e3db998c3b2f9d9cee6d4c2eb531f98028bcb3"
 

--- a/etcd/tests/test.bats
+++ b/etcd/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="v$(etcdctl --version | grep 'etcdctl version:' | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/etcd/tests/test.sh
+++ b/etcd/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Hey all,

This updates etcd to 3.3.10 and adds basic tests. To test this build, run the following command:
```
./tests/test.sh
```
The results should return:
```
 ✓ Version matches

1 test, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>