### PR TITLE
[ruby] Lock rubygems version to 2.7.8

### DIFF
--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -40,6 +40,6 @@ do_check() {
 
 do_install() {
   do_default_install
-  gem update --system --no-document
+  gem update --system 2.7.8 --no-document
   gem install rb-readline --no-document
 }

--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -41,6 +41,6 @@ do_check() {
 
 do_install() {
   do_default_install
-  gem update --system --no-document
+  gem update --system 2.7.8 --no-document
   gem install rb-readline --no-document
 }


### PR DESCRIPTION
`gem update --system` will bring in rubygems 3.x, which is causing a number of issues with downstream projects. This locks us to the rubygems version in use pre-base-plans-refresh.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>