### PR TITLE
[papi] Update version

### DIFF
--- a/papi/plan.sh
+++ b/papi/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=papi
 pkg_origin=core
-pkg_version=5.5.1
+pkg_version=5.6.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Performance API"
 pkg_upstream_url="http://icl.cs.utk.edu/papi/"
 pkg_license=('BSD-3-Clause')
 pkg_source="http://icl.utk.edu/projects/${pkg_name}/downloads/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="49dc2c2323f6164c4a7e81b799ed690ee73158671205e71501f849391dd2c2d4"
+pkg_shasum="49b7293f9ca2d74d6d80bd06b5c4be303663123267b4ac0884cbcae4c914dc47"
 pkg_deps=(
   core/glibc
 )

--- a/papi/plan.sh
+++ b/papi/plan.sh
@@ -16,6 +16,7 @@ pkg_build_deps=(
   core/make
   core/pkg-config
 )
+pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)


### PR DESCRIPTION
Minor version update to papi.  

Validation:
You can run `hab pkg exec $HAB_ORIGIN/papi papi_version` to get the version.
`hab pkg exec $HAB_ORIGIN/papi papi_mem_info` will return information about memory cache.


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>