### PR TITLE
[Artifactory-Pro] Updated plan to 6.6.5

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.6.0
+pkg_version=6.6.5
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=9c1b6d2dfa6e142702d0aa5e09a0dd5435430608742c414dd7675c8ee8352c90
+pkg_shasum=4c4f71a8bbf950a404b0ec15ab2baba3570ba52d9fccd06ce5f41bb119079f3a
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Another simple one. Just bumped the version.

To test this build, log into the studio and run:
```
./tests/test.sh
```

The output should be: 
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Signed-off-by: Christopher P. Maher <chris@mahercode.io>