### PR TITLE
Update postfix version

### DIFF
--- a/postfix/plan.sh
+++ b/postfix/plan.sh
@@ -1,17 +1,18 @@
 pkg_name=postfix
 pkg_origin=core
-pkg_version="3.3.1"
+pkg_version="3.3.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Postfix is a free and open-source mail transfer agent that routes and delivers electronic mail."
 pkg_upstream_url="http://www.postfix.org/"
 pkg_license=('IPL-1.0')
 pkg_source="http://cdn.postfix.johnriley.me/mirrors/${pkg_name}-release/official/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="54f514dae42b5275cb4bc9c69283f16c06200b71813d0bb696568c4ba7ae7e3b"
+pkg_shasum="3c93f31eee49a58e592c31e62a058701cadde11e8e066ea441da19fddad7b35b"
 pkg_build_deps=(
   core/make
   core/gcc
   core/sed
   core/gawk
+  core/m4
 )
 pkg_deps=(
   # postfix deps


### PR DESCRIPTION
Minor version update.  

Validation can be performed by running `hab svc load $HAB_ORIGIN/postfix` and verifying the service starts.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>