### PR TITLE
[artifactory-pro] Updating version to 6.5.9

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.5.3
+pkg_version=6.5.9
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=89364bd4c76a5a50658e7dc1b1e59cf28cf16950ab00670bb0863223d106cbcd
+pkg_shasum=3bfe05ca0215e133968731f8dd8a2a32fba493e4a50463791634951311b1cb49
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hey all,

This just updates Artifactory Pro to version 6.5.9. To test this build, please run the following command in the studio: 

```
./tests/test.sh
```
The results should be:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>