### PR TITLE
[vault] Upgrade vault to 1.0.0, add tests, change storage

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -6,7 +6,7 @@
 ## Description
 [Vault](https://www.vaultproject.io/) secures, stores, and tightly controls access to tokens, passwords, certificates, API keys, and other secrets in modern computing. Vault handles leasing, key revocation, key rolling, and auditing.
 
-This plan provides the static binary for execution.
+This plan provides the static binary for execution, as well as the service.
 
 ## Usage
 This package contains Vault. To use Vault properly, you need to provide it
@@ -27,3 +27,11 @@ hab start core/vault
 ## Update Strategy
 
 Recommended update strategy for Vault is `rolling`.
+
+## BREAKING CHANGES FROM 1.0.0
+
+Vault >=1.0.0 introduced changes in the Habitat plan in order to simplify default configuration and reduce dependencies. This makes adoption and maintenance easier, and aligns with recent RFCs for plan development.
+
+If you have upgraded to Vault 1.0.0 from Vault 0.*, you will notice that the default storage backend has changed from consul to file based.
+
+In order to continue using the consul storage backend, a configuration/wrapper plan must be created to provide your own custom configuration.

--- a/vault/config/settings.hcl
+++ b/vault/config/settings.hcl
@@ -1,6 +1,5 @@
 storage "{{cfg.backend.storage}}" {
-  address = "{{cfg.backend.location}}:{{cfg.backend.port}}"
-  path = "{{cfg.backend.path}}"
+  path = "{{pkg.svc_data_path}}/{{cfg.backend.path}}"
 }
 
 listener "{{cfg.listener.type}}" {

--- a/vault/default.toml
+++ b/vault/default.toml
@@ -4,9 +4,7 @@
 mode = true
 
 [backend]
-storage = "consul"
-location = "127.0.0.1"
-port = "8500"
+storage = "file"
 path = "vault"
 
 [listener]

--- a/vault/hooks/init
+++ b/vault/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+mkdir -p "{{pkg.svc_data_path}}/{{cfg.backend.path}}"

--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=0.11.5
+pkg_version=1.0.0
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=5230377dd8c214b274261a1474ee484a43622cdfa162458311ef11bb8c31b5b8
+pkg_shasum=75afb647d2ebeb46aafbf147ed1f1b379f6b8c9f909550dc2d0976cf153e8aa6
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)
@@ -20,7 +20,7 @@ pkg_exposes=(port)
 
 do_unpack() {
   cd "${HAB_CACHE_SRC_PATH}" || exit
-  unzip ${pkg_filename} -d "${pkg_name}-${pkg_version}"
+  unzip "${pkg_filename}" -d "${pkg_name}-${pkg_version}"
 }
 
 do_build() {

--- a/vault/tests/test.bats
+++ b/vault/tests/test.bats
@@ -10,3 +10,30 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "Usage: vault <command> [args]" ]
 }
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "vault\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep "vault server" | wc -l)"
+  [ "${result}" -eq 1 ]
+}
+
+@test "Listening on ports 8200, 8201" {
+  [ "$(netstat -peanut | grep vault | awk '{print $4}' | awk -F':' '{print $NF}' | grep 8200)" ]
+  [ "$(netstat -peanut | grep vault | awk '{print $4}' | awk -F':' '{print $NF}' | grep 8201)" ]
+}
+
+@test "Good response from /sys/health endpoint" {
+  local endpoint="http://$(netstat -peanut | grep vault | awk '{print $4}' | grep 8200)/v1/sys/health"
+  run curl -s -o /dev/null -w "%{http_code}" "${endpoint}"
+  [ "$output" = "200" ]
+  local health="$(curl -s ${endpoint})"
+  local initialized_result="$(echo "${health}" | jq '.initialized == true')"
+  [ "${initialized_result}" = "true" ]
+  local sealed_result="$(echo "${health}" | jq '.sealed == false')"
+  [ "${sealed_result}" = "true" ]
+  local version_result="$(echo "${health}" | jq -r '.version')"
+  [ "${version_result}" = "${pkg_version}" ]
+}

--- a/vault/tests/test.sh
+++ b/vault/tests/test.sh
@@ -5,17 +5,32 @@ PLANDIR="$(dirname "${TESTDIR}")"
 SKIPBUILD=${SKIPBUILD:-0}
 
 hab pkg install --binlink core/bats
+hab pkg install --binlink core/curl
+hab pkg install --binlink core/jq-static
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+hab pkg binlink core/busybox-static uniq
 
 source "${PLANDIR}/plan.sh"
 
 if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
   set -e
   pushd "${PLANDIR}" > /dev/null
   build
   source results/last_build.env
   hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
   popd > /dev/null
   set +e
+
+  # Give some time for the service to start up
+  sleep 5
 fi
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Since this is a major version up, I've rolled in the breaking change proposed in #1973 

* Upgrade to 1.0.0
* Default storage backend changed to fiule
* Added notice about file backend change to readme
* Added service tests

![tenor-45182711](https://user-images.githubusercontent.com/24568/49413779-6c6c2200-f7b4-11e8-921f-304fe0510431.gif)

```
hab studio enter
./vault/tests/test.sh

...

 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 8200, 8201
 ✓ Good response from /sys/health endpoint

6 tests, 0 failures
```