### PR TITLE
[consul] Add config options to enable ACLs

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -12,6 +12,42 @@ This plan provides the static binary for execution.
 hab svc load core/consul
 ```
 
+### Enable ACLs
+
+To enable ACLs add the `[acl]` stanza to `default.toml`
+
+```toml
+[acl]
+enabled = true
+default_policy = "deny"
+down_policy = "extend-cache"
+```
+
+Sub hashes can be described in standard TOML format:
+
+```
+[acl]
+enabled = true
+default_policy = "deny"
+down_policy = "extend-cache"
+tokens.master = "b1gs33cr3t"
+tokens.agent = "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+```
+
+Would render as:
+
+```json
+  "acl" : {
+    "enabled" : true,
+    "default_policy" : "deny",
+    "down_policy" : "extend-cache",
+    "tokens" : {
+      "master" : "b1gs33cr3t",
+      "agent" : "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+    }
+  }
+```
+
 ## Topology
 
 Consul can be deployed as a single node for testing, with `standalone` topology, or in a multi-node setup also as `standalone`. The nodes share the same configuration, and can utilize service member IP addresses for [consul join commands](2) or using the [start_join configuration](2) options.

--- a/consul/config/basic_config.json
+++ b/consul/config/basic_config.json
@@ -1,5 +1,11 @@
 {
   "datacenter": "{{cfg.server.datacenter}}",
+  {{#if cfg.server.primary_datacenter ~}}
+  "primary_datacenter": "{{cfg.server.primary_datacenter}}"
+  {{~/if~}}
+  {{~#unless cfg.server.primary_datacenter ~}}
+  "primary_datacenter": "{{cfg.server.datacenter}}:
+  {{~/unless}}
   "data_dir": "{{cfg.server.data-dir}}",
   "log_level": "{{cfg.server.loglevel}}",
   "bind_addr": "{{sys.ip}}",
@@ -10,6 +16,9 @@
     "{{member.sys.ip}}" {{~#unless @last}},{{/unless}}
   {{/eachAlive ~}}
   ],
+  {{#if cfg.acl.enabled~}}
+   "acl": {{toJson cfg.acl}},
+  {{~/if}}
   "ports": {
     "dns": {{cfg.ports.dns}},
     "http": {{cfg.ports.http}},

--- a/consul/default.toml
+++ b/consul/default.toml
@@ -9,12 +9,19 @@ expect = "3"
 [server]
 data-dir = "/hab/svc/consul/data/consul"
 datacenter = "dc1"
+# primary_datacenter
 loglevel = "INFO"
 # Revert back to the Legacy UI
 legacy_ui = false
 # switch this to false you want to start in DEVMODE
 # https://www.consul.io/docs/guides/bootstrapping.html
 mode = true
+
+# Uncomment the following to enable ACLs
+# [acl]
+# enabled = true
+# default_policy = "deny"
+# down_policy = "extend-cache"
 
 [ports]
 # The DNS server, -1 to disable


### PR DESCRIPTION
This PR adds configuration options to enable ACLs in Consul (laying the ground work for future work with the Consul Service Mesh).

This PR makes the following additions:

* `primary_datacenter` - [configuration option](https://www.consul.io/docs/agent/options.html#primary_datacenter) that sets that Authoritative datacenter for ACLs.  This option appears to be ignored when ACLs are not enabled, so including it in config where ACLs are disabled doesn't hurt anything.  I wanted `primary_datacenter` to default to `datacenter`.  As there is no if/else if/else I'm abusing if/unless to make `datacenter` applied when `primary_datacenter` is not supplied.

* `acl` stanza - this stanza leverages the `toJson` helper to enable "arbitrary" configuration options to be passed to the `basic_config.json` without them each having to be defined in the `default.toml`/`basic_config.json` template.

The README has been updated with examples.

Thoughts? Comments? Feedback?

Thanks,
- Q