### PR TITLE
[caddy] Updated caddy to 0.11.2, added tests

### DIFF
--- a/caddy/plan.sh
+++ b/caddy/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=caddy
 pkg_origin=core
-pkg_version="0.11.1"
+pkg_version="0.11.2"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/mholt/caddy/releases/download/v${pkg_version}/caddy_v${pkg_version}_linux_amd64.tar.gz"
-pkg_shasum="d0cf0c2383fa8fd461658b802c3ba12da7ab3b568a872526b0dbc3977397d8ee"
+pkg_shasum="0d89172f4de11117a42c477d7f4c2a52e23c1971c0ed5b77b549ad8d15ad97e8"
 pkg_description="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 pkg_upstream_url="https://caddyserver.com"
 pkg_svc_run="caddy -conf ${pkg_svc_config_path}/Caddyfile"

--- a/caddy/tests/test.bats
+++ b/caddy/tests/test.bats
@@ -1,0 +1,24 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v caddy)" ]
+}
+
+@test "Version matches" {
+  result="$(caddy --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run caddy --help
+  [ $status -eq 2 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "caddy\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 8080" {
+  result="$(netstat -peanut | grep caddy | awk '{print $4}' | awk -F':' '{print $NF}')"
+  [ "${result}" -eq 8080 ]
+}

--- a/caddy/tests/test.sh
+++ b/caddy/tests/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static wc
+hab pkg binlink core/busybox-static uniq
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+
+  # Give some time for the service to start up
+  sleep 3
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./caddy/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 8080

5 tests, 0 failures
```

Happy to wait for base plans refresh.