### PR TITLE
[jdk9/jre9] Deprecate Java9

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -502,8 +502,6 @@ plan_path = "jbigkit"
 plan_path = "jdk7"
 [jdk8]
 plan_path = "jdk8"
-[jdk9]
-plan_path = "jdk9"
 [jemalloc]
 plan_path = "jemalloc"
 [jenkins]
@@ -522,8 +520,6 @@ plan_path = "jq-static"
 plan_path = "jre7"
 [jre8]
 plan_path = "jre8"
-[jre9]
-plan_path = "jre9"
 [jruby]
 plan_path = "jruby"
 [jruby1]

--- a/jdk9/README.md
+++ b/jdk9/README.md
@@ -1,32 +1,5 @@
 # Java JDK9
 
-## Description
+This plan has been deprecated as it has been marked EOL by upstream.
 
-This package contains the Java JDK 9 to compile java applications.
-
-Include this as a dependency in your own plan, so you can build your applications / jar files.
-
-Couple it with the `core/jre9` package for running your app (if necessary)
-
-## Usage
-
-Your `plan.sh` dependencies will look similar to this:
-
-```
-pkg_deps=(
-  core/jre9
-)
-pkg_build_deps=(
-  core/jdk9
-)
-```
-
-Build your application with:
-
-```
-do_build() {
-  javac ...
-}
-```
-
-Then, from your own `plan.sh` run hook, you can `exec java ...` to run your application (requires `core/jre9`).
+https://www.oracle.com/technetwork/java/javase/9-0-4-relnotes-4021191.html

--- a/jdk9/plan.sh
+++ b/jdk9/plan.sh
@@ -16,6 +16,9 @@ pkg_bin_dirs=(bin jre/bin)
 pkg_lib_dirs=(lib lib/amd64)
 pkg_include_dirs=(include)
 
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"
+
 source_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
 
 do_setup_environment() {

--- a/jre9/README.md
+++ b/jre9/README.md
@@ -1,24 +1,5 @@
 # Java JRE9
 
-## Description
+This plan has been deprecated as it has been marked EOL by upstream.
 
-This package contains the Java JRE 9 environment required to run java applications.
-
-Include this as a dependency in your own plan, so you can run your jars.
-
-Couple it with the `core/jdk9` package for building your app (if necessary)
-
-## Usage
-
-Your `plan.sh` dependencies will look similar to this:
-
-```
-pkg_deps=(
-  core/jre9
-)
-pkg_build_deps=(
-  core/jdk9
-)
-```
-
-Then, from your own `plan.sh` run hook, you can `exec java ...` to run your application.
+https://www.oracle.com/technetwork/java/javase/9-0-4-relnotes-4021191.html

--- a/jre9/plan.sh
+++ b/jre9/plan.sh
@@ -16,6 +16,9 @@ pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"
+
 source_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}
 
 do_setup_environment() {


### PR DESCRIPTION
This PR deprecates JRE9 and JDK9 per our [deprecation guidelines](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0007-deprecating-packages.md). 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>