### PR TITLE
Bump Bundler Version

### DIFF
--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bundler
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.16.2
+pkg_version=1.16.6
 pkg_origin=core
 pkg_license=('bundler')
 pkg_description="The Ruby language dependency manager"


### PR DESCRIPTION
Running into similar problem as described here: https://forums.habitat.sh/t/new-build-issue-after-ruby-2-4-2-rebuild/594/2
Bumping the version to match fixed it previously.

Signed-off-by: Quentin Hartman quentin.hartman@finalze.com