### PR TITLE
[scaffolding-chef] add @jsirex code for fixing permissions and allowing chef-client/chef-dk overrides

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -12,16 +12,20 @@ if [ -z "${scaffold_policy_name+x}" ]; then
 fi
 
 scaffolding_load() {
-  parent_deps="${pkg_deps[*]}"
-  pkg_deps=("chef/chef-client" "core/cacerts")
-  for i in $parent_deps; do
-    pkg_deps+=($i)
-  done
-  parent_build_deps="${pkg_build_deps[*]}"
-  pkg_build_deps=("chef/chef-dk" "core/git")
-  for i in $parent_build_deps; do
-    pkg_build_deps+=($i)
-  done
+  : "${scaffold_chef_client:=chef/chef-client}"
+  : "${scaffold_chef_dk:=chef/chef-dk}"
+
+  pkg_deps=(
+    "${pkg_deps[@]}"
+    "$scaffold_chef_client"
+    "core/cacerts"
+  )
+  pkg_build_deps=(
+    "${pkg_build_deps[@]}"
+    "$scaffold_chef_dk"
+    "core/git"
+  )
+
   pkg_svc_user="root"
   pkg_svc_run="set_just_so_you_will_render"
 }
@@ -41,7 +45,7 @@ do_default_unpack() {
 do_default_build_service() {
   ## Create hooks
   mkdir -p "$pkg_prefix/hooks"
-  chown 0644 "$pkg_prefix/hooks"
+  chmod 0750 "$pkg_prefix/hooks"
 
   # Run hook
   cat << EOF >> "$pkg_prefix/hooks/run"
@@ -79,7 +83,7 @@ sleep {{cfg.interval}}
 chef_client_cmd
 done
 EOF
-  chown 0755 "$pkg_prefix/hooks/run"
+  chmod 0750 "$pkg_prefix/hooks/run"
 }
 
 do_default_build() {
@@ -109,7 +113,7 @@ do_default_install() {
   chef export "$_policyfile_path/$scaffold_policy_name.lock.json" "$pkg_prefix"
 
   mkdir -p "$pkg_prefix/config"
-  chown 0755 "$pkg_prefix/config"
+  chmod 0750 "$pkg_prefix/config"
   cat << EOF >> "$pkg_prefix/.chef/config.rb"
 cache_path "$pkg_svc_data_path/cache"
 node_path "$pkg_svc_data_path/nodes"
@@ -134,7 +138,7 @@ data_collector.token "{{cfg.data_collector.token}}"
 data_collector.server_url "{{cfg.data_collector.server_url}}"
 {{/if ~}}
 EOF
-  chown 0644 "$pkg_prefix/config/client-config.rb"
+  chmod 0640 "$pkg_prefix/config/client-config.rb"
 
   cat << EOF >> "$pkg_prefix/config/attributes.json"
 {{#if cfg.attributes ~}}
@@ -160,7 +164,7 @@ enable = false
 token = "set_to_your_token"
 server_url = "set_to_your_url"
 EOF
-  chown 0644 "$pkg_prefix/default.toml"
+  chmod 0640 "$pkg_prefix/default.toml"
 }
 
 do_default_strip() {

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.3.0"
+pkg_version="0.4.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION

![excited-kid-birthday](https://user-images.githubusercontent.com/3253989/51194160-58313f80-189f-11e9-8d5c-bcab63a34e61.gif)
Signed-off-by: echohack <echohack@users.noreply.github.com>

In PR #1831 @jsirex originally wrote this code. I am submitting a portion of it here for a smaller patch.

This PR allows users to override the scaffolding's chef-client and chef-dk package. This is so a user can pin their package to previous (old) versions.

Furthermore it fixes some essential bugs with permissions on files and directories.

I have tested it by building packages with the override set and successfully built and stood up my app with it.