### PR TITLE
[terraform] Updating to 0.11.11

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.11.10
+pkg_version=0.11.11
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip
 pkg_filename=${pkg_name}_${pkg_version}_linux_amd64.zip
-pkg_shasum=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
+pkg_shasum=94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Hey all,

Just another simple update. This updates Terraform to version 0.11.11. To test this build, please enter the studio and run:

```
./tests/test.sh
```

The output should be:

```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```

Please let me know if there are any issues or questions. 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>