### PR TITLE
[dejagnu] Updated dejagnu to 1.6.2

### DIFF
--- a/dejagnu/plan.sh
+++ b/dejagnu/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dejagnu
 pkg_origin=core
-pkg_version=1.6.1
+pkg_version=1.6.2
 pkg_license=('GPL-3.0-or-later')
 pkg_upstream_url="https://www.gnu.org/software/dejagnu/"
 pkg_description="A framework for testing other programs."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="bf5b28bb797e0ace4cfc0766a996339c795d8223bef54158be7887046bc01692"
+pkg_shasum="0d0671e1b45189c5fc8ade4b3b01635fb9eeab45cf54f57db23e4c4c1a17d261"
 pkg_deps=(
   core/expect
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   dejagnu: Running post-compile tests
Done. Now run 'make install'.
make  unit
make[1]: Entering directory '/hab/cache/src/dejagnu-1.6.2'
depbase=`echo testsuite/libdejagnu/unit.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
g++ -DPACKAGE_NAME=\"GNU\ DejaGnu\" -DPACKAGE_TARNAME=\"dejagnu\" -DPACKAGE_VERSION=\"1.6.2\" -DPACKAGE_STRING=\"GNU\ DejaGnu\ 1.6.2\" -DPACKAGE_BUGREPORT=\"bug-dejagnu@gnu.org\" -DPACKAGE_URL=\"http://www.gnu.org/software/dejagnu/\" -DPACKAGE=\"dejagnu\" -DVERSION=\"1.6.2\" -I.   -I/hab/pkgs/core/expect/5.45.4/20180608101522/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I. -g -I/hab/pkgs/core/expect/5.45.4/20180608101522/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -MT testsuite/libdejagnu/unit.o -MD -MP -MF $depbase.Tpo -c -o testsuite/libdejagnu/unit.o testsuite/libdejagnu/unit.cc &&\
mv -f $depbase.Tpo $depbase.Po
g++ -I. -g -I/hab/pkgs/core/expect/5.45.4/20180608101522/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include  -L/hab/pkgs/core/expect/5.45.4/20180608101522/lib -L/hab/pkgs/core/gcc/7.3.0/20180608051919/lib -o unit testsuite/libdejagnu/unit.o  
make[1]: Leaving directory '/hab/cache/src/dejagnu-1.6.2'
make  check-DEJAGNU
make[1]: Entering directory '/hab/cache/src/dejagnu-1.6.2'
Making a new site.exp file ...
srcdir='.'; export srcdir; \
EXPECT=/hab/pkgs/core/expect/5.45.4/20180608101522/bin/expect; export EXPECT; \
if /bin/sh -c "./runtest --version" > /dev/null 2>&1; then \
  exit_status=0; l='libdejagnu runtest'; for tool in $l; do \
    if ./runtest  --tool ${tool} --srcdir ${srcdir}/testsuite RUNTEST=./runtest ; \
    then :; else exit_status=1; fi; \
  done; \
else echo "WARNING: could not find './runtest'" 1>&2; :;\
fi; \
exit $exit_status
Using ./testsuite/lib/libdejagnu.exp as tool init file.
Test run by root on Fri Dec 28 00:39:06 2018
Native configuration is x86_64-pc-linux-gnu

		=== libdejagnu tests ===

Schedule of variations:
    unix

Running target unix
Using ./config/unix.exp as generic interface file for target.
Using ./testsuite/../config/unix.exp as tool-and-target-specific interface file.
Running ./testsuite/libdejagnu/tunit.exp ...

		=== libdejagnu Summary ===

Using ./testsuite/lib/runtest.exp as tool init file.
Test run by root on Fri Dec 28 00:39:07 2018
Native configuration is x86_64-pc-linux-gnu

		=== runtest tests ===

Schedule of variations:
    unix

Running target unix
Using ./config/unix.exp as generic interface file for target.
Using ./testsuite/../config/unix.exp as tool-and-target-specific interface file.
Running ./testsuite/runtest.all/libs.exp ...
Running ./testsuite/runtest.all/load_lib.exp ...
Running ./testsuite/runtest.all/options.exp ...
Running ./testsuite/runtest.all/stats-sub.exp ...
Running ./testsuite/runtest.all/stats.exp ...

		=== runtest Summary ===

# of expected passes		77
DejaGnu version	1.6.2
Expect version	5.45.4
Tcl version	8.6
```

One issue is that `test.sh` fails because of this benign error: `WARNING: Couldn't find the global config file.`
