### PR TITLE
[git] Add core/sed as dependency for core/git

### DIFF
--- a/git/plan.sh
+++ b/git/plan.sh
@@ -19,6 +19,7 @@ pkg_deps=(
   core/glibc
   core/openssh
   core/perl
+  core/sed
   core/zlib
 )
 pkg_build_deps=(core/make core/gcc)


### PR DESCRIPTION
git-submodule is using `sed` inside the code. Currently we are getting the following err when run `hab pkg exec core/git git submodule init`:
```
/hab/pkgs/core/git/2.18.0/20181212192153/libexec/git-core/git-submodule: line 7: sed: not found
/hab/pkgs/core/git/2.18.0/20181212192153/libexec/git-core/git-submodule: /hab/pkgs/core/git/2.18.0/20181212192153/libexec/git-core/git-sh-setup: line 105: sed: not found
```