### PR TITLE
[govc] Remove go_scaffolding from govc

### DIFF
--- a/govc/plan.sh
+++ b/govc/plan.sh
@@ -11,8 +11,11 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/git)
 
+
 do_before() {
   GOPATH="${HAB_CACHE_SRC_PATH}/govc-${pkg_version}"
+  go_pkg="${pkg_source#https://}"
+  export GOPATH
 }
 
 do_verify() {
@@ -20,10 +23,7 @@ do_verify() {
 }
 
 do_unpack() {
-  git clone "$pkg_source" "$GOPATH"
-  ( cd "$GOPATH" || exit
-    git checkout -q v"$pkg_version"
-  )
+  git clone --quiet --branch v"${pkg_version}" "${pkg_source}" "${GOPATH}"/src/"${go_pkg}"
 }
 
 do_download() {
@@ -31,12 +31,12 @@ do_download() {
 }
 
 do_build() { 
- ( cd "$GOPATH/govc" || exit
+ ( cd "src/${go_pkg}/govc" || exit
    go build
  )
 }
 
 do_install() {
-  cp "${GOPATH}/govc/govc" "${pkg_prefix}/bin/"
+  cp "src/${go_pkg}/govc/govc" "${pkg_prefix}/bin/"
 }
 

--- a/govc/plan.sh
+++ b/govc/plan.sh
@@ -9,7 +9,7 @@ pkg_source="https://github.com/vmware/govmomi"
 pkg_bin_dirs=(bin)
 
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/go core/git)
+pkg_build_deps=(core/go core/git core/gcc)
 
 
 do_before() {
@@ -23,7 +23,12 @@ do_verify() {
 }
 
 do_unpack() {
-  git clone --quiet --branch v"${pkg_version}" "${pkg_source}" "${GOPATH}"/src/"${go_pkg}"
+  git clone \
+    --quiet \
+    --config advice.detachedHead=false \
+    --branch v"${pkg_version}" \
+    "${pkg_source}" \
+    "${GOPATH}"/src/"${go_pkg}"
 }
 
 do_download() {

--- a/govc/plan.sh
+++ b/govc/plan.sh
@@ -35,7 +35,7 @@ do_download() {
   return 0
 }
 
-do_build() { 
+do_build() {
  ( cd "src/${go_pkg}/govc" || exit
    go build
  )
@@ -44,4 +44,3 @@ do_build() {
 do_install() {
   cp "src/${go_pkg}/govc/govc" "${pkg_prefix}/bin/"
 }
-

--- a/govc/plan.sh
+++ b/govc/plan.sh
@@ -1,10 +1,42 @@
 pkg_name=govc
 pkg_origin=core
-pkg_version="0.16.0"
+pkg_version="0.19.0"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
 pkg_description="govc is a vSphere CLI built on top of govmomi."
 pkg_upstream_url="https://github.com/vmware/govmomi"
-pkg_scaffolding="core/scaffolding-go"
-pkg_source="https://github.com/vmware/govmomi/govc"
+pkg_source="https://github.com/vmware/govmomi"
 pkg_bin_dirs=(bin)
+
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/go core/git)
+
+do_before() {
+  GOPATH="${HAB_CACHE_SRC_PATH}/govc-${pkg_version}"
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  git clone "$pkg_source" "$GOPATH"
+  ( cd "$GOPATH" || exit
+    git checkout -q v"$pkg_version"
+  )
+}
+
+do_download() {
+  return 0
+}
+
+do_build() { 
+ ( cd "$GOPATH/govc" || exit
+   go build
+ )
+}
+
+do_install() {
+  cp "${GOPATH}/govc/govc" "${pkg_prefix}/bin/"
+}
+


### PR DESCRIPTION
Govc was unable to build with the go scaffolding.  This replaces it with an explicit build.    

Verification was performed by running `hab pkg exec $HAB_ORIGIN/govc govc version`  


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>