### PR TITLE
[curl] Update curl 7.62 -> 7.63

### DIFF
--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.62.0
+pkg_version=7.63.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=55ccd5b5209f8cc53d4250e2a9fd87e6f67dd323ae8bd7d06b072cfcbb7836cb
+pkg_shasum=d483b89062832e211c887d7cf1b65c902d591b48c11fe7d174af781681580b41
 pkg_deps=(
   core/cacerts
   core/glibc


### PR DESCRIPTION
   curl: Source Path: /hab/cache/src/curl-7.63.0
   curl: Installed Path: /hab/pkgs/tas50/curl/7.63.0/20190131232646
   curl: Artifact: /src/curl/results/tas50-curl-7.63.0-20190131232646-x86_64-linux.hart
   curl: Build Report: /src/curl/results/last_build.env
   curl: SHA256 Checksum: 5f860842d0218de1f855f298229aabbda356dda74cd420846ecd0ccc7f594349
   curl: Blake2b Checksum: eb78fe24ed70877da3cbcaf4550866c6b7e08481e295f292dfb22e7df821e4be
   curl:
   curl: I love it when a plan.sh comes together.
   curl:
   curl: Build time: 1m48s
[11][default:/src/curl:126]# /hab/pkgs/tas50/curl/7.63.0/20190131232646/bin/curl --help
Usage: curl [options...] <url>
     --abstract-unix-socket <path> Connect via abstract Unix domain socket
     --anyauth       Pick any authentication method
 -a, --append        Append to target file when uploading
     --basic         Use HTTP Basic Authentication
     --cacert <file> CA certificate to verify peer against
...

 Changes:

    curl: add %{stderr} and %{stdout} for --write-out
    curl: add undocumented option --dump-module-paths for win32
    setopt: add CURLOPT_CURLU

Bugfixes:

    (lib)curl.rc: fixup for minor bugs
    CURLINFO_REDIRECT_URL: extract the Location: header field unvalidated
    CURLOPT_HEADERFUNCTION.3: match 'nitems' name in synopsis and description
    CURLOPT_WRITEFUNCTION.3: spell out that it gets called many times
    Curl_follow: accept non-supported schemes for "fake" redirects
    KNOWN_BUGS: add --proxy-any connection issue
    NTLM: Remove redundant ifdef USE_OPENSSL
    NTLM: force the connection to HTTP/1.1
    OS400: add URL API ccsid wrappers and sync ILE/RPG bindings
    SECURITY-PROCESS: bountygraph shuts down again
    TODO: Have the URL API offer IDN decoding
    ares: remove fd from multi fd set when ares is about to close the fd
    axtls: removed
    checksrc: add COPYRIGHTYEAR check
    cmake: fix MIT/Heimdal Kerberos detection
    configure: include all libraries in ssl-libs fetch
    configure: show CFLAGS, LDFLAGS etc in summary
    connect: fix building for recent versions of Minix
    cookies: create the cookiejar even if no cookies to save
    cookies: expire "Max-Age=0" immediately
    curl: --local-port range was not "including"
    curl: fix --local-port integer overflow
    curl: fix memory leak reading --writeout from file
    curl: fixed UTF-8 in current console code page (Windows)
    curl_easy_perform: fix timeout handling
    curl_global_sslset(): id == -1 is not necessarily an error
    curl_multibyte: fix a malloc overcalculation
    curle: move deprecated error code to ifndef block
    docs: curl_formadd field and file names are now escaped
    docs: escape "\n" codes
    doh: fix memory leak in OOM situation
    doh: make it work for h2-disabled builds too
    examples/ephiperfifo: report error when epoll_ctl fails
    ftp: avoid two unsigned int overflows in FTP listing parser
    host names: allow trailing dot in name resolve, then strip it
    http2: Upon HTTP_1_1_REQUIRED, retry the request with HTTP/1.1
    http: don't set CURLINFO_CONDITION_UNMET for http status code 204
    http: fix HTTP Digest auth to include query in URI
    http_negotiate: do not close connection until negotiation is completed
    impacket: add LICENSE
    infof: clearly indicate truncation
    ldap: fix LDAP URL parsing regressions
    libcurl: stop reading from paused transfers
    mprintf: avoid unsigned integer overflow warning
    netrc: don't ignore the login name specified with "--user"
    nss: Fall back to latest supported SSL version
    nss: Fix compatibility with nss versions 3.14 to 3.15
    nss: fix fallthrough comment to fix picky compiler warning
    nss: remove version selecting dead code
    nss: set default max-tls to 1.3/1.2
    openssl: Remove SSLEAY leftovers
    openssl: do not log excess "TLS app data" lines for TLS 1.3
    openssl: do not use file BIOs if not requested
    openssl: fix unused variable compiler warning with old openssl
    openssl: support session resume with TLS 1.3
    openvms: fix example name
    os400: Add curl_easy_conn_upkeep() to ILE/RPG binding
    os400: add CURLOPT_CURLU to ILE/RPG binding
    os400: fix return type of curl_easy_pause() in ILE/RPG binding
    packages: remove old leftover files and dirs
    pop3: only do APOP with a valid timestamp
    runtests: use the local curl for verifying
    schannel: be consistent in Schannel capitalization
    schannel: better CURLOPT_CERTINFO support
    schannel: use Curl_ prefix for global private symbols
    snprintf: renamed and we now only use msnprintf()
    ssl: fix compilation with OpenSSL 0.9.7
    ssl: replace all internal uses of CURLE_SSL_CACERT
    symbols-in-versions: add missing CURLU_ symbols
    test328: verify Content-Encoding: none
    tests: disable SO_EXCLUSIVEADDRUSE for stunnel on Windows
    tests: drop http_pipe.py script no longer used
    tool_cb_wrt: Silence function cast compiler warning
    tool_doswin: Fix uninitialized field warning
    travis: build with clang sanitizers
    travis: remove curl before a normal build
    url: a short host name + port is not a scheme
    url: fix IPv6 numeral address parser
    urlapi: only skip encoding the first '=' with APPENDQUERY set

Signed-off-by: Tim Smith <tsmith@chef.io>