### PR TITLE
[telegraf] Update telegraf to 1.9.2

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version="1.3.5"
+pkg_version="1.9.2"
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum="3c44bf10fc689e723c6f62f28babd8317331af507d1178100cdb16ee15b5a490"
+pkg_shasum="4646884e9388b207aaac647f208be29eeea21150506f370ea4b878b5fb57ee98"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config $pkg_svc_config_path/telegraf.conf"
 pkg_build_deps=(core/wget core/tar)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter

build telegraf
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}

# Check version output
telegraf --version
# Check help output
telegraf --help
# Default config display/output
telegraf config
```

### Sample output

```
# telegraf --version
Telegraf 1.9.2 (git: HEAD dda80799)

# telegraf --help
Telegraf, The plugin-driven server agent for collecting and reporting metrics.

Usage:

  telegraf [commands|flags]
. . .

# telegraf config
# Telegraf Configuration
#
# Telegraf is entirely plugin driven. All metrics are gathered from the
# declared inputs, and sent to the declared outputs.
#
# Plugins must be declared in here to be active.
# To deactivate a plugin, comment out the name and any variables.
#
# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
# file would generate.
#
# Environment variables can be used anywhere in this config file, simply prepend
# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)


# Global tags can be specified here in key="value" format.
[global_tags]
  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
  # rack = "1a"
  ## Environment variables can be used as tags, and throughout the config file
  # user = "$USER"
. . . 
```