### PR TITLE
[dd-agent] Updated dd-agent to 5.30.0

### DIFF
--- a/dd-agent/plan.sh
+++ b/dd-agent/plan.sh
@@ -1,14 +1,31 @@
 pkg_name=dd-agent
 pkg_origin=core
 pkg_version="5.30.0"
+pkg_supervisor_version="3.3.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Datadog Agent"
 pkg_license=("BSD-3-Clause")
 pkg_upstream_url="https://github.com/datadog/dd-agent"
-pkg_build_deps=(core/curl core/sed core/tar)
+pkg_build_deps=(
+  core/curl
+  core/gcc
+  core/git
+  core/make
+  core/openssl
+  core/ruby
+  core/python2
+  core/sed
+  core/tar
+)
 pkg_deps=(core/python2 core/sysstat core/busybox-static)
 pkg_dirname="datadog-agent"
-pkg_bin_dirs=(dd-agent/bin)
+pkg_bin_dirs=(
+  dd-agent/bin
+  dd-agent/venv/bin
+)
+pkg_lib_dirs=(
+  dd-agent/venv/lib
+)
 pkg_svc_run="agent"
 pkg_svc_user="root" # needed for supervisord
 
@@ -19,10 +36,6 @@ do_begin() {
 }
 
 do_build() {
-  return 0
-}
-
-do_install() {
   mkdir -p "$DD_HOME"
   env PATH="$(pkg_path_for core/tar)/bin:$PATH" sh -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh)"
   fix_interpreter "$DD_HOME/bin/agent" core/busybox-static bin/env
@@ -31,6 +44,10 @@ do_install() {
   mkdir -p "$pkg_prefix/config"
   mv "$DD_HOME/agent/datadog.conf" "$pkg_prefix/config"
   ln -s "$pkg_svc_config_path/datadog.conf" "$DD_HOME/agent/datadog.conf"
+}
+
+do_install() {
+  return 0
 }
 
 do_strip() {

--- a/dd-agent/tests/test.bats
+++ b/dd-agent/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(supervisord -v)"
+  [ "$result" = "${pkg_supervisor_version}" ]
+}

--- a/dd-agent/tests/test.sh
+++ b/dd-agent/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   dd-agent: hab-plan-build cleanup
   dd-agent: 
   dd-agent: Source Path: /src/dd-agent
   dd-agent: Installed Path: /hab/pkgs/core/dd-agent/5.30.0/20181228002025
   dd-agent: Artifact: /src/results/core-dd-agent-5.30.0-20181228002025-x86_64-linux.hart
   dd-agent: Build Report: /src/results/last_build.env
   dd-agent: SHA256 Checksum: 314f081f6796fcc4aa4b3f0adc0a74c0cfd64b003c4b79a71feb840c101565f2
   dd-agent: Blake2b Checksum: e9dc1dae43f109ff462aa51c5ad7b1cdb3f62bae7ada9f717f715b2d686cc23b
   dd-agent: 
   dd-agent: I love it when a plan.sh comes together.
   dd-agent: 
   dd-agent: Build time: 5m21s
```