### PR TITLE
[nginx] Update Nginx to 1.15.7 for Windows and Linux

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.15.6"
+$pkg_version="1.15.7"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="e3429c131c6062f292976516ecb21f691ed289dddb613f79b4dc8c3caf94e8fa"
+$pkg_shasum="1aa4ead19ebc0c11f7f9586d9cc7b293d53a4bd13d711f8fdcf86f1ce04a161b"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,14 +1,26 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.15.6
+pkg_version=1.15.7
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6
-pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
-pkg_build_deps=(core/gcc core/make core/coreutils)
+pkg_shasum=8f22ea2f6c0e0a221b6ddc02b6428a3ff708e2ad55f9361102b1c9f4142bdf93
+pkg_deps=(
+  core/glibc
+  core/libedit
+  core/ncurses
+  core/zlib
+  core/bzip2
+  core/openssl
+  core/pcre
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/coreutils
+)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(sbin)
 pkg_include_dirs=(include)
@@ -20,20 +32,20 @@ pkg_exports=(
 pkg_exposes=(port)
 
 do_build() {
-  ./configure --prefix="$pkg_prefix" \
-    --conf-path="$pkg_svc_config_path/nginx.conf" \
-    --sbin-path="$pkg_prefix/bin/nginx" \
-    --pid-path="$pkg_svc_var_path/nginx.pid" \
-    --lock-path="$pkg_svc_var_path/nginx.lock" \
+  ./configure --prefix="${pkg_prefix}" \
+    --conf-path="${pkg_svc_config_path}/nginx.conf" \
+    --sbin-path="${pkg_prefix}/bin/nginx" \
+    --pid-path="${pkg_svc_var_path}/nginx.pid" \
+    --lock-path="${pkg_svc_var_path}/nginx.lock" \
     --user=hab \
     --group=hab \
     --http-log-path=/dev/stdout \
     --error-log-path=stderr \
-    --http-client-body-temp-path="$pkg_svc_var_path/client-body" \
-    --http-proxy-temp-path="$pkg_svc_var_path/proxy" \
-    --http-fastcgi-temp-path="$pkg_svc_var_path/fastcgi" \
-    --http-scgi-temp-path="$pkg_svc_var_path/scgi" \
-    --http-uwsgi-temp-path="$pkg_svc_var_path/uwsgi" \
+    --http-client-body-temp-path="${pkg_svc_var_path}/client-body" \
+    --http-proxy-temp-path="${pkg_svc_var_path}/proxy" \
+    --http-fastcgi-temp-path="${pkg_svc_var_path}/fastcgi" \
+    --http-scgi-temp-path="${pkg_svc_var_path}/scgi" \
+    --http-uwsgi-temp-path="${pkg_svc_var_path}/uwsgi" \
     --with-ipv6 \
     --with-pcre \
     --with-pcre-jit \
@@ -62,6 +74,6 @@ do_build() {
 
 do_install() {
   make install
-  mkdir -p "$pkg_prefix/sbin"
-  cp "$HAB_CACHE_SRC_PATH/$pkg_dirname/objs/nginx" "$pkg_prefix/sbin"
+  mkdir -p "${pkg_prefix}/sbin"
+  cp "${HAB_CACHE_SRC_PATH}/${pkg_dirname}/objs/nginx" "${pkg_prefix}/sbin"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

```
hab studio enter
./nginx/tests/test.sh

... 

The rakops/nginx/1.15.7/20181205001026 service was successfully loaded
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

7 tests, 0 failures
```