### PR TITLE
[vault] Update vault to 1.0.2

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=1.0.0
+pkg_version=1.0.2
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=75afb647d2ebeb46aafbf147ed1f1b379f6b8c9f909550dc2d0976cf153e8aa6
+pkg_shasum=5549714c24b61ea77a7afb30e1fbff6ec596cfd39dab7a2e6cf7e71432d616cc
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./vault/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 8200, 8201
 ✓ Good response from /sys/health endpoint

6 tests, 0 failures
[3][default:/src:0]#
```