### PR TITLE
[php] Update PHP to 7.3.1

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=php
 pkg_origin=core
-pkg_version=7.3.0
+pkg_version=7.3.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("PHP-3.01")
 pkg_upstream_url=http://php.net/
@@ -8,7 +8,7 @@ pkg_description="PHP is a popular general-purpose scripting language that is esp
 pkg_source="https://php.net/get/${pkg_name}-${pkg_version}.tar.xz/from/this/mirror"
 pkg_filename="${pkg_name}-${pkg_version}.tar.xz"
 pkg_dirname="${pkg_name}-${pkg_version}"
-pkg_shasum=7d195cad55af8b288c3919c67023a14ff870a73e3acc2165a6d17a4850a560b5
+pkg_shasum=cfe93e40be0350cd53c4a579f52fe5d8faf9c6db047f650a4566a2276bf33362
 pkg_deps=(
   core/bzip2
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build php
source results/last_build.env
./php/test/test.sh ${pkg_ident}
hab pkg install --binlink results/${pkg_artifact}
php --version
```

### Sample output

```
» Installing core/php/7.3.1/20190109050058
→ Using core/php/7.3.1/20190109050058
★ Install of core/php/7.3.1/20190109050058 complete with 0 new packages installed.
Libzip is supported.

# php --version
PHP 7.3.1 (cli) (built: Jan  9 2019 05:11:57) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.1, Copyright (c) 1998-2018 Zend Technologies
```