### PR TITLE
[mention-bot] Deprecate mention-bot

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -816,8 +816,6 @@ plan_path = "mawk"
 plan_path = "mc"
 [memcached]
 plan_path = "memcached"
-[mention-bot]
-plan_path = "mention-bot"
 [mercurial]
 plan_path = "mercurial"
 [mesa]

--- a/mention-bot/README.md
+++ b/mention-bot/README.md
@@ -1,0 +1,5 @@
+# Mention-bot
+
+This plan has been deprecated as upstream has indicated it is no longer maintained.
+
+https://github.com/facebookarchive/mention-bot

--- a/mention-bot/plan.sh
+++ b/mention-bot/plan.sh
@@ -22,6 +22,9 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"
+
 do_prepare() {
   npm config set spin=false
 }


### PR DESCRIPTION
This PR deprecates mention-bot per our [deprecation guidelines](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0007-deprecating-packages.md). 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>