### PR TITLE
[dotnet-core-sdk] Updating to version 2.2.101

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="2.1.500"
+$pkg_version="2.2.101"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/2a508a9d-91e8-4126-904c-f7a515f8a33b/24ff5fe2610ce1ce76370ed053b14094/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="113575b3126791ee4d77e0fb36d9407bd62270101c8351f8da0937b660cb7cd8"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/25d4104d-1776-41cb-b96e-dff9e9bf1542/b878c013de90f0e6c91f6f3c98a2d592/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_shasum="fe13ce1eac2ebbc73fb069506d4951c57178935952a30ede029bf849279b4079"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=2.1.500
+pkg_version=2.2.101
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/e5eef3df-d2e3-429b-8204-f58372eb6263/20c825ddcc6062e93ff0c60e8354d3af/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=371f27441914931ed08a0bd2c5f2ea77323e4c9a5fa6b11a92cc5b53e3295073
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/80e1d007-d6f0-402f-b047-779464dd989b/9ae5e2df9aa166b720bdb92d19977044/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=2b14129d8e0fa01ba027145022e0580796604f091a52fcb86d23c0fa1fa438e9
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Hey all,

Here is another simple update. This updates both the Windows and Linux plans. To test the Linux build, please enter the studio and run:

```
./tests/test.sh
```

The results should be: 

```
 ✓ Version matches
 ✓ Info command

2 tests, 0 failures
```

Please let me know if there are any questions. 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>