### PR TITLE
bump version for json runtime config

### DIFF
--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.2.4"
+pkg_version="0.3.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This is a version bump for releasing #2008 as version 0.3.0 of scaffolding-chef.