### PR TITLE
[dotnet-core] Updating dotnet-core to 2.1.6

### DIFF
--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core"
 $pkg_origin="core"
-$pkg_version="2.1.5"
+$pkg_version="2.1.6"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/ce443d89-75f1-4122-aaa8-c094a9017b4a/255b06ace4207a8ee923758160ed01c3/dotnet-runtime-${pkg_version}-win-x64.zip"
-$pkg_shasum="bfee610814720072bf67d3cc5738345a83ebb517add66f4fdaea280f417e91ed"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/3f6b6def-4e9a-4405-b21f-89f77d1605c4/52be50baa0e9bfa118fe6de80be89ab6/dotnet-runtime-${pkg_version}-win-x64.zip"
+$pkg_shasum="f528261c7532847025d19dafd11d543cefc4860209feb0d7ea5356518a288548"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=2.1.5
+pkg_version=2.1.6
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/05a71d80-3e59-4f1f-8298-2697013e261c/be191f2f4f4db74c29030008ed3632f0/dotnet-runtime-2.1.5-linux-x64.tar.gz"
-pkg_shasum=2962adbe0f52dc072e07f083ada37e5441a1981970196364612322f825c579d1
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/5c1334bc-bd26-4232-a745-2728b36a2628/8e163216cdcec15332ebf2e5575962de/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=b7c56119afb73c31f1cebb53cad758685850c248d44fdfc571af26390f53635b
 pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Hey all,

This updates both the Linux and Windows plans to version 2.1.6. To test the Linux build, enter the studio and run:

```
./tests/test.sh
```

The results should be:

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>