### PR TITLE
[leveldb] Add gcc libs

### DIFF
--- a/leveldb/plan.sh
+++ b/leveldb/plan.sh
@@ -7,8 +7,15 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://github.com/google/leveldb/archive/v${pkg_version}.tar.gz"
 pkg_shasum="f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664"
-pkg_deps=(core/snappy core/glibc)
-pkg_build_deps=(core/make core/gcc)
+pkg_deps=(
+  core/snappy
+  core/glibc
+  core/gcc-libs
+)
+pkg_build_deps=(
+  core/make
+  core/gcc
+)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #2220 

### Testing

```
hab studio enter
build leveldb
source results/last_build.env
find /hab/pkgs/${pkg_ident}/lib -type f -exec echo "{}" \; -exec ldd {} \;
```

### Sample output

```
/hab/pkgs/rakops/leveldb/1.20/20190131001554/lib/libleveldb.so
	linux-vdso.so.1 (0x00007ffe58e91000)
	libsnappy.so.1 => /hab/pkgs/core/snappy/1.1.4/20190117153136/lib/libsnappy.so.1 (0x00007f087efd9000)
	libstdc++.so.6 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libstdc++.so.6 (0x00007f087ec23000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007f087ea90000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007f087efbf000)
	libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007f087ef9f000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f087e8d8000)
	/hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007f087ee2b000)
/hab/pkgs/rakops/leveldb/1.20/20190131001554/lib/libleveldb.so.1.20
	linux-vdso.so.1 (0x00007ffd62dfd000)
	libsnappy.so.1 => /hab/pkgs/core/snappy/1.1.4/20190117153136/lib/libsnappy.so.1 (0x00007fa26ee0c000)
	libstdc++.so.6 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libstdc++.so.6 (0x00007fa26ea56000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007fa26e8c3000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007fa26edf2000)
	libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007fa26edd2000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007fa26e70b000)
	/hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007fa26ec5e000)
/hab/pkgs/rakops/leveldb/1.20/20190131001554/lib/libleveldb.so.1
	linux-vdso.so.1 (0x00007ffd00d78000)
	libsnappy.so.1 => /hab/pkgs/core/snappy/1.1.4/20190117153136/lib/libsnappy.so.1 (0x00007f81df1f3000)
	libstdc++.so.6 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libstdc++.so.6 (0x00007f81dee3d000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007f81decaa000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007f81df1d9000)
	libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007f81df1b9000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f81deaf2000)
	/hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007f81df045000)

```