### PR TITLE
[scaffolding-chef] add a first_run splay tunable

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -54,6 +54,8 @@ chef_client_cmd()
 
 SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
 
+SPLAY_FIRST_RUN_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay_first_run}} -n 1)
+
 export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 
 cd {{pkg.path}}
@@ -66,7 +68,7 @@ cd {{pkg.path}}
 # the chef-client run has finished.
 
 exec 2>&1
-sleep \$SPLAY_DURATION
+sleep \$SPLAY_FIRST_RUN_DURATION
 chef_client_cmd
 echo "chef_client_ident = \"{{pkg.ident}}\"" | hab config apply {{svc.service}}.{{svc.group}} $(date +'%s')
 
@@ -137,7 +139,8 @@ EOF
   ## Create config
   cat << EOF >> "$pkg_prefix/default.toml"
 interval = 1800
-splay = 180
+splay = 1800
+splay_first_run = 0
 run_lock_timeout = 1800
 log_level = "warn"
 chef_client_ident = "" # this is blank by default so it can be populated from the bind

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.2.3"
+pkg_version="0.2.4"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

The goal of this small PR is to allow folks a separate tunable for the initial run.

When you're running < 100 nodes, nobody wants to wait for the initial run. And they shouldn't have to. Waiting for the initial run is only something that should be done for large node upgrades and rollouts of large masses of infrastructure where the thundering herd problem is a real issue.

The thundering herd problem only becomes a larger problem when you are upgrading thousands of nodes simultaneously. Let me elaborate how this would all go down:

The Habitat Supervisor checks for updates once per minute. This isn't a splay (randomized), so you will achieve fairly consistent network timings and load timings when pulling artifacts from Builder.

Once the package is pulled down, it will execute the run hook, execute the chef-client run, and then use the data collector to push up the report over the network to your Chef Automate server.

It's the last part that's the difficult one. If you're upgrading large numbers of nodes simultaneously, that's gonna hurt your network. But even if your network is amazing, your Chef Automate server is suddenly going to receive 10,000 node reports simultaneously. Elasticsearch probably won't like that, especially if these are large node objects. Additionally if you have notifications or other services set up, you may put some heavy load on those services as they filter out 10,000 failure reports to your slack channels, etc.

So there you have it, we now have a tunable so you can avoid this very problem. It is set to 0 by default for the initial experience, but operators with large infrastructures will absolutely want to set this to a higher number, based on what they believe their network load, and Chef Automate server can handle.

---------------------------------------

The other thing is this lets `splay` serve a single purpose. Previously we needed to balance the splay value between a good initial value and a long enough random time. After talking to some Chef Server and Chef Automate scaling folks, I believe the optimal splay time for CCR performance is exactly equal to the interval. So we set them the same here by default. This means nodes using the scaffolding should check in once every 30 minutes to 60 minutes by default. (Or 32 times per day on average)