### PR TITLE
[consul] Updating version to 1.4.0

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.3.1
+pkg_version=1.4.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=87c9bce5128654e8f785a324ad88912101acda4c7915c73e74fdbd875d8e7806
+pkg_shasum=41f8c3d63a18ef4e51372522c1e052618cdfcffa3d9f02dba0b50820e8279824
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Hey all,

This is a minor update to version 1.4.0. To test this build, enter the studio and run the following command:
```
./tests/test.sh
```

The results should look like:
```
Waiting for consul to start
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>