### PR TITLE
[xz] Update XZ from 5.2.3 -> 5.2.4

### DIFF
--- a/xz/plan.ps1
+++ b/xz/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="xz"
 $pkg_origin="core"
-$pkg_version="5.2.3"
+$pkg_version="5.2.4"
 $pkg_description="XZ Utils is free general-purpose data compression software with a high compression ratio. XZ Utils were written for POSIX-like systems, but also work on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils."
 $pkg_upstream_url="http://tukaani.org/xz/"
 $pkg_license=@("gpl2+", "lgpl2+")
 $pkg_source="https://tukaani.org/${pkg_name}/${pkg_name}-${pkg_version}-windows.zip"
-$pkg_shasum="afe73c260e38fdebdd14c9eaab71c19b206ff74cebbdc744b0fa35b77b243220"
+$pkg_shasum="9a5163623f435b6fa0844b6b884babd6bf4f8d876ae2d8134deeb296afd49c61"
 $pkg_bin_dirs=@("bin")
 $pkg_include_dirs=@("include")
 $pkg_lib_dirs=@("lib")

--- a/xz/plan.sh
+++ b/xz/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=xz
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=5.2.3
+pkg_version=5.2.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 XZ Utils is free general-purpose data compression software with a high \
@@ -11,7 +11,7 @@ on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils.\
 pkg_upstream_url="http://tukaani.org/xz/"
 pkg_license=('gpl2+' 'lgpl2+')
 pkg_source="http://tukaani.org/${_distname}/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb"
+pkg_shasum="b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
5.2.4 (2018-04-29)

    * liblzma:

        - Allow 0 as memory usage limit instead of returning
          LZMA_PROG_ERROR. Now 0 is treated as if 1 byte was specified,
          which effectively is the same as 0.

        - Use "noexcept" keyword instead of "throw()" in the public
          headers when a C++11 (or newer standard) compiler is used.

        - Added a portability fix for recent Intel C Compilers.

        - Microsoft Visual Studio build files have been moved under
          windows/vs2013 and windows/vs2017.

    * xz:

        - Fix "xz --list --robot missing_or_bad_file.xz" which would
          try to print an unitialized string and thus produce garbage
          output. Since the exit status is non-zero, most uses of such
          a command won't try to interpret the garbage output.

        - "xz --list foo.xz" could print "Internal error (bug)" in a
          corner case where a specific memory usage limit had been set.

Signed-off-by: Tim Smith <tsmith@chef.io>