### PR TITLE
[c-ares] minor bump to 1.15

### DIFF
--- a/c-ares/README.md
+++ b/c-ares/README.md
@@ -12,4 +12,4 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Add `core/c-ares` if your C/C++ apps depend on this.

--- a/c-ares/plan.sh
+++ b/c-ares/plan.sh
@@ -1,31 +1,81 @@
 pkg_name=c-ares
 pkg_origin=core
-pkg_version="1.13.0"
+pkg_version="1.15.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_upstream_url="https://c-ares.haxx.se/"
 pkg_description="A C library for asynchronous DNS requests"
-pkg_source="https://c-ares.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=03f708f1b14a26ab26c38abd51137640cb444d3ec72380b21b20f1a8d2861da7
-pkg_deps=(core/glibc)
+pkg_source="https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz"
+pkg_shasum=7deb7872cbd876c29036d5f37e30c4cbc3cc068d59d8b749ef85bb0736649f04
+pkg_dirname="c-ares-cares-1_15_0"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+)
 pkg_build_deps=(
   core/coreutils
+  core/busybox-static
   core/diffutils
   core/file
   core/gcc
-  core/make
+  core/cmake
+  core/ninja
 )
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_begin() {
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_SEPARATOR=";"
+  export HAB_ENV_CMAKE_FIND_ROOT_PATH_TYPE="aggregate"
+}
+
+do_setup_environment() {
+  set_buildtime_env BUILDDIR "build"
+
+  # this allows cmake users to utilize `CMAKE_FIND_ROOT_PATH` to find various cmake configs
+  push_runtime_env CMAKE_FIND_ROOT_PATH "${pkg_prefix}/lib/cmake/c-ares"
+}
 
 do_prepare() {
-  CPPFLAGS="$CFLAGS"
-  CFLAGS=""
-  export CPPFLAGS CFLAGS
+  mkdir -p "${BUILDDIR}"
 }
 
 do_build() {
-  ./configure --prefix="$pkg_prefix" \
-      --disable-tests
-  make
+  pushd "${BUILDDIR}" || exit 1
+    cmake \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCARES_STATIC="ON" \
+    -DCARES_INSTALL="ON" \
+    -DCARES_BUILD_TESTS="${DO_CHECK}" \
+    -DCARES_BUILD_TOOLS="ON" \
+    -G "Ninja" \
+    ..
+  ninja -j"$(nproc --ignore=1)"
+  popd || exit 1
+}
+
+do_check() {
+  pushd "${BUILDDIR}" || exit 1
+  CTEST_OUTPUT_ON_FAILURE=1 ctest -R aresfuzz
+
+  # TODO(bdangit): disabled 2 types of tests:
+  #  1. Live Testing: requires access to the internet.
+  #  2. MockChannelTest.HostAliasUnreadable: seg faults and would require extensive deepdive
+  #     with a debugger.
+  ./bin/arestest -4 --gtest_filter=-*.Live*:AddressFamilies/MockChannelTest.HostAliasUnreadable*
+
+  if ifconfig | grep -q 'inet6'
+  then
+    build_line "HAS IPV6"
+    ./bin/arestest -6 --gtest_filter=-*.Live*:AddressFamilies/MockChannelTest.HostAliasUnreadable*
+  fi
+
+  popd || exit 1
+}
+
+do_install() {
+  pushd "${BUILDDIR}" || exit 1
+  ninja install
+  popd || exit 1
 }


### PR DESCRIPTION
Minor bump to 1.15.
[Changelog](https://c-ares.haxx.se/changelog.html#1_15_0)

- Switch to ninja for faster builds
- Build both shared libs and static libs
- Inject cmake config into `CMAKE_FIND_ROOTH_PATH`
- This adds in do_check() tests
- Switch to github.com for the authoriative source files
  Note: this tarball contains all source files packaged in
  `test/fuzzinput` and `test/fuzznames`

## Testing

```
hab studio enter
DO_CHECK=1 build
```

Signed-off-by: Ben Dang <me@bdang.it>