### PR TITLE
[lsof] Update version

### DIFF
--- a/lsof/plan.sh
+++ b/lsof/plan.sh
@@ -1,9 +1,9 @@
 pkg_name="lsof"
 pkg_origin="core"
-pkg_version="4.89"
+pkg_version="4.91"
 pkg_license=('lsof')
 pkg_source="https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_${pkg_version}.tar.bz2"
-pkg_shasum="81ac2fc5fdc944793baf41a14002b6deb5a29096b387744e28f8c30a360a3718"
+pkg_shasum="c9da946a525fbf82ff80090b6d1879c38df090556f3fe0e6d782cb44172450a3"
 pkg_upstream_url="https://people.freebsd.org/~abe/"
 pkg_description="lsof - list open files"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -14,7 +14,7 @@ pkg_dirname="lsof_${pkg_version}"
 
 do_unpack() {
   do_default_unpack
-  $_tar_cmd xf "${CACHE_PATH}/lsof_4.89_src.tar" -C "${CACHE_PATH}" --strip-components=1
+  $_tar_cmd xf "${CACHE_PATH}/${pkg_name}_${pkg_version}_src.tar" -C "${CACHE_PATH}" --strip-components=1
 }
 
 do_build() {


### PR DESCRIPTION
Minor version update.  Validation can be performed by running `hab pkg exec $HAB_ORIGIN/lsof losf` and inspecting the output.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>