### PR TITLE
[boost/boost159] Move gcc-libs to pkg_deps

### DIFF
--- a/boost/plan.sh
+++ b/boost/plan.sh
@@ -12,6 +12,7 @@ pkg_dirname=boost_1_66_0
 pkg_deps=(
   core/glibc
   core/gcc-libs
+  core/zlib
 )
 
 pkg_build_deps=(
@@ -27,7 +28,6 @@ pkg_build_deps=(
   core/libxslt
   core/openssl
   core/which
-  core/zlib
 )
 
 pkg_lib_dirs=(lib)

--- a/boost159/plan.sh
+++ b/boost159/plan.sh
@@ -8,12 +8,11 @@ pkg_license=('Boost Software License')
 pkg_dirname="boost_${pkg_version//./_}"
 pkg_source="http://downloads.sourceforge.net/project/boost/boost/${pkg_version}/${pkg_dirname}.tar.gz"
 pkg_shasum="47f11c8844e579d02691a607fbd32540104a9ac7a2534a8ddaef50daf502baac"
-
 pkg_deps=(
   core/glibc
   core/gcc-libs
+  core/zlib
 )
-
 pkg_build_deps=(
   core/glibc
   core/gcc-libs
@@ -27,9 +26,7 @@ pkg_build_deps=(
   core/libxslt
   core/openssl
   core/which
-  core/zlib
 )
-
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #2208 and Fixes #2209 

### Testing

```
hab studio enter
build boost
source results/last_build.env
ldd /hab/pkgs/${pkg_ident}/lib/libboost_iostreams.so.1.66.0
```

### Sample output

```
ldd /hab/pkgs/${pkg_ident}/lib/libboost_iostreams.so.1.66.0
	linux-vdso.so.1 (0x00007ffcfa5b1000)
	libz.so.1 => /hab/pkgs/core/zlib/1.2.11/20190115003728/lib/libz.so.1 (0x00007ff4cba49000)
	librt.so.1 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/librt.so.1 (0x00007ff4cba3f000)
	libstdc++.so.6 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libstdc++.so.6 (0x00007ff4cb65b000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007ff4cb8ac000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007ff4cb892000)
	libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007ff4cb63b000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007ff4cb483000)
	/hab/pkgs/core/glibc/2.27/20180608041157/lib64/ld-linux-x86-64.so.2 (0x00007ff4cb863000)

```