### PR TITLE
[ruby] Add ruby26 plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1202,6 +1202,11 @@ plan_path = "ruby25"
 paths = [
   "ruby/*"
 ]
+[ruby26]
+plan_path = "ruby26"
+paths = [
+  "ruby/*"
+]
 [runc]
 plan_path = "runc"
 [runit]

--- a/ruby26/README.md
+++ b/ruby26/README.md
@@ -1,0 +1,15 @@
+# ruby26
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/ruby26/README.md
+++ b/ruby26/README.md
@@ -12,4 +12,8 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+hab pkg exec core/ruby26 ruby --help
+
+You can add this as a build dependency to your plan with:
+
+pkg_build_deps=(core/ruby26)

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -1,0 +1,44 @@
+pkg_name=ruby26
+pkg_origin=core
+pkg_version=2.6.1
+pkg_description="A dynamic, open source programming language with a focus on \
+  simplicity and productivity. It has an elegant syntax that is natural to \
+  read and easy to write."
+pkg_license=("Ruby")
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
+pkg_upstream_url=https://www.ruby-lang.org/en/
+pkg_shasum=17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8
+pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+pkg_interpreters=(bin/ruby)
+pkg_dirname="ruby-$pkg_version"
+
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O3 -g -pipe"
+  build_line "Setting CFLAGS='$CFLAGS'"
+}
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-shared \
+    --disable-install-doc \
+    --with-openssl-dir="$(pkg_path_for core/openssl)" \
+    --with-libyaml-dir="$(pkg_path_for core/libyaml)"
+
+  make
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  do_default_install
+  gem update --system --no-document
+  gem install rb-readline --no-document
+}


### PR DESCRIPTION
[9][default:/src/ruby26:126]# /hab/cache/src/ruby-2.6.1/ruby -v
ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-linux]

Signed-off-by: Tim Smith <tsmith@chef.io>