### PR TITLE
[zsh] Update ZSH to 5.6.2

### DIFF
--- a/zsh/plan.sh
+++ b/zsh/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=zsh
 pkg_origin=core
-pkg_version=5.5.1
+pkg_version=5.6.2
 pkg_description="Zsh is a shell designed for interactive use, although it is also a powerful scripting language."
 pkg_upstream_url="http://www.zsh.org"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('zsh')
-pkg_source="https://downloads.sourceforge.net/project/zsh/zsh/${pkg_version}/zsh-${pkg_version}.tar.gz"
-pkg_shasum=774caa89e7aea5f33c3033cbffd93e28707f72ba5149c79709e48e6c2d2ee080
+pkg_source="https://downloads.sourceforge.net/project/zsh/zsh/${pkg_version}/zsh-${pkg_version}.tar.xz"
+pkg_shasum=a50bd66c0557e8eca3b8fa24e85d0de533e775d7a22df042da90488623752e9e
 pkg_deps=(
   core/coreutils
   core/gdbm


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Ref #1772 - 2 tests were failing. This is still the case, but testing of ZSH post-build and install seems fine. Not a regression.

```
hab studio enter
DO_CHECK=1 build zsh
```

Note: 2 tests will fail (see not above)

Build without tests:

```
hab studio enter
build zsh
```