### PR TITLE
[shellcheck] bump: 0.5.0 -> 0.6.0

### DIFF
--- a/shellcheck/plan.sh
+++ b/shellcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=shellcheck
 hkg_name=ShellCheck
 pkg_origin=core
-pkg_version=0.5.0
+pkg_version=0.6.0
 pkg_license=('GPL-3')
 pkg_upstream_url="http://www.shellcheck.net/"
 pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="2b9430736f48de17a60c035546a6a969c14392521bec30119e1c869017d3307c"
+pkg_shasum="f6e79fb34d076504176761cc8b7c3f996f8d31bed23250fb1570e32283cd7df6"
 pkg_dirname="${hkg_name}-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/releases/v0.6.0
