### PR TITLE
[nettle] Upgrade nettle to 3.4.1

### DIFF
--- a/nettle/plan.sh
+++ b/nettle/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="https://www.lysator.liu.se/~nisse/nettle/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-3.0' 'GPL-2.0' 'GPL-3.0')
 pkg_source="https://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="ae7a42df026550b85daca8389b6a60ba6313b0567f374392e54918588a411e94"
+pkg_shasum="f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad"
 pkg_deps=(
   core/glibc
   core/gmp

--- a/nettle/plan.sh
+++ b/nettle/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=nettle
 pkg_origin=core
-pkg_version="3.4"
+pkg_version="3.4.1"
 pkg_description="a low-level cryptographic library"
 pkg_upstream_url="https://www.lysator.liu.se/~nisse/nettle/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
Security updates for:

```
CVE-2018-16868 gnutls: Bleichenbacher-like side channel leakage in
  PKCS#1 1.5 verification and padding oracle verification
CVE-2018-16869 nettle: Leaky data conversion exposing a manager oracle
```

Ref: http://lists.gnu.org/archive/html/info-gnu/2018-12/msg00001.html

Closes #2020 