### PR TITLE
[nginx] Update nginx to 1.15.8

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.15.6"
+$pkg_version="1.15.8"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="e3429c131c6062f292976516ecb21f691ed289dddb613f79b4dc8c3caf94e8fa"
+$pkg_shasum="cc93da0c47f1a251bce34d54e8db950427a61bcfbed7a2bf0ac1eadc3895e396"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.15.6
+pkg_version=1.15.8
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6
+pkg_shasum=a8bdafbca87eb99813ae4fcac1ad0875bf725ce19eb265d28268c309b2b40787
 pkg_deps=(core/glibc core/libedit core/ncurses core/zlib core/bzip2 core/openssl core/pcre)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing

```
hab studio enter
./nginx/tests/test.sh
```

Output

```
The core/nginx/1.15.8/20181227044533 service was successfully loaded
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

7 tests, 0 failures
```