### PR TITLE
[curl] Updated curl to 7.63.0

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source ../curl/plan.sh
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.62.0
+pkg_version=7.63.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/

--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -1,4 +1,4 @@
-source ../curl/plan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../curl/plan.sh"
 
 pkg_name=curl-static-musl
 pkg_distname=curl

--- a/curl-static-musl/tests/test.bats
+++ b/curl-static-musl/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(curl --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/curl-static-musl/tests/test.sh
+++ b/curl-static-musl/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.62.0
+pkg_version=7.63.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=55ccd5b5209f8cc53d4250e2a9fd87e6f67dd323ae8bd7d06b072cfcbb7836cb
+pkg_shasum=d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41
 pkg_deps=(
   core/cacerts
   core/glibc

--- a/curl/tests/test.bats
+++ b/curl/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(curl --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/curl/tests/test.sh
+++ b/curl/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   curl: hab-plan-build cleanup
   curl: 
   curl: Source Path: /hab/cache/src/curl-7.63.0
   curl: Installed Path: /hab/pkgs/core/curl/7.63.0/20181227232311
   curl: Artifact: /src/results/core-curl-7.63.0-20181227232311-x86_64-linux.hart
   curl: Build Report: /src/results/last_build.env
   curl: SHA256 Checksum: 8db48b6a9481b75148987235f295f14a112916c7582ca05e58e91f912b02bbe6
   curl: Blake2b Checksum: 801b0e8736745fd3e784e92c4e5a93adbca1bf8fbfed0461bf6e1c38b6390e2c
   curl: 
   curl: I love it when a plan.sh comes together.
   curl: 
   curl: Build time: 1m58s
```