### PR TITLE
[gnatsd] Update gnatsd to 1.4.0, extend test sleep delay

### DIFF
--- a/gnatsd/plan.sh
+++ b/gnatsd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=gnatsd
 pkg_origin=core
-pkg_version=1.3.0
+pkg_version=1.4.0
 pkg_description="A High Performance NATS Server written in Go."
 pkg_upstream_url=https://github.com/nats-io/gnatsd
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/nats-io/gnatsd/archive/v${pkg_version}.tar.gz"
-pkg_shasum=2cb9a228acfa1932196652f4c50118e55c9b5ea1b1d6549c0f2cdda7edc1fc10
+pkg_shasum=193778c9c697823d5a198552236fb2f519d509213fbbbea77cd4341719066bfb
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)

--- a/gnatsd/tests/test.sh
+++ b/gnatsd/tests/test.sh
@@ -13,10 +13,11 @@ hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
 
 source "${PLANDIR}/plan.sh"
-# Unload the service if its already loaded.
-hab svc unload "${HAB_ORIGIN}/${pkg_name}"
 
 if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
   set -e
   pushd "${PLANDIR}" > /dev/null
   build
@@ -27,7 +28,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 
   # Give some time for the service to start up
-  sleep 5
+  sleep 10
 fi
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./gnatsd/tests/test.sh
```

### Sample output

```
The rakops/gnatsd/1.4.0/20190116003341 service was successfully loaded
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on port 8222 (HTTP)
 ✓ Listening on port 4242 (NATS)

7 tests, 0 failures
```