### PR TITLE
[libtiff] Update libtiff 4.0.6 -> 4.0.10

### DIFF
--- a/libtiff/plan.sh
+++ b/libtiff/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libtiff
 pkg_origin=core
-pkg_version=4.0.6
+pkg_version=4.0.10
 pkg_description="Library for reading and writting files in the Tag Image File Format (TIFF)"
 pkg_upstream_url="http://www.remotesensing.org/libtiff/"
 pkg_license=('libtiff')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.osgeo.org/libtiff/tiff-${pkg_version}.tar.gz"
-pkg_shasum=4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c
+pkg_shasum=2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4
 pkg_deps=(core/glibc core/zlib core/libjpeg-turbo core/xz core/jbigkit)
 pkg_build_deps=(core/gcc core/make core/diffutils core/file)
 pkg_dirname="tiff-${pkg_version}"


### PR DESCRIPTION
   libtiff: Source Path: /hab/cache/src/tiff-4.0.10
   libtiff: Installed Path: /hab/pkgs/tas50/libtiff/4.0.10/20190131231911
   libtiff: Artifact: /src/libtiff/results/tas50-libtiff-4.0.10-20190131231911-x86_64-linux.hart
   libtiff: Build Report: /src/libtiff/results/last_build.env
   libtiff: SHA256 Checksum: f01a3a7bdeb20c6585cea232e85243bfe6a34c65e89beb163ff972196df6c1b5
   libtiff: Blake2b Checksum: 8441008d48ca7c266d2d09faea526ab36346a4ca53753797c88726f6506c43e5
   libtiff:
   libtiff: I love it when a plan.sh comes together.
   libtiff:
   libtiff: Build time: 0m49s

2018-11-10  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* configure.ac: libtiff 4.0.10 released.

	Change COMPRESSION_ZSTD to 50000 and COMPRESSION_WEBP to 50001.

2018-11-04  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	Added preliminary release notes for release 4.0.10.

2018-11-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	tiff2pdf: Eliminate compiler warning about snprintf output truncation when formatting pdf_datetime.

2018-11-03  Olivier Paquet  <olivier.paquet@gmail.com>

	Merge branch 'no_tif_platform_console' into 'master'
	Remove builtin support for GUI warning and error message boxes

	See merge request libtiff/libtiff!24

2018-11-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	tiffcrop.c: Eliminate compiler warning about snprintf output truncation when formatting filenum.

	TWebPVGetField(): Add apparently missing break statement impacting TIFFTAG_WEBP_LOSSLESS.

	Eliminate compiler warnings about duplicate definitions of streq/strneq macros.

	Ignore generated files.

	Remove and ignore files which are a product of autogen.sh.

2018-11-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	Fix TIFFErrorExt() formatting of size_t type for 32-bit compiles.

2018-10-30  Even Rouault  <even.rouault@spatialys.com>

	tiff2bw: avoid null pointer dereference in case of out of memory situation. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2819 / CVE-2018-18661

	tiffio.h: fix comment.

2018-10-26  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'header2' into 'master'
	Fix 725279bd: Standalone tif_predict.h: tiff.h should be tiffiop.h

	See merge request libtiff/libtiff!41

2018-10-26  Kurt Schwehr  <schwehr@google.com>

	Fix 725279bd: Standalone tif_predict.h: tiff.h should be tiffiop.h.

2018-10-25  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'headers' into 'master'
	Add includes to headers to allow them to stand alone.

	See merge request libtiff/libtiff!40

2018-10-24  Kurt Schwehr  <schwehr@google.com>

	Add includes to headers to allow them to stand alone.
	This allows compilers that can do header stand alone header parsing
	to process libtiff.

2018-10-18  Even Rouault  <even.rouault@spatialys.com>

	LZMAPreEncode: emit verbose error if lzma_stream_encoder() fails (typically because not enough memory available)

2018-10-17  Even Rouault  <even.rouault@spatialys.com>

	tif_webp.c: fix previous commit that broke scanline decoding.

	tif_webp.c: fix potential read outside libwebp buffer on corrupted images

2018-10-14  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'jbig_decode_overflow' into 'master'
	JBIG: fix potential out-of-bounds write in JBIGDecode()

	See merge request libtiff/libtiff!38

2018-10-14  Even Rouault  <even.rouault@spatialys.com>

	JBIG: fix potential out-of-bounds write in JBIGDecode()
	JBIGDecode doesn't check if the user provided buffer is large enough
	to store the JBIG decoded image, which can potentially cause out-of-bounds
	write in the buffer.
	This issue was reported and analyzed by Thomas Dullien.

	Also fixes a (harmless) potential use of uninitialized memory when
	tif->tif_rawsize > tif->tif_rawcc

	And in case libtiff is compiled with CHUNKY_STRIP_READ_SUPPORT, make sure
	that whole strip data is provided to JBIGDecode()

2018-10-05  Even Rouault  <even.rouault@spatialys.com>

	tif_webp.c: fix scanline reading/writing.

	WEBP codec: initialize nSamples in TWebPSetupDecode() and TWebPSetupEncode()

2018-10-05  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'tif_webp' into 'master'
	webp support

	See merge request libtiff/libtiff!32

2018-10-05  Norman Barker  <norman.barker@mapbox.com>

	webp in tiff.

2018-09-17  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'master' into 'master'
	fix three potential vulnerabilities.

	See merge request libtiff/libtiff!33

2018-09-08  Young_X  <YangX92@hotmail.com>

	fix out-of-bound read on some tiled images.

	avoid potential int32 overflows in multiply_ms()

	only read/write TIFFTAG_GROUP3OPTIONS or TIFFTAG_GROUP4OPTIONS if compression is COMPRESSION_CCITTFAX3 or COMPRESSION_CCITTFAX4

2018-08-15  Even Rouault  <even.rouault@spatialys.com>

	TIFFSetupStrips(): avoid potential uint32 overflow on 32-bit systems with large number of strips. Probably relates to http://bugzilla.maptools.org/show_bug.cgi?id=2788 / CVE-2018-10779

2018-08-07  Even Rouault  <even.rouault@spatialys.com>

	ZSTD: fix flush issue that can cause endless loop in ZSTDEncode()
	Fixes https://github.com/OSGeo/gdal/issues/833

2018-08-07  Even Rouault  <even.rouault@spatialys.com>

	Merge branch 'fix_bug_2800' into 'master'
	Fix libtiff 4.0.8 regression when reading LZW-compressed strips with scanline API

	See merge request libtiff/libtiff!31

2018-08-07  Even Rouault  <even.rouault@spatialys.com>

	Fix libtiff 4.0.8 regression when reading LZW-compressed strips with scanline API
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2800

2018-07-05  Even Rouault  <even.rouault@spatialys.com>

	Add tag and pseudo-tag definitions for ESRI LERC codec (out of tree codec whose source is at https://github.com/OSGeo/gdal/blob/master/gdal/frmts/gtiff/tif_lerc.c)

2018-07-02  Even Rouault  <even.rouault@spatialys.com>

	Fix TIFFTAG_ZSTD_LEVEL pseudo tag value to be > 65536, and the next one in the series

2018-05-25  Stefan Weil  <sw@weilnetz.de>

	Remove builtin support for GUI warning and error message boxes.
	Now warnings always go to the console by default unless applications
	define their own warning and error handlers.

	GUI applications (and Windows CE) are required to define such handlers.

2018-05-12  Even Rouault  <even.rouault@spatialys.com>

	LZWDecodeCompat(): fix potential index-out-of-bounds write. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2780 / CVE-2018-8905
	The fix consists in using the similar code LZWDecode() to validate we
	don't write outside of the output buffer.

	TIFFFetchNormalTag(): avoid (probably false positive) clang-tidy clang-analyzer-core.NullDereference warnings

	TIFFWriteDirectorySec: avoid assertion. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2795. CVE-2018-10963

2018-05-04  Even Rouault  <even.rouault@spatialys.com>

	tif_color.c: fix code comment.

2018-04-17  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'fuzzer-fix' into 'master'
	remove a pointless multiplication and a variable that's not necessary

	See merge request libtiff/libtiff!29

2018-04-17  Paul Kehrer  <paul.l.kehrer@gmail.com>

	remove a pointless multiplication and a variable that's not necessary.

2018-04-17  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'ossfuzz' into 'master'
	move oss-fuzz build script and fuzzer into libtiff tree

	See merge request libtiff/libtiff!28

2018-04-17  Paul Kehrer  <paul.l.kehrer@gmail.com>

	move oss-fuzz build script and fuzzer into libtiff tree.

2018-04-14  Even Rouault  <even.rouault@spatialys.com>

	_TIFFGetMaxColorChannels: update for LOGLUV, ITULAB and ICCLAB that have 3 color channels

2018-04-12  Even Rouault  <even.rouault@spatialys.com>

	Fix MSVC warning.

2018-04-12  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'master' into 'master'
	Fix NULL pointer dereference in TIFFPrintDirectory (bugzilla 2778/CVE-2018-7456)

	See merge request libtiff/libtiff!27

2018-04-11  Hugo Lefeuvre  <hle@debian.org>

	Fix NULL pointer dereference in TIFFPrintDirectory.
	The TIFFPrintDirectory function relies on the following assumptions,
	supposed to be guaranteed by the specification:

	(a) A Transfer Function field is only present if the TIFF file has
	    photometric type < 3.

	(b) If SamplesPerPixel > Color Channels, then the ExtraSamples field
	    has count SamplesPerPixel - (Color Channels) and contains
	    information about supplementary channels.

	While respect of (a) and (b) are essential for the well functioning of
	TIFFPrintDirectory, no checks are realized neither by the callee nor
	by TIFFPrintDirectory itself. Hence, following scenarios might happen
	and trigger the NULL pointer dereference:

	(1) TIFF File of photometric type 4 or more has illegal Transfer
	    Function field.

	(2) TIFF File has photometric type 3 or less and defines a
	    SamplesPerPixel field such that SamplesPerPixel > Color Channels
	    without defining all extra samples in the ExtraSamples fields.

	In this patch, we address both issues with respect of the following
	principles:

	(A) In the case of (1), the defined transfer table should be printed
	    safely even if it isn't 'legal'. This allows us to avoid expensive
	    checks in TIFFPrintDirectory. Also, it is quite possible that
	    an alternative photometric type would be developed (not part of the
	    standard) and would allow definition of Transfer Table. We want
	    libtiff to be able to handle this scenario out of the box.

	(B) In the case of (2), the transfer table should be printed at its
	    right size, that is if TIFF file has photometric type Palette
	    then the transfer table should have one row and not three, even
	    if two extra samples are declared.

	In order to fulfill (A) we simply add a new 'i < 3' end condition to
	the broken TIFFPrintDirectory loop. This makes sure that in any case
	where (b) would be respected but not (a), everything stays fine.

	(B) is fulfilled by the loop condition
	'i < td->td_samplesperpixel - td->td_extrasamples'. This is enough as
	long as (b) is respected.

	Naturally, we also make sure (b) is respected. This is done in the
	TIFFReadDirectory function by making sure any non-color channel is
	counted in ExtraSamples.

	This commit addresses CVE-2018-7456.

2018-03-27  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'tiffset-long8' into 'master'
	tiffset: Add support for LONG8, SLONG8 and IFD8 field types

	See merge request libtiff/libtiff!25

2018-03-26  Roger Leigh  <rleigh@codelibre.net>

	port: Clean up NetBSD sources and headers to build standalone.

2018-03-23  Roger Leigh  <rleigh@dundee.ac.uk>

	port: Add strtol, strtoll and strtoull.
	Also update strtoul.  All use the same implementation from NetBSD libc.

	tiffset: Add support for LONG8, SLONG8 and IFD8 field types.

2018-03-17  Even Rouault  <even.rouault@spatialys.com>

	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
	Rework fix done in 3719385a3fac5cfb20b487619a5f08abbf967cf8 to work in more
	cases like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6979.
	Credit to OSS Fuzz

	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724

2018-03-13  Even Rouault  <even.rouault@spatialys.com>

	libtiff/tif_luv.c: rewrite loops in a more readable way (to avoid false positive reports like http://bugzilla.maptools.org/show_bug.cgi?id=2779)

2018-03-13  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'avoid_memory_exhaustion_in_ChopUpSingleUncompressedStrip' into 'master'
	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)

	See merge request libtiff/libtiff!26

2018-03-11  Even Rouault  <even.rouault@spatialys.com>

	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
	In ChopUpSingleUncompressedStrip(), if the computed number of strips is big
	enough and we are in read only mode, validate that the file size is consistent
	with that number of strips to avoid useless attempts at allocating a lot of
	memory for the td_stripbytecount and td_stripoffset arrays.

	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724

2018-03-10  Even Rouault  <even.rouault@spatialys.com>

	Typo fix in comment.

2018-03-03  Even Rouault  <even.rouault@spatialys.com>

	Avoid warning with gcc 8 (partially revert 647b0e8c11ee11896f319b92cf110775f538d75c)

2018-02-25  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'typos' into 'master'
	Fix some typos

	See merge request libtiff/libtiff!23

2018-02-24  Stefan Weil  <sw@weilnetz.de>

	Fix some typos.
	Most of them were found by codespell.

2018-02-14  Even Rouault  <even.rouault@spatialys.com>

	Typo fix in comment.

	Merge branch 'zstd'

	Add warning about COMPRESSION_ZSTD not being officialy registered.

2018-02-14  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'bug2772' into 'master'
	Fix for bug 2772

	See merge request libtiff/libtiff!20

2018-02-12  Nathan Baker  <nathanb@lenovo-chrome.com>

	Fix for bug 2772.
	It is possible to craft a TIFF document where the IFD list is circular,
	leading to an infinite loop while traversing the chain. The libtiff
	directory reader has a failsafe that will break out of this loop after
	reading 65535 directory entries, but it will continue processing,
	consuming time and resources to process what is essentially a bogus TIFF
	document.

	This change fixes the above behavior by breaking out of processing when
	a TIFF document has >= 65535 directories and terminating with an error.

2018-02-09  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'libtiff-as-subdirectory-fixes' into 'master'
	Prefer target_include_directories

	See merge request libtiff/libtiff!12

2018-02-06  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'cmake-cleanups' into 'master'
	Cmake cleanups

	See merge request libtiff/libtiff!11

2018-02-06  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'check-right-cxx-variable' into 'master'
	Check right cxx variable

	See merge request libtiff/libtiff!19

2018-02-06  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'dont-leak-stream-open' into 'master'
	Fix a memory leak in TIFFStreamOpen

	See merge request libtiff/libtiff!17

2018-02-06  Ben Boeckel  <ben.boeckel@kitware.com>

	cmake: check CXX_SUPPORT.
	This variable is set in response to the `cxx` cache variable; use it
	instead.

2018-02-04  Olivier Paquet  <olivier.paquet@gmail.com>

	Merge branch 'warnings' into 'master'
	Fix all compiler warnings for default build

	See merge request libtiff/libtiff!16

2018-02-04  Nathan Baker  <elitebadger@gmail.com>

	Fix all compiler warnings for default build.

2018-01-30  Paul Kehrer  <paul.l.kehrer@gmail.com>

	tabs are hard.

2018-01-29  Paul Kehrer  <paul.l.kehrer@gmail.com>

	use hard tabs like the rest of the project.

	Fix a memory leak in TIFFStreamOpen.
	TIFFStreamOpen allocates a new tiff{o,i}s_data, but if TIFFClientOpen
	fails then that struct is leaked. Delete it if the returned TIFF * is
	null.

2018-01-29  Kevin Funk  <kfunk@kde.org>

	Bump minimum required CMake version to v2.8.11.
	Because we use the BUILD_INTERFACE generator expression

2018-01-27  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'patch-1' into 'master'
	Update CMakeLists.txt for build fix on Windows

	See merge request libtiff/libtiff!14

2018-01-27  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'patch-2' into 'master'
	Update tiffgt.c for build fix on Windows

	See merge request libtiff/libtiff!13

2018-01-25  Olivier Paquet  <olivier.paquet@gmail.com>

	Merge branch 'bug2750' into 'master'
	Add workaround to pal2rgb buffer overflow.

	See merge request libtiff/libtiff!15

2018-01-25  Nathan Baker  <elitebadger@gmail.com>

	Add workaround to pal2rgb buffer overflow.

2018-01-23  Andrea  <andrea@andreaplanet.com>

	Update tiffgt.c for build fix on Windows.

	Update CMakeLists.txt for build fix on Windows.

2018-01-15  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'has-attribute-check' into 'master'
	tiffiop: use __has_attribute to detect the no_sanitize attribute

	See merge request libtiff/libtiff!10

2018-01-15  Ben Boeckel  <ben.boeckel@kitware.com>

	cmake: avoid setting hard-coded variables in the cache.

	cmake: avoid an unnecessary intermediate variable.

	cmake: avoid an unnecessary intermediate variable.

	cmake: avoid tautological logic.

	cmake: use check_symbol_exists.
	This accounts for symbols being provided by macros.

	cmake: remove unused configure checks.

2018-01-12  Kevin Funk  <kfunk@kde.org>

	Prefer target_include_directories.
	When libtiff is included in a super project via a simple
	`add_subdirectory(libtiff)`, this way the `tiff` library target has all
	the necessary information to build against it.

	Note: The BUILD_INTERFACE generator expression feature requires at least
	CMake v2.8.11 if I'm correct.

2018-01-09  Ben Boeckel  <ben.boeckel@kitware.com>

	tiffiop: use __has_attribute to detect the no_sanitize attribute.

2017-12-31  Even Rouault  <even.rouault@spatialys.com>

	man/TIFFquery.3tiff: remove reference to non-existing TIFFReadStrip() function in TIFFIsByteSwapped() documentation. Patch by Eric Piel. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2763

	libtiff/tif_dir.c: _TIFFVGetField(): fix heap out-of-bounds access when requesting TIFFTAG_NUMBEROFINKS on a EXIF directory. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2765. Reported by Google Autofuzz project

	libtiff/tif_print.c: TIFFPrintDirectory(): fix null pointer dereference on corrupted file. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2770

2017-12-21  Even Rouault  <even.rouault@spatialys.com>

	Add libzstd to gitlab-ci.

2017-12-21  Even Rouault  <even.rouault@spatialys.com>

	Add ZSTD compression codec.
	From https://github.com/facebook/zstd
	"Zstandard, or zstd as short version, is a fast lossless compression
	algorithm, targeting real-time compression scenarios at zlib-level
	and better compression ratios. It's backed by a very fast entropy stage,
	provided by Huff0 and FSE library."

	We require libzstd >= 1.0.0 so as to be able to use streaming compression
	and decompression methods.

	The default compression level we have selected is 9 (range goes from 1 to 22),
	which experimentally offers equivalent or better compression ratio than
	the default deflate/ZIP level of 6, and much faster compression.

	For example on a 6600x4400 16bit image, tiffcp -c zip runs in 10.7 seconds,
	while tiffcp -c zstd runs in 5.3 seconds. Decompression time for zip is
	840 ms, and for zstd 650 ms. File size is 42735936 for zip, and
	42586822 for zstd. Similar findings on other images.

	On a 25894x16701 16bit image,

	                Compression time     Decompression time     File size

	ZSTD                 35 s                   3.2 s          399 700 498
	ZIP/Deflate       1m 20 s                   4.9 s          419 622 336

2017-12-10  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'fix_cve-2017-9935' into 'master'
	Fix CVE-2017-9935

	See merge request libtiff/libtiff!7

2017-12-10  Brian May  <brian@linuxpenguins.xyz>

	tiff2pdf: Fix apparent incorrect type for transfer table.
	The standard says the transfer table contains unsigned 16 bit values,
	I have no idea why we refer to them as floats.

2017-12-10  Brian May  <brian@linuxpenguins.xyz>

	tiff2pdf: Fix CVE-2017-9935.
	Fix for http://bugzilla.maptools.org/show_bug.cgi?id=2704

	This vulnerability - at least for the supplied test case - is because we
	assume that a tiff will only have one transfer function that is the same
	for all pages. This is not required by the TIFF standards.

	We than read the transfer function for every page.  Depending on the
	transfer function, we allocate either 2 or 4 bytes to the XREF buffer.
	We allocate this memory after we read in the transfer function for the
	page.

	For the first exploit - POC1, this file has 3 pages. For the first page
	we allocate 2 extra extra XREF entries. Then for the next page 2 more
	entries. Then for the last page the transfer function changes and we
	allocate 4 more entries.

	When we read the file into memory, we assume we have 4 bytes extra for
	each and every page (as per the last transfer function we read). Which
	is not correct, we only have 2 bytes extra for the first 2 pages. As a
	result, we end up writing past the end of the buffer.

	There are also some related issues that this also fixes. For example,
	TIFFGetField can return uninitalized pointer values, and the logic to
	detect a N=3 vs N=1 transfer function seemed rather strange.

	It is also strange that we declare the transfer functions to be of type
	float, when the standard says they are unsigned 16 bit values. This is
	fixed in another patch.

	This patch will check to ensure that the N value for every transfer
	function is the same for every page. If this changes, we abort with an
	error. In theory, we should perhaps check that the transfer function
	itself is identical for every page, however we don't do that due to the
	confusion of the type of the data in the transfer function.

2017-12-10  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'undef-warn-fixes' into 'master'
	Fix a couple of harmless but annoying -Wundef warnings

	See merge request libtiff/libtiff!8

2017-12-07  Vadim Zeitlin  <vadim@zeitlins.org>

	Remove tests for undefined SIZEOF_VOIDP.
	As configure never uses AC_CHECK_SIZEOF(void*), this symbol is never
	defined and so it doesn't make sense to test it in the code, this just
	results in -Wundef warnings if they're enabled.

	Avoid harmless -Wundef warnings for __clang_major__
	Check that we're using Clang before checking its version.

2017-12-02  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'remove_autogenerated_files' into 'master'
	Remove autogenerated files

	See merge request libtiff/libtiff!5

2017-12-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	Merge branch 'tif_config_h_includes' into 'master'
	'tif_config.h' or 'tiffiop.h' must be included before any system header.

	See merge request libtiff/libtiff!6

2017-12-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	'tif_config.h' or 'tiffio.h' must be included before any system header.

2017-12-01  Even Rouault  <even.rouault@spatialys.com>

	.gitignore: add patterns for build from root.

	Remove remaining .cvsignore files.

	Remove autoconf/automake generated files, and add them to .gitignore.

2017-12-01  Olivier Paquet  <olivier.paquet@gmail.com>

	Merge branch 'makedistcheck' into 'master'
	build/gitlab-ci and build/travis-ci: add a 'make dist' step in autoconf_build()…

	See merge request libtiff/libtiff!4

2017-12-01  Even Rouault  <even.rouault@spatialys.com>

	build/gitlab-ci and build/travis-ci: add a 'make dist' step in autoconf_build() target, to check we are release-ready

2017-12-01  Even Rouault  <even.rouault@mines-paris.org>

	Merge branch 'git_updates' into 'master'
	CVS to Git updates

	See merge request libtiff/libtiff!2

2017-12-01  Even Rouault  <even.rouault@spatialys.com>

	HOWTO-RELEASE: update to use signed tags.

	README.md: use markdown syntax for hyperlinks.

2017-11-30  Even Rouault  <even.rouault@spatialys.com>

	Add .gitignore.

	Regenerate autoconf files.

	Makefile.am: update to reflect removal of README.vms and README -> README.md

	Remove all $Id and $Headers comments with CVS versions.

	HOWTO-RELEASE: update for git.

	Remove outdated .cvsignore.

	Remove outdated commit script.

	Remove README.vms.

	Rename README as README.md, and update content.

	html/index.html: reflect change from CVS to gitlab.

2017-11-30  Olivier Paquet  <olivier.paquet@gmail.com>

	Merge branch 'test-ci' into 'master'
	Update CI configuration

	See merge request libtiff/libtiff!1

2017-11-23  Roger Leigh  <rleigh@codelibre.net>

	appveyor: Correct path for git clone and skip artefact archival.

2017-11-22  Roger Leigh  <rleigh@codelibre.net>

	travis-ci: Remove unused matrix exclusion.

	Add gitlab-ci build support.

2017-11-18  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* configure.ac: libtiff 4.0.9 released.

	* html/v4.0.9.html: Add HTML file to document changes in libtiff
	v4.0.9.

2017-11-17  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_aux.c, tif_getimage.c, tif_read.c: typo fixes in
	comments.

2017-11-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* test/Makefile.am: Add some tests for tiff2bw.

2017-11-01  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* tools/tiff2bw.c (main): Free memory allocated in the tiff2bw
	program.  This is in response to the report associated with
	CVE-2017-16232 but does not solve the extremely high memory usage
	with the associated POC file.

2017-10-29  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* tools/tiff2pdf.c (t2p_sample_realize_palette): Fix possible
	arithmetic overflow in bounds checking code and eliminate
	comparison between signed and unsigned type.

	* tools/fax2tiff.c (_FAX_Client_Data): Pass FAX_Client_Data as the
	client data.  This client data is not used at all at the moment,
	but it makes the most sense.  Issue that the value of
	client_data.fd was passed where a pointer is expected was reported
	via email by Gerald Schade on Sun, 29 Oct 2017.

2017-10-23  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: avoid floating point division by zero in
	initCIELabConversion()
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3733
	Credit to OSS Fuzz

2017-10-17  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: add compatibility with libjpeg-turbo 1.5.2 that
	honours max_memory_to_use > 0.
	Cf https://github.com/libjpeg-turbo/libjpeg-turbo/issues/162

2017-10-10  Even Rouault <even.rouault at spatialys.com>

	* nmake.opt: support a DEBUG=1 option, so as to adjust OPTFLAGS and use
	/MDd runtime in debug mode.

2017-10-01  Even Rouault <even.rouault at spatialys.com>

	* tools/tiffset.c: fix setting a single value for the ExtraSamples tag
	(and other tags with variable number of values).
	So 'tiffset -s ExtraSamples 1 X'. This only worked
	when setting 2 or more values, but not just one.

2017-09-29  Even Rouault <even.rouault at spatialys.com>

	* libtiff/libtiff.def: add TIFFReadRGBAStripExt and TIFFReadRGBATileExt
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2735

2017-09-09  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: add NULL check to avoid likely false positive
	null-pointer dereference warning by CLang Static Analyzer.

2017-09-07  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tiffiop.h, tif_aux.c: redirect SeekOK() macro to a _TIFFSeekoK()
	function that checks if the offset is not bigger than INT64_MAX, so as
	to avoid a -1 error return code of TIFFSeekFile() to match a required
	seek to UINT64_MAX/-1.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2726
	Adapted from proposal by Nicolas Ruff.

2017-08-29  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: accept reading the last strip of a JPEG compressed
	file if the codestream height is larger than the truncated height of the
	strip. Emit a warning in this situation since this is non compliant.

2017-08-28  Even Rouault <even.rouault at spatialys.com>

	* test/Makefile.am: add missing reference to images/quad-lzw-compat.tiff
	to fix "make distcheck". Patch by Roger Leigh

2017-08-23  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirwrite.c: replace assertion to tag value not fitting
	on uint32 when selecting the value of SubIFD tag by runtime check
	(in TIFFWriteDirectoryTagSubifd()).
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2728
	Reported by team OWL337

2017-08-23  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirwrite.c: replace assertion related to not finding the
	SubIFD tag by runtime check (in TIFFWriteDirectorySec())
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2727
	Reported by team OWL337

2017-07-24  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_luv.c: further reduce memory requirements for temporary
	buffer when RowsPerStrip >= image_length in LogLuvInitState() and
	LogL16InitState().
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2700
	Credit to OSS Fuzz

2017-07-24  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: fix fromskew computation when to-be-skipped
	pixel number is not a multiple of the horizontal subsampling, and
	also in some other cases. Impact putcontig8bitYCbCr44tile,
	putcontig8bitYCbCr42tile, putcontig8bitYCbCr41tile,
	putcontig8bitYCbCr21tile and putcontig8bitYCbCr12tile
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2637 (discovered
	by Agostino Sarubbo)
	and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2691 (credit
	to OSS Fuzz)

2017-07-24  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: gtTileContig() and gtTileSeparate():
	properly break from loops on error when stoponerr is set, instead
	of going on iterating on row based loop.

2017-07-18  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_luv.c: LogLuvInitState(): avoid excessive memory
	allocation when RowsPerStrip tag is missing.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2683
	Credit to OSS-Fuzz

2017-07-15  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: add protection against excessive memory
	allocation attempts in TIFFReadDirEntryArray() on short files.
	Effective for mmap'ed case. And non-mmap'ed case, but restricted
	to 64bit builds.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2675

2017-07-15  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: in TIFFFetchStripThing(), only grow the
	arrays that hold StripOffsets/StripByteCounts, when they are smaller
	than the expected number of striles, up to 1 million striles, and
	error out beyond. Can be tweaked by setting the environment variable
	LIBTIFF_STRILE_ARRAY_MAX_RESIZE_COUNT.
	This partially goes against a change added on 2002-12-17 to accept
	those arrays of wrong sizes, but is needed to avoid denial of services.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2350
	Credit to OSS Fuzz

2017-07-15  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillStrip() / TIFFFillTile().
	Complementary fix for http://bugzilla.maptools.org/show_bug.cgi?id=2708
	in the isMapped() case, so as to avoid excessive memory allocation
	when we need a temporary buffer but the file is truncated.

2017-07-15  Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: prevent heap buffer overflow write in "Raw"
	mode on PlanarConfig=Contig input images.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2715
	Reported by team OWL337

2017-07-11  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dir.c: avoid potential null pointer dereference in
	_TIFFVGetField() on corrupted TIFFTAG_NUMBEROFINKS tag instance.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2713

2017-07-11  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_lzw.c: fix potential out-of-buffer read on 1-byte LZW
	strips. Crashing issue only on memory mapped files, where the strip
	offset is the last byte of the file, and the file size is a multiple
	of one page size on the CPU architecture (typically 4096). Credit
	to myself :-)

2017-07-11  Even Rouault <even.rouault at spatialys.com>

	* test/tiffcp-lzw-compat.sh, test/images/quad-lzw-compat.tiff: new files
	to test old-style LZW decompression
	* test/common.sh, Makefile.am, CMakeList.txt: updated with above

2017-07-11  Even Rouault <even.rouault at spatialys.com>

	* refresh autoconf/make stuff with what is on Ubuntu 16.04 (minor changes)

2017-07-11  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_lzw.c: fix 4.0.8 regression in the decoding of old-style LZW
	compressed files.

2017-07-10  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_pixarlog.c: avoid excessive memory allocation on decoding
	when RowsPerStrip tag is not defined (and thus td_rowsperstrip == UINT_MAX)
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2554
	Credit to OSS Fuzz

2017-07-04  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c, tiffiop.h: add a _TIFFReadEncodedTileAndAllocBuffer()
	and _TIFFReadTileAndAllocBuffer() variants of TIFFReadEncodedTile() and
	TIFFReadTile() that allocates the decoded buffer only after a first
	successful TIFFFillTile(). This avoids excessive memory allocation
	on corrupted files.
	* libtiff/tif_getimage.c: use _TIFFReadTileAndAllocBuffer().
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2470
	Credit to OSS Fuzz.

2017-07-04  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_error.c, tif_warning.c: correctly use va_list when both
	an old-style and new-style warning/error handlers are installed.
	Patch by Paavo Helde (sent on the mailing list)

2017-07-02  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFStartTile(): set tif_rawcc to
	tif_rawdataloaded when it is set. Similarly to TIFFStartStrip().
	This issue was revealed by the change of 2017-06-30 in TIFFFileTile(),
	limiting the number of bytes read. But it could probably have been hit
	too in CHUNKY_STRIP_READ_SUPPORT mode previously ?
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2454
	Credit to OSS Fuzz

2017-06-30  Even Rouault <even.rouault at spatialys.com>

	* man: update documentation regarding SubIFD tag and
	TIFFSetSubDirectory() data type.
	Patch by Eric Piel
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2671

2017-06-30  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirwrite.c: in TIFFWriteDirectoryTagCheckedXXXX()
	functions associated with LONG8/SLONG8 data type, replace assertion that
	the file is BigTIFF, by a non-fatal error.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2712
	Reported by team OWL337

2017-06-30  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c, tiffiop.h: add a _TIFFReadEncodedStripAndAllocBuffer()
	function, variant of TIFFReadEncodedStrip() that allocates the
	decoded buffer only after a first successful TIFFFillStrip(). This avoids
	excessive memory allocation on corrupted files.
	* libtiff/tif_getimage.c: use _TIFFReadEncodedStripAndAllocBuffer().
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2708 and
	https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2433 .
	Credit to OSS Fuzz

2017-06-30  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillTile(): add limitation to the number
	of bytes read in case td_stripbytecount[strip] is bigger than
	reasonable, so as to avoid excessive memory allocation (similarly to
	what was done for TIFFFileStrip() on 2017-05-10)

2017-06-29  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tiffiop.h, libtiff/tif_jpeg.c, libtiff/tif_jpeg_12.c,
	libtiff/tif_read.c: make TIFFReadScanline() works in
	CHUNKY_STRIP_READ_SUPPORT mode with JPEG stream with multiple scans.
	Also make configurable through a LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER
	environment variable the maximum number of scans allowed. Defaults to
	100.

2017-06-27  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: in TIFFReadDirEntryFloat(), check that a
	double value can fit in a float before casting. Patch by Nicolas RUFF

2017-06-26  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jbig.c: fix memory leak in error code path of JBIGDecode()
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2706
	Reported by team OWL337

2017-06-24  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: error out at decoding time if anticipated libjpeg
	memory allocation is above 100 MB. libjpeg in case of multiple scans,
	which is allowed even in baseline JPEG, if components are spread over several
	scans and not interleavedin a single one, needs to allocate memory (or
	backing store) for the whole strip/tile.
	See http://www.libjpeg-turbo.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
	This limitation may be overriden by setting the
	LIBTIFF_ALLOW_LARGE_LIBJPEG_MEM_ALLOC environment variable, or recompiling
	libtiff with a custom value of TIFF_LIBJPEG_LARGEST_MEM_ALLOC macro.

2017-06-24  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: add anti-denial of service measure to avoid excessive
	CPU consumption on progressive JPEGs with a huge number of scans.
	See http://www.libjpeg-turbo.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
	Note: only affects libtiff since 2014-12-29 where support of non-baseline JPEG
	was added.

2017-06-18  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tiffiop.h: add TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW macro to
	disable CLang warnings raised by -fsanitize=undefined,unsigned-integer-overflow
	* libtiff/tif_predict.c: decorate legitimate functions where unsigned int
	overflow occur with TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW
	* libtiff/tif_dirread.c: avoid unsigned int overflow in EstimateStripByteCounts()
	and BYTECOUNTLOOKSBAD when file is too short.
	* libtiff/tif_jpeg.c: avoid (harmless) unsigned int overflow on tiled images.
	* libtiff/tif_fax3.c: avoid unsigned int overflow in Fax3Encode2DRow(). Could
	potentially be a bug with huge rows.
	* libtiff/tif_getimage.c: avoid many (harmless) unsigned int overflows.

2017-06-12  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: TIFFFetchStripThing(): limit the number of items
	read in StripOffsets/StripByteCounts tags to the number of strips to avoid
	excessive memory allocation.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2215
	Credit to OSS Fuzz

2017-06-12  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: fix regression of libtiff 4.0.8 in
	ChopUpSingleUncompressedStrip() regarding update of newly single-strip
	uncompressed files whose bytecount is 0. Before the change of 2016-12-03,
	the condition bytecount==0 used to trigger an early exit/disabling of
	strip chop. Re-introduce that in update mode. Otherwise this cause
	later incorrect setting for the value of StripByCounts/StripOffsets.
	( https://trac.osgeo.org/gdal/ticket/6924 )

2017-06-10  Even Rouault <even.rouault at spatialys.com>

	* .appveyor.yml, .travis.yml, build/travis-ci: apply patches
	0001-ci-Travis-script-improvements.patch and
	0002-ci-Invoke-helper-script-via-shell.patch by Roger Leigh
	(sent to mailing list)

2017-06-08  Even Rouault <even.rouault at spatialys.com>

	* .travis.yml, build/travis-ci: new files from
	0001-ci-Add-Travis-support-for-Linux-builds-with-Autoconf.patch by
	Roger Leigh (sent to mailing list on 2017-06-08)
	This patch adds support for the Travis-CI service.

	* .appveyor.yml: new file from
	0002-ci-Add-AppVeyor-support.patch by Roger Leigh (sent to mailing
	list on 2017-06-08)
	This patch adds a .appveyor.yml file to the top-level.  This allows
	one to opt in to having a branch built on Windows with Cygwin,
	MinGW and MSVC automatically when a branch is pushed to GitHub,
	GitLab, BitBucket or any other supported git hosting service.

	* CMakeLists.txt, test/CMakeLists.txt, test/TiffTestCommon.cmake: apply
	patch 0001-cmake-Improve-Cygwin-and-MingGW-test-support.patch from Roger
	Leigh (sent to mailing list on 2017-06-08)
	This patch makes the CMake build system support running the tests
	with MinGW or Cygwin.

2017-06-08  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_swab.c: if DISABLE_CHECK_TIFFSWABMACROS is defined, do not do
	the #ifdef TIFFSwabXXX checks. Make it easier for GDAL to rename the symbols
	of its internal libtiff copy.

2017-06-01  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirinfo.c, tif_dirread.c: add _TIFFCheckFieldIsValidForCodec(),
	and use it in TIFFReadDirectory() so as to ignore fields whose tag is a
	codec-specified tag but this codec is not enabled. This avoids TIFFGetField()
	to behave differently depending on whether the codec is enabled or not, and
	thus can avoid stack based buffer overflows in a number of TIFF utilities
	such as tiffsplit, tiffcmp, thumbnail, etc.
	Patch derived from 0063-Handle-properly-CODEC-specific-tags.patch
	(http://bugzilla.maptools.org/show_bug.cgi?id=2580) by Raphaël Hertzog.
	Fixes:
	http://bugzilla.maptools.org/show_bug.cgi?id=2580
	http://bugzilla.maptools.org/show_bug.cgi?id=2693
	http://bugzilla.maptools.org/show_bug.cgi?id=2625 (CVE-2016-10095)
	http://bugzilla.maptools.org/show_bug.cgi?id=2564 (CVE-2015-7554)
	http://bugzilla.maptools.org/show_bug.cgi?id=2561 (CVE-2016-5318)
	http://bugzilla.maptools.org/show_bug.cgi?id=2499 (CVE-2014-8128)
	http://bugzilla.maptools.org/show_bug.cgi?id=2441
	http://bugzilla.maptools.org/show_bug.cgi?id=2433

2017-05-29  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: initYCbCrConversion(): stricter validation for
	refBlackWhite coefficients values. To avoid invalid float->int32 conversion
	(when refBlackWhite[0] == 2147483648.f)
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1907
	Credit to OSS Fuzz

2017-05-29  Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_color.c: TIFFYCbCrToRGBInit(): stricter clamping to avoid
	int32 overflow in TIFFYCbCrtoRGB().
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1844
	Credit to OSS Fuzz

2017-05-21  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* configure.ac: libtiff 4.0.8 released.

	* html/v4.0.8.html: Add description of changes targeting the 4.0.8
	release.

2017-05-20 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: initYCbCrConversion(): stricter validation for
	refBlackWhite coefficients values. To avoid invalid float->int32 conversion.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1718
	Credit to OSS Fuzz

2017-05-18 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: initYCbCrConversion(): check luma[1] is not zero
	to avoid division by zero.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1665
	Credit to OSS Fuzz

2017-05-17 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: _TIFFVSetField(): fix outside range cast of double to
	float.
	Credit to Google Autofuzz project

2017-05-17 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: initYCbCrConversion(): add basic validation of
	luma and refBlackWhite coefficients (just check they are not NaN for now),
	to avoid potential float to int overflows.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1663
	Credit to OSS Fuzz

2017-05-17 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_pixarlog.c: PixarLogDecode(): resync tif_rawcp with
	next_in and tif_rawcc with avail_in at beginning and end of function,
	similarly to what is done in LZWDecode(). Likely needed so that it
	works properly with latest chnges in tif_read.c in CHUNKY_STRIP_READ_SUPPORT
	mode. But untested...

2017-05-17 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_lzw.c: update dec_bitsleft at beginning of LZWDecode(),
	and update tif_rawcc at end of LZWDecode(). This is needed to properly
	work with the latest chnges in tif_read.c in CHUNKY_STRIP_READ_SUPPORT
	mode.

2017-05-14 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_luv.c: LogL16InitState(): avoid excessive memory
	allocation when RowsPerStrip tag is missing.
	Credit to OSS-Fuzz (locally run, on GDAL)

2017-05-14 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_packbits.c: fix out-of-buffer read in PackBitsDecode()
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1563
	Credit to OSS-Fuzz

2017-05-13 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_pixarlog.c, tif_luv.c: avoid potential int32
	overflows in multiply_ms() and add_ms().
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1558
	Credit to OSS-Fuzz

2017-05-13 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_color.c: avoid potential int32 overflow in
	TIFFYCbCrToRGBInit()
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1533
	Credit to OSS-Fuzz

2017-05-13 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: update tif_rawcc in CHUNKY_STRIP_READ_SUPPORT
	mode with tif_rawdataloaded when calling TIFFStartStrip() or
	TIFFFillStripPartial(). This avoids reading beyond tif_rawdata
	when bytecount > tif_rawdatasize.
	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1545.
	Credit to OSS-Fuzz

2017-05-12 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillStripPartial():
	avoid excessive memory allocation in case of shorten files.
	Only effective on 64 bit builds.
	Credit to OSS-Fuzz (locally run, on GDAL)

2017-05-12 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillStripPartial() / TIFFSeek(),
	avoid potential integer overflows with read_ahead in
	CHUNKY_STRIP_READ_SUPPORT mode. Should
	especially occur on 32 bit platforms.

2017-05-10 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillStrip() and TIFFFillTile():
	avoid excessive memory allocation in case of shorten files.
	Only effective on 64 bit builds and non-mapped cases.
	Credit to OSS-Fuzz (locally run, on GDAL)

2017-05-10 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_zip.c, tif_pixarlog.c, tif_predict.c: fix memory
	leak when the underlying codec (ZIP, PixarLog) succeeds its
	setupdecode() method, but PredictorSetup fails.
	Credit to OSS-Fuzz (locally run, on GDAL)

2017-05-10 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: TIFFFillStrip(): add limitation to the number
	of bytes read in case td_stripbytecount[strip] is bigger than
	reasonable, so as to avoid excessive memory allocation.

2017-04-28 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2bw.c: close TIFF handle in error code path.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2677

2017-04-27 Even Rouault <even.rouault at spatialys.com>

	* litiff/tif_fax3.c: avoid crash in Fax3Close() on empty file.
	Patch by Alan Coopersmith  + complement by myself.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2673
	* tools/fax2tiff.c: emit appropriate message if the input file is
	empty. Patch by Alan Coopersmith.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2672

2017-04-27 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_ojpeg.c: fix potential memory leak in
	OJPEGReadHeaderInfoSecTablesQTable, OJPEGReadHeaderInfoSecTablesDcTable
	and OJPEGReadHeaderInfoSecTablesAcTable
	Patch by Nicolás Peña.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2670

2017-04-27 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: fix memory leak in non DEFER_STRILE_LOAD
	mode (ie default) when there is both a StripOffsets and
	TileOffsets tag, or a StripByteCounts and TileByteCounts
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2689
	* tools/tiff2ps.c: call TIFFClose() in error code paths.

2017-02-25 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_fax3.c, tif_predict.c, tif_getimage.c: fix GCC 7
	-Wimplicit-fallthrough warnings.

2017-02-18 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_pixarlog.c: fix memory leak in error code path of
	PixarLogSetupDecode(). Patch by Nicolás Peña.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2665

2017-02-18 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_lzw.c: in LZWPostEncode(), increase, if necessary, the
	code bit-width after flushing the remaining code and before emitting
	the EOI code.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=1982

2017-01-31 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: only run JPEGFixupTagsSubsampling() if the
	YCbCrSubsampling tag is not explicitly present. This helps a bit to reduce
	the I/O amount when te tag is present (especially on cloud hosted files).

2017-01-14 Even Rouault <even.rouault at spatialys.com>

	* tools/raw2tiff.c: avoid integer division by zero.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2631

2017-01-12 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_ojpeg.c: fix leak in OJPEGReadHeaderInfoSecTablesQTable,
	OJPEGReadHeaderInfoSecTablesDcTable and OJPEGReadHeaderInfoSecTablesAcTable
	when read fails.
	Patch by Nicolás Peña.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2659

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_luv.c, tif_lzw.c, tif_packbits.c: return 0 in Encode
	functions instead of -1 when TIFFFlushData1() fails.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2130

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: error out cleanly in cpContig2SeparateByRow and
	cpSeparate2ContigByRow if BitsPerSample != 8 to avoid heap based overflow.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2656 and
	http://bugzilla.maptools.org/show_bug.cgi?id=2657

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tiffio.h, tif_unix.c, tif_win32.c, tif_vms.c: add _TIFFcalloc()

	* libtiff/tif_read.c: TIFFReadBufferSetup(): use _TIFFcalloc() to zero
	initialize tif_rawdata.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2651

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: add explicit uint32 cast in putagreytile to
	avoid UndefinedBehaviorSanitizer warning.
	Patch by Nicolás Peña.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2658

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c: avoid potential undefined behaviour on signed integer
	addition in TIFFReadRawStrip1() in isMapped() case.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2650

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: validate BitsPerSample in JPEGSetupEncode() to avoid
	undefined behaviour caused by invalid shift exponent.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2648

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dir.c, tif_dirread.c, tif_dirwrite.c: implement various clampings
	of double to other data types to avoid undefined behaviour if the output range
	isn't big enough to hold the input value.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2643
	http://bugzilla.maptools.org/show_bug.cgi?id=2642
	http://bugzilla.maptools.org/show_bug.cgi?id=2646
	http://bugzilla.maptools.org/show_bug.cgi?id=2647

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: avoid division by floating point 0 in
	TIFFReadDirEntryCheckedRational() and TIFFReadDirEntryCheckedSrational(),
	and return 0 in that case (instead of infinity as before presumably)
	Apparently some sanitizers do not like those divisions by zero.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2644

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirwrite.c: in TIFFWriteDirectoryTagCheckedRational, replace
	assertion by runtime check to error out if passed value is strictly
	negative.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2535

	* tools/tiffcrop.c: remove extraneous TIFFClose() in error code path, that
	caused double free.
	Related to http://bugzilla.maptools.org/show_bug.cgi?id=2535

2017-01-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: avoid integer division by zero in
	JPEGSetupEncode() when horizontal or vertical sampling is set to 0.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2653

2017-01-03 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_jpeg.c: increase libjpeg max memory usable to
	10 MB instead of libjpeg 1MB default. This helps when creating files
	with "big" tile, without using libjpeg temporary files.
	Related to https://trac.osgeo.org/gdal/ticket/6757

2016-12-20 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: avoid potential heap-based overflow in
	t2p_readwrite_pdf_image_tile().
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2640

2016-12-20 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: avoid potential invalid memory read in
	t2p_writeproc.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2639

2016-12-20 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: fix wrong usage of memcpy() that can trigger
	unspecified behaviour.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2638

2016-12-18 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c: fix potential memory leaks in error code
	path of TIFFRGBAImageBegin().
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2627

2016-12-18 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: prevent heap-based buffer overflow in -j mode
	on a paletted image. Note: this fix errors out before the overflow
	happens. There could probably be a better fix.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2635

2016-12-17 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tiffio.h, libtiff/tif_getimage.c: add TIFFReadRGBAStripExt()
	and TIFFReadRGBATileExt() variants of the functions without ext, with
	an extra argument to control the stop_on_error behaviour.

2016-12-17 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2ps.c: fix 2 heap-based buffer overflows (in PSDataBW
	and PSDataColorContig). Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2633 and
	http://bugzilla.maptools.org/show_bug.cgi?id=2634.

2016-12-13 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_fax3.h: revert change done on 2016-01-09 that made
	Param member of TIFFFaxTabEnt structure a uint16 to reduce size of
	the binary. It happens that the Hylafax software uses the tables that
	follow this typedef (TIFFFaxMainTable, TIFFFaxWhiteTable,
	TIFFFaxBlackTable), although they are not in a public libtiff header.
	Raised by Lee Howard.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2636

2016-12-04 Even Rouault <even.rouault at spatialys.com>

	* html/man/Makefile.am: remove thumbnail.1.html and rgb2ycbcr.1.html
	from installed pages since the corresponding utilities are no longer
	installed. Reported by Havard Eidnes
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2606

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_write.c: fix misleading indentation as warned by GCC.

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: replace assert( (bps % 8) == 0 ) by a non assert check.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2605

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: fix uint32 underflow/overflow that can cause heap-based
	buffer overflow.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2610

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: avoid potential division by zero is BitsPerSamples tag is
	missing.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2607

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* man/Makefile.am: remove thumbnail.1 and rgb2ycbcr.1 from installed man
	pages since the corresponding utilities are no longer installed.
	Reported by Havard Eidnes
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2606

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tif_dir.c: when TIFFGetField(, TIFFTAG_NUMBEROFINKS, ) is called,
	limit the return number of inks to SamplesPerPixel, so that code that parses
	ink names doesn't go past the end of the buffer.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2599

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: avoid potential division by zero is BitsPerSamples tag is
	missing.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2597

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffinfo.c: fix null pointer dereference in -r mode when the image has
	no StripByteCount tag.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2594

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcrop.c: fix integer division by zero when BitsPerSample is missing.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2619

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcrop.c: add 3 extra bytes at end of strip buffer in
	readSeparateStripsIntoBuffer() to avoid read outside of heap allocated buffer.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2621

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcrop.c: fix readContigStripsIntoBuffer() in -i (ignore) mode so
	that the output buffer is correctly incremented to avoid write outside bounds.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2620

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_ojpeg.c: make OJPEGDecode() early exit in case of failure in
	OJPEGPreDecode(). This will avoid a divide by zero, and potential other issues.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2611

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: modify ChopUpSingleUncompressedStrip() to
	instanciate compute ntrips as TIFFhowmany_32(td->td_imagelength, rowsperstrip),
	instead of a logic based on the total size of data. Which is faulty is
	the total size of data is not sufficient to fill the whole image, and thus
	results in reading outside of the StripByCounts/StripOffsets arrays when
	using TIFFReadScanline().
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2608.

	* libtiff/tif_strip.c: revert the change in TIFFNumberOfStrips() done
	for http://bugzilla.maptools.org/show_bug.cgi?id=2587 / CVE-2016-9273 since
	the above change is a better fix that makes it unnecessary.

2016-12-03 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_pixarlog.c, libtiff/tif_luv.c: fix heap-based buffer
	overflow on generation of PixarLog / LUV compressed files, with
	ColorMap, TransferFunction attached and nasty plays with bitspersample.
	The fix for LUV has not been tested, but suffers from the same kind
	of issue of PixarLog.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2604

2016-12-02 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcp.c: avoid uint32 underflow in cpDecodedStrips that
	can cause various issues, such as buffer overflows in the library.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2598

2016-12-02 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_read.c, libtiff/tiffiop.h: fix uint32 overflow in
	TIFFReadEncodedStrip() that caused an integer division by zero.
	Reported by Agostino Sarubbo.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2596

2016-11-20 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_getimage.c, libtiff/tif_open.c: add parenthesis to
	fix cppcheck clarifyCalculation warnings
	* libtiff/tif_predict.c, libtiff/tif_print.c: fix printf unsigned
	vs signed formatting (cppcheck invalidPrintfArgType_uint warnings)

2016-11-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* tools/fax2tiff.c (main): Applied patch by Jörg Ahrens to fix
	passing client data for Win32 builds using tif_win32.c
	(USE_WIN32_FILEIO defined) for file I/O.  Patch was provided via
	email on November 20, 2016.

2016-11-19  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* libtiff 4.0.7 released.

	* configure.ac: Update for 4.0.7 release.

	* tools/tiffdump.c (ReadDirectory): Remove uint32 cast to
	_TIFFmalloc() argument which resulted in Coverity report.  Added
	more mutiplication overflow checks.

2016-11-18 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcrop.c: Fix memory leak in (recent) error code path.
	Fixes Coverity 1394415.

2016-11-17  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* libtiff/tif_getimage.c: Fix some benign warnings which appear in
	64-bit compilation under Microsoft Visual Studio of the form
	"Arithmetic overflow: 32-bit value is shifted, then cast to 64-bit
	value.  Results might not be an expected value.".  Problem was
	reported on November 16, 2016 on the tiff mailing list.

2016-11-16 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: in TIFFFetchNormalTag(), do not dereference
	NULL pointer when values of tags with TIFF_SETGET_C16_ASCII / TIFF_SETGET_C32_ASCII
	access are 0-byte arrays.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2593 (regression introduced
	by previous fix done on 2016-11-11 for CVE-2016-9297).
	Reported by Henri Salo. Assigned as CVE-2016-9448

2016-11-12  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>

	* tools/tiffinfo.c (TIFFReadContigTileData): Fix signed/unsigned
	comparison warning.
	(TIFFReadSeparateTileData): Fix signed/unsigned comparison
	warning.

	* tools/tiffcrop.c (readContigTilesIntoBuffer): Fix
	signed/unsigned comparison warning.

	* html/v4.0.7.html: Add a file to document the pending 4.0.7
	release.

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: avoid undefined behaviour related to overlapping
	of source and destination buffer in memcpy() call in
	t2p_sample_rgbaa_to_rgb()
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2577

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* tools/tiff2pdf.c: fix potential integer overflows on 32 bit builds
	in t2p_read_tiff_size()
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2576

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_aux.c: fix crash in TIFFVGetFieldDefaulted()
	when requesting Predictor tag and that the zip/lzw codec is not
	configured.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2591

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: in TIFFFetchNormalTag(), make sure that
	values of tags with TIFF_SETGET_C16_ASCII / TIFF_SETGET_C32_ASCII
	access are null terminated, to avoid potential read outside buffer
	in _TIFFPrintField().
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2590 (CVE-2016-9297)

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dirread.c: reject images with OJPEG compression that
	have no TileOffsets/StripOffsets tag, when OJPEG compression is
	disabled. Prevent null pointer dereference in TIFFReadRawStrip1()
	and other functions that expect td_stripbytecount to be non NULL.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2585

2016-11-11 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffcrop.c: fix multiple uint32 overflows in
	writeBufferToSeparateStrips(), writeBufferToContigTiles() and
	writeBufferToSeparateTiles() that could cause heap buffer overflows.
	Reported by Henri Salo from Nixu Corporation.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2592 (CVE-2016-9532)

2016-11-10 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_strip.c: make TIFFNumberOfStrips() return the td->td_nstrips
	value when it is non-zero, instead of recomputing it. This is needed in
	TIFF_STRIPCHOP mode where td_nstrips is modified. Fixes a read outsize of
	array in tiffsplit (or other utilities using TIFFNumberOfStrips()).
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2587 (CVE-2016-9273)

2016-11-04 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_predic.c: fix memory leaks in error code paths added in
	previous commit (fix for MSVR 35105)

2016-10-31 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_predict.h, libtiff/tif_predict.c:
	Replace assertions by runtime checks to avoid assertions in debug mode,
	or buffer overflows in release mode. Can happen when dealing with
	unusual tile size like YCbCr with subsampling. Reported as MSVR 35105
	by Axel Souchet	& Vishal Chauhan from the MSRC Vulnerabilities & Mitigations
	team.

2016-10-26 Even Rouault <even.rouault at spatialys.com>

	* tools/fax2tiff.c: fix segfault when specifying -r without
	argument. Patch by Yuriy M. Kaminskiy.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2572

2016-10-25 Even Rouault <even.rouault at spatialys.com>

	* libtiff/tif_dir.c: discard values of SMinSampleValue and
	SMaxSampleValue when they have been read and the value of
	SamplesPerPixel is changed afterwards (like when reading a
	OJPEG compressed image with a missing SamplesPerPixel tag,
	and whose photometric is RGB or YCbCr, forcing SamplesPerPixel
	being 3). Otherwise when rewriting the directory (for example
	with tiffset, we will expect 3 values whereas the array had been
	allocated with just one), thus causing a out of bound read access.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2500
	(CVE-2014-8127, duplicate: CVE-2016-3658)

	* libtiff/tif_dirwrite.c: avoid null pointer dereference on td_stripoffset
	when writing directory, if FIELD_STRIPOFFSETS was artificially set
	for a hack case	in OJPEG case.
	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2500
	(CVE-2014-8127, duplicate: CVE-2016-3658)

2016-10-25 Even Rouault <even.rouault at spatialys.com>

	* tools/tiffinfo.c: fix out-of-bound read on some tiled images.
	(h…