### PR TITLE
[libfcgi] Add gcc libs to deps

### DIFF
--- a/libfcgi/plan.sh
+++ b/libfcgi/plan.sh
@@ -9,31 +9,25 @@ pkg_source="http://ftp.debian.org/debian/pool/main/${pkg_name:0:4}/${pkg_name}/$
 pkg_shasum="c21f553f41141a847b2f1a568ec99a3068262821e4e30bc9d4b5d9091aa0b5f7"
 pkg_filename="${pkg_name}_${pkg_version}.orig.tar.gz"
 pkg_dirname="${pkg_name}-${pkg_version}.orig"
-
 pkg_build_deps=(
   core/make
   core/gcc
   core/patch
 )
-
 pkg_deps=(
   core/glibc
+  core/gcc-libs
 )
-
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
-
 do_build() {
   patch -p0 -i "${PLAN_CONTEXT}/stdio.patch"
-
   do_default_build
 }
 
 do_install() {
   do_default_install
-
-  build_line "Copying LICENSE to build artifact"
   cp -v ./LICENSE.TERMS "${pkg_prefix}/LICENSE"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #2221 

### Testing

```
hab studio enter
build libfcgi
source results/last_build.env
ldd /hab/pkgs/${pkg_ident}/lib/libfcgi++.so.0.0.0
```

### Sample output

```
# ldd /hab/pkgs/${pkg_ident}/lib/libfcgi++.so.0.0.0
	linux-vdso.so.1 (0x00007ffe9cbaa000)
	libfcgi.so.0 => /hab/pkgs/rakops/libfcgi/2.4.0/20190131014632/lib/libfcgi.so.0 (0x00007f5039893000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007f5039879000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f50396c1000)
	/hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007f5039687000)

```