### PR TITLE
[haproxy] Update haproxy to 1.9.0, add haproxy19 plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -460,6 +460,11 @@ plan_path = "haproxy18"
 paths = [
   "haproxy/*"
 ]
+[haproxy19]
+plan_path = "haproxy19"
+paths = [
+  "haproxy/*"
+]
 [harfbuzz]
 plan_path = "harfbuzz"
 [helm]

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=haproxy
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=1.8.14
+pkg_version=1.9.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
-pkg_source=https://www.haproxy.org/download/1.8/src/haproxy-${pkg_version}.tar.gz
+pkg_source=https://www.haproxy.org/download/1.9/src/haproxy-${pkg_version}.tar.gz
 pkg_upstream_url="https://www.haproxy.org/"
-pkg_shasum=b17e402578be85e58af7a3eac99b1f675953bea9f67af2e964cf8bdbd1bd3fdf
+pkg_shasum=16629e66175606de4bd1a2ccd826d607618323d34f400f52bcf048cee003817d
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
 pkg_svc_user=root
 pkg_svc_group=root

--- a/haproxy19/README.md
+++ b/haproxy19/README.md
@@ -1,0 +1,71 @@
+# haproxy
+
+HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. It is particularly suited for very high traffic web sites and powers quite a number of the world's most visited ones.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+This is a service package that will be run by the Habitat supervisor.
+
+## Usage
+
+You can start the service with:
+
+```
+$ hab start core/haproxy18
+```
+
+And bind another Habitat service to it - see "Binding" below for more details.
+
+## Bindings
+
+Consuming services can bind to HAProxy via:
+
+```
+hab svc load core/haproxy18 --bind port:haproxy.default
+```
+
+## Topologies
+
+This plan currently only supports the standalone topology.
+
+### Standalone
+
+To run a standalone haproxy instance, run
+
+```
+hab sup run --topology standalone
+hab svc load core/haproxy18
+```
+
+The standalone topology is used by default by the habitat supervisor if none is specified.
+For more details on the standalone topology, see [the Habitat docs on standalone](https://www.habitat.sh/docs/using-habitat/#standalone).
+
+### Leader-Follower
+
+This plan does not make use of the leader/follower topology.
+
+Check out [the Habitat docs on Leader-Follower](https://www.habitat.sh/docs/using-habitat/#leader-follower-topology) for more details on what the leader-follower topology is and what it does.
+
+## Update Strategies
+
+The authors do not provide any recommendations for how to use update strategies with this package.
+
+Check out [the update strategy documentation](https://www.habitat.sh/docs/using-habitat/#update-strategy) for information on the strategies Habitat supports.
+
+### Configuration Updates
+
+Check out the [configuration update](https://www.habitat.sh/docs/using-habitat/#configuration-updates) documentation for more information on what configuration updates are and how they are executed.
+
+Take a look at the [default.toml](default.toml) for this package to see the configuration settings you can override.
+
+## Scaling
+
+This package does not currently support high availability on its own.
+
+## Monitoring
+
+This service can be monitored by making TCP connections to the configured port (default is 80)

--- a/haproxy19/config/haproxy.conf
+++ b/haproxy19/config/haproxy.conf
@@ -1,0 +1,34 @@
+global
+    maxconn {{cfg.maxconn}}
+
+defaults
+    mode {{cfg.front-end.mode}}
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend http-in
+    bind {{cfg.front-end.listen}}:{{cfg.front-end.port}}
+    default_backend default
+
+backend default
+{{#if cfg.httpchk}}
+    option httpchk {{cfg.httpchk}}
+{{~/if}}
+{{~#eachAlive bind.backend.members as |member|}}
+    server {{member.sys.ip}} {{member.sys.ip}}:{{member.cfg.port}}
+{{~/eachAlive}}
+
+{{#if cfg.status.enabled}}
+listen  stats
+    bind {{cfg.status.listen}}:{{cfg.status.port}}
+    mode            http
+    log             global
+    maxconn 10
+    stats enable
+    stats hide-version
+    stats refresh 30s
+    stats show-node
+    stats auth {{cfg.status.user}}:{{cfg.status.password}}
+    stats uri  {{cfg.status.uri}}
+{{~/if}}

--- a/haproxy19/default.toml
+++ b/haproxy19/default.toml
@@ -1,0 +1,15 @@
+maxconn = 32
+httpchk = "GET /"
+
+[front-end]
+listen = "*"
+port = 80
+mode = "http"
+
+[status]
+enabled = false
+listen = "*"
+port = 9000
+user = "admin"
+password = "password"
+uri = "/haproxy-stats"

--- a/haproxy19/plan.sh
+++ b/haproxy19/plan.sh
@@ -1,0 +1,13 @@
+source ../haproxy/plan.sh
+
+pkg_name=haproxy19
+pkg_origin=core
+pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
+pkg_distname=haproxy
+pkg_version=1.9.0
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('GPL-2.0' 'LGPL-2.1')
+pkg_source=https://www.haproxy.org/download/1.8/src/${pkg_distname}-${pkg_version}.tar.gz
+pkg_shasum=16629e66175606de4bd1a2ccd826d607618323d34f400f52bcf048cee003817d
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_upstream_url="https://www.haproxy.org/"

--- a/haproxy19/tests/test.bats
+++ b/haproxy19/tests/test.bats
@@ -1,0 +1,21 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v haproxy)" ]
+}
+
+@test "Version matches" {
+  result="$(haproxy -v 2>&1 | head -n 1 | awk '{print $3}' | \
+          awk --field-separator '-' '{print $1}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Service is running" {
+  echo -e "$(hab svc status)"
+  [ "$(hab svc status | grep "haproxy18\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 80" {
+  result="$(netstat -peanut | grep haproxy | awk '{print $4}' | awk -F':' '{print $2}')"
+  [ "${result}" -eq 80 ]
+}

--- a/haproxy19/tests/test.sh
+++ b/haproxy19/tests/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+
+hab pkg install --binlink core/bats
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "$(dirname "${PLANDIR}")" > /dev/null
+  build "${pkg_name}"
+  source results/last_build.env
+  hab svc load -f core/nginx
+  echo '[http.listen]
+port = 81' | hab config apply nginx.default "$(date +%s)"
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}" --bind=backend:nginx.default
+  popd > /dev/null
+  set +e
+fi
+
+echo "Waiting 5 seconds hoping haproxy will start..."
+sleep 5
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Testing:

```
hab studio enter
./haproxy/tests/test.sh
```

Output:

```
Waiting 5 seconds hoping haproxy will start...
 ✓ Command is on path
 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

4 tests, 0 failures
```

Note: Need to also connect new haproxy19 plan on builder.