### PR TITLE
[rust] use 2015 CPP and do not dirty repo in build

### DIFF
--- a/rust/plan.ps1
+++ b/rust/plan.ps1
@@ -7,19 +7,22 @@ $pkg_license=@("Apache-2.0", "MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://static.rust-lang.org/dist/rust-$pkg_version-x86_64-pc-windows-msvc.msi"
 $pkg_shasum="dde419524226d4a5f0f9e37fa719221bb7984d35f3d3b7dd57aa1b781bca962d"
-$pkg_deps=@("core/visual-cpp-redist-2013", "core/visual-cpp-build-tools-2015")
+$pkg_deps=@("core/visual-cpp-redist-2015", "core/visual-cpp-build-tools-2015")
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 $pkg_lib_dirs=@("lib")
 
 function Invoke-Unpack {
-  lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
   mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  Move-Item "rust-$pkg_version-x86_64-pc-windows-msvc/SourceDir/Rust" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  try {
+    lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+  }
+  finally { Pop-Location }
 }
 
 function Invoke-Install {
-  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/Rust/*" "$pkg_prefix" -Recurse -Force
+  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/rust-$pkg_version-x86_64-pc-windows-msvc/SourceDir/Rust/*" "$pkg_prefix" -Recurse -Force
 }
 
 function Invoke-Check() {


### PR DESCRIPTION
This uses the new 2015 CPP redist package and I have tested that using the rust toolchain with that dep works fine. This will prevent habitat builds from pulling 2 CPP packages.

This also cleans up the builds so that nothing is extracted directly into the `src` dir. This is something I will need to do across all plans using this pattern.

Signed-off-by: mwrock <matt@mattwrock.com>