### PR TITLE
[packer] Update packer to 1.3.3, windows and linux, add extra run tests

### DIFF
--- a/packer/plan.ps1
+++ b/packer/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="packer"
 $pkg_origin="core"
-$pkg_version="1.2.4"
+$pkg_version="1.3.3"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('MPL2')
 $pkg_bin_dirs=@("bin")
 $pkg_source="https://releases.hashicorp.com/packer/${pkg_version}/packer_${pkg_version}_windows_amd64.zip"
-$pkg_shasum="97c030add9c3d772f445df7bae3f0e70c4b67d4ed13c39e02b4cc338d8c93016"
+$pkg_shasum="02e35d7ec6dbd009c117f9731c42b8ba67fd6d53ec05f57849445f316ae8f817"
 
 function Invoke-Install {
   Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_name-$pkg_version/$pkg_name.exe" $pkg_prefix\bin

--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.3.2
+pkg_version=1.3.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="5e51808299135fee7a2e664b09f401b5712b5ef18bd4bad5bc50f4dcd8b149a1"
+pkg_shasum="2e3ea8f366d676d6572ead7e0c773158dfea0aed9c6a740c669d447bcb48d65f"
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)

--- a/packer/tests/test.bats
+++ b/packer/tests/test.bats
@@ -4,3 +4,8 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   result="$(packer version | head -1 | awk '{print $2}')"
   [ "$result" = "v${pkg_version}" ]
 }
+
+@test "Help command" {
+  run packer --help
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing:

```
hab studio enter
./packer/tests/test.sh
```

Output:

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

Windows package uploaded, needs promotion to stable when this PR is approved: https://bldr.habitat.sh/#/pkgs/core/packer/1.3.3/20181229145152