### PR TITLE
[llvm5][clang5] Deprecate llvm5 and clang5

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -119,11 +119,6 @@ plan_path = "check"
 plan_path = "chrony"
 [clang]
 plan_path = "clang"
-[clang5]
-plan_path = "clang5"
-paths = [
-  "clang/*"
-]
 [clang7]
 plan_path = "clang7"
 paths = [
@@ -773,11 +768,6 @@ plan_path = "linux-headers-musl"
 plan_path = "linux-pam"
 [llvm]
 plan_path = "llvm"
-[llvm5]
-plan_path = "llvm5"
-paths = [
-  "llvm/*"
-]
 [llvm7]
 plan_path = "llvm7"
 paths = [

--- a/clang5/README.md
+++ b/clang5/README.md
@@ -1,16 +1,3 @@
 # clang5
 
-LLVM native C/C++/Objective-C compiler
-
-## Maintainers
-
-* The Habitat Maintainers: <humans@habitat.sh>
-
-## Type of Package
-
-Binary package
-
-## Usage
-
-Include `core/clang5` if you need any of the libraries, includes, clang tools and clang-tools-extra.  For additional
-usage, refer to the [`pkg_upstream_url`](http://clang.llvm.org/)
+This package requires llvm5 to build, which has been deprecated.

--- a/clang5/plan.sh
+++ b/clang5/plan.sh
@@ -19,3 +19,6 @@ pkg_build_deps=(
   core/diffutils
   core/ninja
 )
+
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"

--- a/llvm5/README.md
+++ b/llvm5/README.md
@@ -1,10 +1,3 @@
 # llvm5
 
-This package provides the llvm 5.x libraries and binaries.
-
-## Usage
-
-Typically this is a build dependency that can be added to your
-plan.sh:
-
-    pkg_build_deps=(core/llvm5)
+This package requires an older version of GCC than is in stable to build and has been deprecated.

--- a/llvm5/plan.sh
+++ b/llvm5/plan.sh
@@ -24,3 +24,6 @@ pkg_build_deps=(
   core/gcc
   core/ninja
 )
+
+# Hint for rebuild scripts. Not a formal part of plan-build.
+pkg_deprecated="true"


### PR DESCRIPTION
In the recent base-plans-refresh #1767 we updated the version of GCC from 7 to 8.    llvm5 is unable to build with this new version and needs to be deprecated. Since clang5 requires llvm5 to build, it is deprecated as part of this PR as well.

#### Why didn't we introduce a gcc7 and gcc7-libs per RFC-003?

Adding a gcc7 plan would be a relatively safe operation as it would be primarily used at build time, but would necessitate the addition of a gcc7-libs package. With gcc7-libs, you could potentially end up in a state where you have two different versions of gcc libraries that your software would consume at runtime leading to unexpected behavior. 

Consider two fictional packages, A and B.  A has a runtime dependency on `gcc-libs` and `B`. `B` has a runtime dependency on `gcc7-libs`.  When you execute a command from A, it will start to load the libraries required. Depending on the load order, it will load libraries from one of the gcc-libs packages first. When it tries to load libraries from the other gcc-libs package, it will see that the libraries with that name are already loaded. At this point, your software or _some_ of its library dependencies are utilizing libraries of different versions than they were built against.  

Since gcc-libs and gcc7-libs don't conflict with each other from a package naming perspective, we are unable to guard against that behavior at this time. We chose to break RFC-003 in this instance instead and deprecate llvm5 and clang5.

If you are interested in much more detailed write up about library loading in Linux, [this post](https://amir.rachum.com/blog/2016/09/17/shared-libraries/) is a good place to start. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>