### PR TITLE
[hugo] Update Hugo to 0.52

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.50"
+pkg_version="0.52"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

```
hab studio enter
./hugo/tests/test.sh

...

 ✓ Version matches

1 test, 0 failures
```