### PR TITLE
[bundler] Bump bundler version

### DIFF
--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bundler
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.16.2
+pkg_version=1.16.6
 pkg_origin=core
 pkg_license=('bundler')
 pkg_description="The Ruby language dependency manager"


### PR DESCRIPTION
See https://forums.habitat.sh/t/new-build-issue-after-ruby-2-4-2-rebuild/594/2 and https://github.com/habitat-sh/core-plans/pull/1598

I'm getting the same issue, only with 1.16.2 and 1.16.6:

```
Vendoring 'bundler' version 1.16.6
ERROR:  Could not find a valid gem '/hab/pkgs/core/bundler/1.16.2/20181212193253/cache/bundler-1.16.6.gem' (>= 0) in any repository
```