### PR TITLE
[consul] Update consul to 1.4.1, security update

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.4.0
+pkg_version=1.4.1
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=41f8c3d63a18ef4e51372522c1e052618cdfcffa3d9f02dba0b50820e8279824
+pkg_shasum=965ecbfb2bb2443d5271ae5702b9fc80b8c5158654caa850107ecf4608eb2d11
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Blog post / release notes: https://www.hashicorp.com/blog/hashicorp-consul-1-4-1

### Testing

```
hab studio enter
./consul/tests/test.sh
```

### Sample output

```
Waiting for consul to start

 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```