### PR TITLE
[node8] Update Node8 to 8.14.0

### DIFF
--- a/node8/plan.sh
+++ b/node8/plan.sh
@@ -2,14 +2,14 @@ source "../node/plan.sh"
 
 pkg_name=node8
 pkg_origin=core
-pkg_version=8.12.0
+pkg_version=8.14.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=b4797843136edd9195c28221a1680ae52c29d867fc5fc1c99f7d6e2f2126a67b
+pkg_shasum=c49f4d2223be9f2d2d73a131e9a25d9668b7ec2c1319d28c3c3658ff503b720c
 
 # the archive contains a 'v' version # prefix, but the default value of
 # pkg_dirname is node-${pkg_version} (without the v). This tweak makes build happy
-pkg_dirname=node-v$pkg_version
+pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Node 8.14.0 Changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.14.0)
* [Node 8.13.0 Changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.13.0)

### Testing

```
$ hab studio enter
# build node8
# source results/last_build.env 
# hab pkg install --binlink ${pkg_ident}
# node --version
v8.14.0
```
