### PR TITLE
[zstd] Update zstd to 1.3.8

### DIFF
--- a/zstd/plan.sh
+++ b/zstd/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=zstd
-pkg_version=1.1.0
+pkg_version=1.3.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_description="Zstandard is a real-time compression algorithm, providing high compression ratios. "\
 "It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder"
 pkg_upstream_url=http://facebook.github.io/zstd/
 pkg_source="https://github.com/facebook/zstd/archive/v${pkg_version}.tar.gz"
-pkg_shasum=61cbbd28ff78f658f0564c2ccc206ac1ac6abe7f2c65c9afdca74584a104ea51
+pkg_shasum=5dd1e90eb16c25425880c8a91327f63de22891ffed082fcc17e5ae84fce0d5fb
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_bin_dirs=(bin)

--- a/zstd/plan.sh
+++ b/zstd/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=zstd
-pkg_version=1.3.7
+pkg_version=1.3.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_description="Zstandard is a real-time compression algorithm, providing high compression ratios. "\
 "It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder"
 pkg_upstream_url=http://facebook.github.io/zstd/
 pkg_source="https://github.com/facebook/zstd/archive/v${pkg_version}.tar.gz"
-pkg_shasum=5dd1e90eb16c25425880c8a91327f63de22891ffed082fcc17e5ae84fce0d5fb
+pkg_shasum=90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing:

```
hab studio enter
DO_CHECK=1 build zstd
```

Note: the build time is lengthy ~20 mins on an average machine.