### PR TITLE
[curator] Updated curator to 5.6.0

### DIFF
--- a/curator/plan.sh
+++ b/curator/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=curator
 pkg_origin=core
-pkg_version=5.5.1
+pkg_version=5.6.0
 pkg_description="Elasticsearch Curator helps you curate, or manage your indices."
 pkg_upstream_url=https://github.com/elastic/curator
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"

--- a/curator/tests/test.bats
+++ b/curator/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(curator --version | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/curator/tests/test.sh
+++ b/curator/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/curator4/plan.sh
+++ b/curator4/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=curator4
 pkg_origin=core
-pkg_version=4.1.2
+pkg_version=4.2.6
 pkg_description="Elasticsearch Curator helps you curate, or manage your indices."
 pkg_upstream_url=https://github.com/elastic/curator
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   curator: hab-plan-build cleanup
   curator: 
   curator: Source Path: /hab/cache/src/curator-5.6.0
   curator: Installed Path: /hab/pkgs/core/curator/5.6.0/20181227231616
   curator: Artifact: /src/results/core-curator-5.6.0-20181227231616-x86_64-linux.hart
   curator: Build Report: /src/results/last_build.env
   curator: SHA256 Checksum: 71dac7c6ccf33b09d8bfe75eb258e0caa56871a59a0ab7092555edfeb200f042
   curator: Blake2b Checksum: b5cd7fc791cc140aa337769e3d78a34119fe8d765f0a5ed2689b746455321253
   curator: 
   curator: I love it when a plan.sh comes together.
   curator: 
   curator: Build time: 1m18s
```