### PR TITLE
Fix ruby25 download url

### DIFF
--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -6,7 +6,7 @@ pkg_description="A dynamic, open source programming language with a focus on \
   read and easy to write."
 pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
 pkg_shasum=9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)


### PR DESCRIPTION
This corrects the download url for the ruby25 package.  Prior to this change, it would evaluate to `ruby25/ruby25-2.5.3.tar.gz` which is not how upstream distributes the source.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>