### PR TITLE
[ruby22] Deprecate Ruby22

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1186,11 +1186,6 @@ plan_path = "rq"
 plan_path = "rsync"
 [ruby]
 plan_path = "ruby"
-[ruby22]
-plan_path = "ruby22"
-paths = [
-  "ruby/*"
-]
 [ruby23]
 plan_path = "ruby23"
 paths = [

--- a/ruby22/README.md
+++ b/ruby22/README.md
@@ -1,15 +1,7 @@
 # ruby22
 
-A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+This package has been deprecated as it is no longer maintaned by upstream.
 
-## Maintainers
+https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
 
-* The Habitat Maintainers: <humans@habitat.sh>
 
-## Type of Package
-
-Binary package
-
-## Usage
-
-*TODO: Add instructions for usage*

--- a/ruby22/README.md
+++ b/ruby22/README.md
@@ -3,5 +3,3 @@
 This package has been deprecated as it is no longer maintaned by upstream.
 
 https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
-
-

--- a/ruby22/plan.sh
+++ b/ruby22/plan.sh
@@ -15,3 +15,6 @@ pkg_shasum=cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358
 pkg_dirname="ruby-$pkg_version"
 pkg_deps=(core/glibc/2.22 core/ncurses/6.0 core/zlib/1.2.8 core/openssl/1.0.2l core/libyaml/0.1.6/20170514013335 core/libffi/3.2.1/20170514003538 core/readline/6.3.8)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc/5.2.0 core/sed)
+
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"


### PR DESCRIPTION
This PR deprecates Ruby22 per our [deprecation guidelines](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0007-deprecating-packages.md). 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>