### PR TITLE
[devicemapper] Updated devicemapper to 2.03.00

### DIFF
--- a/devicemapper/plan.sh
+++ b/devicemapper/plan.sh
@@ -8,11 +8,14 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${pkg_version}.tgz"
 pkg_shasum="405992bf76960e60c7219d84d5f1e22edc34422a1ea812e21b2ac3c813d0da4e"
-pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/gcc
   core/libaio
   core/make
+)
+pkg_deps=(
+  core/glibc
+  core/libaio
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)

--- a/devicemapper/plan.sh
+++ b/devicemapper/plan.sh
@@ -1,13 +1,19 @@
 pkg_name=devicemapper
 pkg_origin=core
-pkg_version="2.02.171"
+pkg_version="2.03.00"
+pkg_description="The Device-mapper is a component of the linux kernel (since version 2.6) that supports logical volume management."
+pkg_upstream_url="https://sourceware.org/lvm2/"
 pkg_dirname="LVM2.${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${pkg_version}.tgz"
-pkg_shasum="b815a711a2fabaa5c3dc1a4a284df0268bf0f325f0fc0f5c9530c9bbb54b9964"
+pkg_shasum="405992bf76960e60c7219d84d5f1e22edc34422a1ea812e21b2ac3c813d0da4e"
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/make core/gcc)
+pkg_build_deps=(
+  core/gcc
+  core/libaio
+  core/make
+)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(sbin)

--- a/devicemapper/plan.sh
+++ b/devicemapper/plan.sh
@@ -10,7 +10,6 @@ pkg_source="https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${pkg_versi
 pkg_shasum="405992bf76960e60c7219d84d5f1e22edc34422a1ea812e21b2ac3c813d0da4e"
 pkg_build_deps=(
   core/gcc
-  core/libaio
   core/make
 )
 pkg_deps=(

--- a/devicemapper/tests/test.bats
+++ b/devicemapper/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(vgs --version 2> /dev/null | grep -e 'LVM version' | awk '{print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/devicemapper/tests/test.sh
+++ b/devicemapper/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>

```
   devicemapper: hab-plan-build cleanup
   devicemapper: 
   devicemapper: Source Path: /hab/cache/src/LVM2.2.03.00
   devicemapper: Installed Path: /hab/pkgs/core/devicemapper/2.03.00/20181228005216
   devicemapper: Artifact: /src/results/core-devicemapper-2.03.00-20181228005216-x86_64-linux.hart
   devicemapper: Build Report: /src/results/last_build.env
   devicemapper: SHA256 Checksum: 73f463c44cd4646d57867b226d7ceb7421665ba6c6951b3e27929d7f54823287
   devicemapper: Blake2b Checksum: 5d55e59a9b6d4f5a2752e8c5b2cd28e9c2d1165021f25f3304ac516e350a118c
   devicemapper: 
   devicemapper: I love it when a plan.sh comes together.
   devicemapper: 
   devicemapper: Build time: 1m6s
```