### PR TITLE
[sbt] Update sbt to 1.2.7, minor cleanup

### DIFF
--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,13 +1,12 @@
 pkg_origin=core
 pkg_name=sbt
-pkg_version=1.2.4
+pkg_version=1.2.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A build tool for Scala, Java, and more"
 pkg_upstream_url="https://www.scala-sbt.org"
 pkg_license=("BSD-3-Clause")
-pkg_source=https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz
-pkg_shasum=36db5a4cbad1d39fb01978a09007b9d833c9172d9cd4a3b08180c24c6a0dfb1b
-pkg_dirname="$pkg_name-$pkg_version"
+pkg_source="https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz"
+pkg_shasum=2625cbd8db75ec9b4a57e9a0af55a5ee8ad7700e1eba7d97ad78d9296450e781
 pkg_deps=(
   core/coreutils
   core/jre8
@@ -18,9 +17,8 @@ pkg_deps=(
 pkg_bin_dirs=(bin)
 
 do_prepare() {
-  JAVA_HOME="$(pkg_path_for jre8)"
+  JAVA_HOME="$(pkg_path_for core/jre8)"
   export JAVA_HOME
-  build_line "Setting JAVA_HOME=$JAVA_HOME"
 }
 
 do_build() {
@@ -28,8 +26,8 @@ do_build() {
 }
 
 do_install() {
-  mkdir -p "$pkg_prefix/share"
-  cp -ra "$HAB_CACHE_SRC_PATH/sbt" "$pkg_prefix/share"
-  ln -s "$pkg_prefix/share/sbt/bin/sbt" "$pkg_prefix/bin/"
+  mkdir -p "${pkg_prefix}/share"
+  cp -ra "${HAB_CACHE_SRC_PATH}/sbt" "${pkg_prefix}/share"
+  ln -s "${pkg_prefix}/share/sbt/bin/sbt" "${pkg_prefix}/bin/"
   fix_interpreter "${pkg_prefix}/bin/sbt" core/coreutils bin/env
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

```
hab studio enter
build sbt
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
hab pkg install --binlink core/jre8

sbt --help
```

I promise to automate tests soon for this.