### PR TITLE
[elixir] Update Elixir to 1.8.0

### DIFF
--- a/elixir/plan.sh
+++ b/elixir/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=elixir
-pkg_version=1.7.4
+pkg_version=1.8.0
 pkg_description="A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain."
 pkg_upstream_url=http://elixir-lang.org
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/elixir-lang/elixir/archive/v${pkg_version}.tar.gz"
-pkg_shasum=c7c87983e03a1dcf20078141a22355e88dadb26b53d3f3f98b9a9268687f9e20
+pkg_shasum=fe896d8b2914f982d2e6fceeb585f59a8f92ad872653fc46c13df9ff86d69234
 pkg_deps=(
   core/busybox
   core/cacerts


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./elixir/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Trivial Elixir code tests

2 tests, 0 failures
```