### PR TITLE
[go] Bump to 1.11.5

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.11.3
+pkg_version=1.11.5
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=7ec5140f384db2bd42b396c93c231dfba342ee137ad8a4b33120016951eb1231
+pkg_shasum=bc1ef02bb1668835db1390a2e478dcbccb5dd16911691af9d75184bbe5aa943e
 pkg_dirname=go
 pkg_deps=(core/glibc core/iana-etc core/cacerts)
 pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)


### PR DESCRIPTION
This is a security release that addresses CVE-2019-6486. See

https://groups.google.com/forum/#!msg/golang-announce/mVeX35iXuSw/Flp8FX7QEAAJ

for more information.

Signed-off-by: Steven Danna <steve@chef.io>