### PR TITLE
[cppcheck] Updated cppcheck to 1.86

### DIFF
--- a/cppcheck/plan.sh
+++ b/cppcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cppcheck
 pkg_origin=core
-pkg_version=1.84
+pkg_version=1.86
 pkg_description="static analysis of C/C++ code"
 pkg_upstream_url="http://cppcheck.sourceforget.net"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/danmar/cppcheck/archive/${pkg_version}.tar.gz"
 pkg_filename="${pkg_version}.tar.gz"
-pkg_shasum=aaa6293d91505fc6caa6982ca3cd2d949fa1aac603cabad072b705fdda017fc5
+pkg_shasum=86ea85c2ee5ec31a7410bfc7c206b87e600d284089428750d66d1ce1ffa0c9a6
 pkg_deps=(
   core/glibc
   core/gcc-libs


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   cppcheck: hab-plan-build cleanup
   cppcheck: 
   cppcheck: Source Path: /hab/cache/src/cppcheck-1.86
   cppcheck: Installed Path: /hab/pkgs/core/cppcheck/1.86/20181227215628
   cppcheck: Artifact: /src/cppcheck/results/core-cppcheck-1.86-20181227215628-x86_64-linux.hart
   cppcheck: Build Report: /src/cppcheck/results/last_build.env
   cppcheck: SHA256 Checksum: 04879ddf93338cfd578fea25309dd3c786b1c02fcd81534401522ceaf2e4d592
   cppcheck: Blake2b Checksum: 6f0aed71b67b59568da3fe5d419629a1a2d7426be4a4ff593d495c0fc88ad0bd
   cppcheck: 
   cppcheck: I love it when a plan.sh comes together.
   cppcheck: 
   cppcheck: Build time: 1m20s
» Installing results/core-cppcheck-1.86-20181227215628-x86_64-linux.hart
→ Using core/cppcheck/1.86/20181227215628
★ Install of core/cppcheck/1.86/20181227215628 complete with 0 new packages installed.
» Binlinking cppcheck from core/cppcheck/1.86/20181227215628 into /hab/bin
★ Binlinked cppcheck from core/cppcheck/1.86/20181227215628 to /hab/bin/cppcheck
 ✓ Command is on path
 ✓ Version matches
 ✓ Help Command Check

3 tests, 0 failures

```