### PR TITLE
[node/node11] Update Node and Node11 to 11.6.0

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="11.0.0"
+$pkg_version="11.6.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="a4be82fad7610131a68507aad93db4bb5809025af499b667e8201c93ee85aea4"
+$pkg_shasum="b5a896741c8cc1f5ccf353d24577c5b78b11af9e52cb9969a70d27d311e3873c"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=11.2.0
+pkg_version=11.6.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=2766fea693bc7a4750feef16d3c109df44d4319d4763678d60a5e8f177d0fa9e
+pkg_shasum=39ef4f1866f75786baff5959439483fafdc99d3ee3a0568a13cc635d64cf5e0b
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node11/plan.ps1
+++ b/node11/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node11"
 $pkg_origin="core"
-$pkg_version="11.0.0"
+$pkg_version="11.6.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="a4be82fad7610131a68507aad93db4bb5809025af499b667e8201c93ee85aea4"
+$pkg_shasum="b5a896741c8cc1f5ccf353d24577c5b78b11af9e52cb9969a70d27d311e3873c"

--- a/node11/plan.sh
+++ b/node11/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node11
 pkg_origin=core
-pkg_version=11.2.0
+pkg_version=11.6.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=2766fea693bc7a4750feef16d3c109df44d4319d4763678d60a5e8f177d0fa9e
+pkg_shasum=39ef4f1866f75786baff5959439483fafdc99d3ee3a0568a13cc635d64cf5e0b
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing:

```
hab studio enter
build node
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
node --version
```