### PR TITLE
Disable SC2164

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
     sha: 1.0.2
     hooks:
     -   id: shell-lint
-        args: ["--exclude=SC1090,SC1091,SC2034,SC2039,SC2148,SC2153,SC2154,SC2140"]
+        args: ["--exclude=SC1090,SC1091,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"]
         exclude: config/.*$
 -   repo: local
     hooks:


### PR DESCRIPTION
This PR disables [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164) in CI.  [plan-build sets](https://github.com/habitat-sh/habitat/blob/master/components/plan-build/bin/hab-plan-build.sh#L334) `-e` which normally disables this check, but shellcheck isn't aware of that due how `plan.sh` is source by plan-build.  

`--exclude` args were also re-ordered for readability as part of this PR.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>