### PR TITLE
[ansible] Move OpenSSL dep

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -10,12 +10,12 @@ pkg_deps=(
   core/libffi
   core/python2
   core/sshpass
+  core/openssl
 )
 pkg_build_deps=(
   core/gcc
   core/libyaml
   core/make
-  core/openssl
 )
 pkg_bin_dirs=(bin)
 pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."

--- a/ansible/tests/test.sh
+++ b/ansible/tests/test.sh
@@ -18,7 +18,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 fi
 
-PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path "${pkg_origin}/ansible")/lib/python2.7/site-packages"
+PYTHONPATH="$(hab pkg path core/python2)/lib/python2.7/site-packages:$(hab pkg path "${HAB_ORIGIN}/${pkg_name}")/lib/python2.7/site-packages"
 export PYTHONPATH
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #2206 - Also fixed tests to work correctly based on users / test server origin settings.

### Testing

```
hab studio enter
./ansible/tests/test.sh

source ansible/plan.sh
find $(hab pkg path "${HAB_ORIGIN}/${pkg_name}") -iname "*.so" -exec ldd \{\} \; | grep -i "not found"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
[57][default:/src:0]# find $(hab pkg path "${HAB_ORIGIN}/${pkg_name}") -iname "*.so" -exec ldd \{\} \; | grep -i "not found"
[58][default:/src:1]# 
```

NOTE: The exit code from the `find | ldd` should be `1` to indicate no instances of "not found" entries were in the ldd output.