### PR TITLE
[dotnet-core] Updated Windows/Linux Plans to 2.2.0

### DIFF
--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core"
 $pkg_origin="core"
-$pkg_version="2.1.6"
+$pkg_version="2.2.0"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/3f6b6def-4e9a-4405-b21f-89f77d1605c4/52be50baa0e9bfa118fe6de80be89ab6/dotnet-runtime-${pkg_version}-win-x64.zip"
-$pkg_shasum="f528261c7532847025d19dafd11d543cefc4860209feb0d7ea5356518a288548"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/62711024-fa98-4919-9fe0-466744b20941/4cdef0431350a441b45e11784f657b09/dotnet-runtime-${pkg_version}-win-x64.zip"
+$pkg_shasum="191c08b9d8de65b5203fbd61d7e82a332225727628d0d6ca3b7a25afac819f62"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=2.1.6
+pkg_version=2.2.0
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/5c1334bc-bd26-4232-a745-2728b36a2628/8e163216cdcec15332ebf2e5575962de/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=b7c56119afb73c31f1cebb53cad758685850c248d44fdfc571af26390f53635b
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/1057e14e-16cc-410b-80a4-5c2420c8359c/004dc3ce8255475d4723de9a011ac513/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=452ea9e2fc4f84fd5d0bf17501aa99a99d33badabee23950e537a1a4dc6a2b05
 pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Hey all,

Here is another simple bump in version here for both Windows and Linux. To test the Linux plan, please enter the studio and run this:

```
./tests/test.sh
```

The output should be:

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

Please let me know if there are any questions. 


Signed-off-by: Christopher P. Maher <chris@mahercode.io>