### PR TITLE
[strace] Update strace to 4.26

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=4.25
+pkg_version=4.26
 pkg_license=("BSD-3-Clause-LBNL")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=d685f8e65470b7832c3aff60c57ab4459f26ff89f07c10f92bd70ee89efac701
+pkg_shasum=7c4d2ffeef4f7d1cdc71062ca78d1130eb52f947c2fca82f59f6a1183bfa1e1c
 pkg_deps=(
   core/glibc
   core/libunwind


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing:

```
hab studio enter
./strace/tests/test.sh
```

Output:

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```