### PR TITLE
[libpng] Update libpng to 1.6.36

### DIFF
--- a/libpng/plan.sh
+++ b/libpng/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libpng
-pkg_version=1.6.35
+pkg_version=1.6.36
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("libpng")
@@ -7,7 +7,7 @@ pkg_description="An Open, Extensible Image Format with Lossless Compression"
 pkg_upstream_url=http://www.libpng.org/pub/png/
 pkg_source="http://download.sourceforge.net/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=2b82ab3e996803b80bc73206857e826a155d3ebb374e8eb03a87a63c6f672cf7
+pkg_shasum=ca13c548bde5fb6ff7117cc0bdab38808acb699c0eccb613f0e4697826e1fd7d
 pkg_deps=(
   core/glibc
   core/zlib


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

```
hab studio enter
DO_CHECK=1 build libpng
```

Runs checks:

```
============================================================================
Testsuite summary for libpng 1.6.36
============================================================================
# TOTAL: 33
# PASS:  33
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```