### PR TITLE
[dex] Remove go_scaffolding and replace `go get` with `git clone`

### DIFF
--- a/dex/plan.sh
+++ b/dex/plan.sh
@@ -7,16 +7,17 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
 pkg_source="https://$gopkg"
 pkg_upstream_url=$pkg_source
-pkg_build_deps=()
 pkg_exports=(
   [port]=service.port
   [host]=service.host
 )
-pkg_deps=()
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/go core/git)
 pkg_bin_dirs=(bin)
-pkg_scaffolding=core/scaffolding-go
-scaffolding_go_base_path=github.com/dexidp
-scaffolding_go_build_deps=()
+
+do_before() {
+  GOPATH=$HAB_CACHE_SRC_PATH/$pkg_dirname
+}
 
 do_prepare() {
   build_line "GO_LDFLAGS=\"-w -X $gopkg/version.Version=v$pkg_version\""
@@ -24,14 +25,21 @@ do_prepare() {
 }
 
 do_download() {
-  # `-d`: don't let go build it, we'll have to build this ourselves
-  build_line "go get -d $gopkg"
-  go get -d $gopkg
+  return 0
+}
 
-  pushd "${scaffolding_go_gopath:?}/src/$gopkg"
+do_verify() {
+  return 0
+}
+
+# Use unpack instead of download, so that plan-build can manage the
+# source path. This ensures us a clean checkout every time we build.
+do_unpack() {
+  git clone "$pkg_source" "$GOPATH/$gopkg"
+  ( cd "$GOPATH/$gopkg" || exit
     build_line "checking out $pkg_version"
     git reset --hard "v$pkg_version"
-  popd
+  )
 }
 
 do_build() {
@@ -41,5 +49,5 @@ do_build() {
 
 do_install() {
   build_line "copying static web content"
-  cp -r "${scaffolding_go_gopath:?}/src/$gopkg/web" "$pkg_prefix"
+  cp -r "$GOPATH/$gopkg/web" "$pkg_prefix"
 }

--- a/dex/plan.sh
+++ b/dex/plan.sh
@@ -17,6 +17,7 @@ pkg_bin_dirs=(bin)
 
 do_before() {
   GOPATH=$HAB_CACHE_SRC_PATH/$pkg_dirname
+  export GOPATH
 }
 
 do_prepare() {
@@ -35,8 +36,8 @@ do_verify() {
 # Use unpack instead of download, so that plan-build can manage the
 # source path. This ensures us a clean checkout every time we build.
 do_unpack() {
-  git clone "$pkg_source" "$GOPATH/$gopkg"
-  ( cd "$GOPATH/$gopkg" || exit
+  git clone "$pkg_source" "$GOPATH/src/$gopkg"
+  ( cd "$GOPATH/src/$gopkg" || exit
     build_line "checking out $pkg_version"
     git reset --hard "v$pkg_version"
   )
@@ -49,5 +50,5 @@ do_build() {
 
 do_install() {
   build_line "copying static web content"
-  cp -r "$GOPATH/$gopkg/web" "$pkg_prefix"
+  cp -r "$GOPATH/src/$gopkg/web" "$pkg_prefix"
 }

--- a/dex/plan.sh
+++ b/dex/plan.sh
@@ -12,7 +12,7 @@ pkg_exports=(
   [host]=service.host
 )
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/go core/git)
+pkg_build_deps=(core/go core/git core/gcc)
 pkg_bin_dirs=(bin)
 
 do_before() {


### PR DESCRIPTION
When building dex as it exists in master,  you get the following error: 

`can't load package: package github.com/dexidp/dex: build constraints exclude all Go files in /hab/cache/src/scaffolding-go-gopath/src/github.com/dexidp/dex`

This is possibly a change in behavior for `go get` in`1.11.2`.  Last stable build was with `go 1.11.1`:
```
hab pkg exec core/dex dex version
dex Version: v2.13.0
Go Version: go1.11.1
Go OS/ARCH: linux amd64
```

To fix this, I've changed the `go get` to a `git clone` and removed the scaffolding as it is largely unused.  

Test results:
```
The smacfarlane/dex/2.13.0/20181213203205 service was successfully loaded
Waiting for dex to start (5s)
 ✓ Port Listen TCP/5556
 ✓ /dex/healthz endpoint returns success
 ✓ OpenID Connect discovery document is returned with issuer set
 ✓ 'dex version' returns the correct version
```

@srenatus  I know y'all use this pretty heavily, is there any additional testing you'd like to do before this is merged? 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>