### PR TITLE
[dbus] Updated dbus to 1.13.8

### DIFF
--- a/dbus/plan.sh
+++ b/dbus/plan.sh
@@ -1,19 +1,20 @@
 pkg_name=dbus
 pkg_origin=core
-pkg_version="1.10.18"
+pkg_version="1.13.8"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPLv2')
 pkg_description="D-Bus is a message bus system, a simple way for applications to talk to one another."
 pkg_upstream_url="https://www.freedesktop.org/wiki/Software/dbus/"
-pkg_source="https://dbus.freedesktop.org/releases/dbus/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="6049ddd5f3f3e2618f615f1faeda0a115104423a7996b7aa73e2f36e38cc514a"
+pkg_source="https://dbus.freedesktop.org/releases/dbus/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="82a89f64e1b55e459725186467770995f33cac5eb8a050b5d8cbeb338078c4f6"
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/autoconf
   core/automake
   core/make
-  core/gcc
   core/expat
+  core/gcc
+  core/pkg-config
 )
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)

--- a/dbus/tests/test.bats
+++ b/dbus/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(dbus-daemon --version | head -1 | awk '{print $5}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/dbus/tests/test.sh
+++ b/dbus/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   dbus: hab-plan-build cleanup
   dbus: 
   dbus: Source Path: /hab/cache/src/dbus-1.13.8
   dbus: Installed Path: /hab/pkgs/core/dbus/1.13.8/20181228001153
   dbus: Artifact: /src/results/core-dbus-1.13.8-20181228001153-x86_64-linux.hart
   dbus: Build Report: /src/results/last_build.env
   dbus: SHA256 Checksum: 6d8ba3db4af416425ae7f56fb4d0a55dafc6b1eca9fc446dbef7ed6dcd858761
   dbus: Blake2b Checksum: 0cf2d7a02a7529c103848a181eef35a66fea50293fae0e085fbfd6c474807b31
   dbus: 
   dbus: I love it when a plan.sh comes together.
   dbus: 
   dbus: Build time: 1m4s
```