### PR TITLE
[netdata] add dependencies for mysql monitoring

### DIFF
--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -23,6 +23,7 @@ pkg_deps=(
   core/curl
   core/gawk
   core/glibc
+  core/mysql-client
   core/python
   core/util-linux
   core/zlib
@@ -39,6 +40,15 @@ pkg_exports=(
 pkg_exposes=(port)
 pkg_svc_run="netdata -D -c ${pkg_svc_config_path}/netdata.conf"
 
+
+do_setup_environment() {
+  push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python3.7/site-packages"
+}
+
+do_prepare() {
+  python -m venv "${pkg_prefix}"
+  source "${pkg_prefix}/bin/activate"
+}
 
 do_build() {
   # patch shell script shebang lines to use habitat-provided env
@@ -66,6 +76,10 @@ do_install() {
   find ./libexec/netdata -type f -executable \
     -print \
     -exec bash -c 'sed -e "s#\#\!/usr/bin/env bash#\#\!$1/bin/bash#" --in-place "$2"' _ "$(pkg_path_for bash)" "{}" \;
+
+  build_line "Installing python dependencies"
+  pip install "mysqlclient"
+  pip freeze > requirements.txt
 
   popd > /dev/null
 }


### PR DESCRIPTION
A lot of netdata's stock data collection plugins are child-plugins under its python meta-plugin. This PR gives netdata the python environment those plugins need and illustrates how to add one of the optional dependencies

There is a table of the common optional python dependencies at the end of this section: https://docs.netdata.cloud/packaging/installer/#prepare-your-system

Question: would it be best for the core plan to come with a wide set of common optional dependencies? I figured it's worth including at least one common one so that there's a clear approach to adding more in forked plans. I could get behind trying to add all the deps in that table of common ones though