### PR TITLE
[scaffolding-chef] remove binding feature for chef-client consumer packages for now

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -74,7 +74,6 @@ cd {{pkg.path}}
 exec 2>&1
 sleep \$SPLAY_FIRST_RUN_DURATION
 chef_client_cmd
-echo "chef_client_ident = \"{{pkg.ident}}\"" | hab config apply {{svc.service}}.{{svc.group}} $(date +'%s')
 
 while true; do
 

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.4.0"
+pkg_version="0.5.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

See discussion in #2203 

Removing this feature for now until we can build a more robust version of it.