### PR TITLE
[dpkg] Update dpkg from 1.19.2 -> 1.19.4

### DIFF
--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dpkg
 pkg_origin=core
-pkg_version=1.19.2
+pkg_version=1.19.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_upstream_url=https://wiki.debian.org/dpkg
 pkg_description="dpkg is a package manager for Debian-based systems"
 pkg_source=http://http.debian.net/debian/pool/main/d/${pkg_name}/${pkg_name}_${pkg_version}.tar.xz
-pkg_shasum=f8f2ae2cf8065b81239db960b3794099ec607c94a125cec61c986f68f9861b71
+pkg_shasum=c15234e98655689586bff2d517a6fdc6135d139c54d52ae9cfa6a90007fee0ae
 pkg_deps=(
   core/bzip2
   core/glibc


### PR DESCRIPTION
dpkg: Source Path: /hab/cache/src/dpkg-1.19.4
dpkg: Installed Path: /hab/pkgs/tas50/dpkg/1.19.4/20190201004320
dpkg: Artifact: /src/dpkg/results/tas50-dpkg-1.19.4-20190201004320-x86_64-linux.hart
dpkg: Build Report: /src/dpkg/results/last_build.env
dpkg: SHA256 Checksum: 35209e1e016e097e47303c3d22c0e2d6d129c4a6d5b420992a4ad7e6f658fa3f
dpkg: Blake2b Checksum: dc9a2f1ea84c5e998e88d512bec4cb3c9649358ef9c57984b58ef99776f02ec5
dpkg:
dpkg: I love it when a plan.sh comes together.
dpkg:
dpkg: Build time: 1m1s

[33][default:/src/dpkg:2]# /hab/pkgs/tas50/dpkg/1.19.4/20190201004320/bin/dpkg --help
Usage: dpkg [<option> ...] <command>

pkg (1.19.4) unstable; urgency=medium

start-stop-daemon: Do not sanity check the pidfile when it is specified as
/dev/null, as that implies the caller wants to start the program no matter
what. Closes: #920242
Portability:
start-stop-daemon: Only use SO_PASSCRED if defined. Fixes build failure
at least on GNU/Hurd.
Packaging:
autopkgtest: Pass --disable-nls and --disable-dselect to configure.
autopkgtest: Change Depends to «build-essential, autoconf, pkg-config».

-- Guillem Jover Wed, 23 Jan 2019 13:06:39 +0100

1.19.3
Superseded in sid-release on 2019-01-27

dpkg (1.19.3) unstable; urgency=medium

[ Guillem Jover ]

dpkg-source: Stop filtering @builddeps@ from Testsuite-Triggers field.
Closes: #910734
dpkg-genchanges: Only reference binary packages being uploaded, which
means that for a source-only upload, the Binary and Description fields
should be empty. Closes: #818618
dpkg-scanpackages: Do not compute unnecessary checksums when using the
--hash argument. Based on a patch by Chris Lamb .
Closes: #916456
dpkg-scanpackages: Emit a warning with the list of repeat packages.
Prompted by Johannes Schauer .
start-stop-daemon: Check whether standalone --pidfile use is secure.
Prompted by Michael Orlitzky .
start-stop-daemon: Print complete verbose lines, instead of partial lines
with no newlines and a final print with a newline.
start-stop-daemon: Add new --notify-await and --notify-timeout options,
which implement the systemd readiness protocol for services.
Closes: #910707
update-alternatives: Add new --debug option.
update-alternatives: Fix removal of obsolete slaves from the linked list.
Reported by Andreas Beckmann . Closes: #916799
vendor.mk: Fix dpkg_vendor_derives_from macro documentation.
Thanks to Colin Watson . Closes: #913816
vendor.mk: Add support for an improved dpkg_vendor_derives_from macro.
Version the macros so that both can be used, and default the unversioned
one to the version 0 macro.
dpkg: Mark the package we are giving up on a trigger cycle as "istobe"
normal, so that the dependency checks know they cannot expect this package
to be processed anymore. Otherwise we ended up never detecting that we
were not making progress, as we expected to process this package at a later
point, when that would never happen anymore. This then was causing asserts
in the process queue loop. Closes: #901127, #910819
dpkg: Reset progress_bytrigproc once we have injected it into the current
package process queue iteration, so that we do not keep trying to process
it, which might end up generating artificial trigger cycles, if
dependencies are not satisfied yet.
dpkg: Convert one trigger processing required type into the new try-queued
one, so that we stop skipping unsatisfiable dependency checks.
dpkg: Move trigproc cycle reset inside try-deferred conditional. We should
only reset the cycle detection in case we are not bailing out from the
processing with an error, otherwise we could come back to this package and
detect an artificial trigger cycle.
dpkg: Introduce a new dependency try level for trigger processing. This
completely defers trigger processing until after the dependency cycle
breaking level, so to avoid generating artificial trigger cycles, when we
end up trying to process triggers with yet unsatisifiable dependencies.
Closes: #810724, #854478, #911620
dpkg: Fix --help output, to clarify which arguments are optional.
libdpkg: Add proper tar error handling. This makes the tar extractor
track and report back parse errors, so that we can give more descriptive
messages.
libdpkg: Detect unsupported tar entry types to give better error messages.
libdpkg: Add new db-fsys:Files and db-fsys:Last-Modified virtual fields.
Perl modules:
Dpkg::Changelog::Debian: Preserve modelines at EOF. Closes: #916056
Thanks to Chris Lamb for initial test cases.
Dpkg::File: Make file_slurp() also accept pathnames in addition to
filehandles.
Dpkg::Vendor::Ubuntu: Fix buildflags override after default setting move.
Based on a patch by Iain Lane and
Adam Conrad . Closes: #915881
Dpkg::Shlibs::Objdump: Remove unused Dpkg::IPC import.
Dpkg::Shlibs::Objdump: Only select objdump program when going to use it.
Dpkg::Source::Package: Do not reinitialize fields member in constructor.
Dpkg::Source::Patch: Do not recommend --include-removal when not
supported. Closes: #913012
Dpkg::Source::Package::V3::Bzr: Fix format name in output message.
Dpkg::Source::Package: Add a new format option to the new constructor.
Prompted by James McCoy .
Dpkg::Source::Package: Improve debian/source/format parsing and
validation.
Dpkg::Source::Format: New public module.
Prompted by Mattia Rizzolo .
Documentation:
dpkg(1): Clarify --remove action. Closes: #914478
dpkg-query(1): Clarify --list option behavior when no arguments are
specified. Closes: #917098
deb-control(5): Clarify by adding a reference to deb-src-control(5) and
removing an invalid comment in the example.
Prompted by Helmut Grohne .
dpkg(1): Clarify databases used by --yet-to-unpack and --predep-package.
Prompted by Johannes Schauer .
Clarify character classes for various formats in man pages, by
explicitly listing the character ranges within parenthesis.
Prompted by Ian Jackson .
dpkg-query(1): Document the version introducing the -f option.
dpkg-architecture(1): Add reference to the TERMS section in the
VARIABLES section. Prompted by Axel Beckert .
Fix POD for Dpkg::Interface::Storable derived method implementations.
Dpkg::Deps::Simple(3): Fix POD signature for new constructor.
Code internals:
dpkg-maintscript-helper: Use an explicit escape instead of a literal
backslash.
Quote shell variables. Reported by Johannes Schauer .
Switch perl code to use the new Dpkg::Source::Format module.
dpkg-source: Move source format selection earlier in the build.
dpkg-source: Use new format argument for Dpkg::Source::Package->new().
dpkg-shlibdeps: Remove unused variable.
dpkg-scanpackages: Unroll a single iteration loop.
start-stop-daemon: Compare foundany against 0 instead of treating it
like a boolean.
start-stop-daemon: Switch code to use new info() and debug() functions.
update-alternatives: Use enums for actions instead of strings.
update-alternatives: Switch verbose selection into an enum.
dpkg: Negate tortoise_not_in_hare() function name and return value.
dpkg: Initialize trigcyclenode's next member once.
dpkg: Use common pattern of assigning as an iterator.
dpkg: Factor trigproc_new_cyclenode() out from check_trigger_cycle().
dpkg: Switch dependtry from an int to an enum.
dpkg: Move dependtry description from deferred_configure() to its
declaration.
dpkg: Split trigger processing types into required, try-queued and
try-deferred.
dpkg-query: Rename variable to avoid shadowing a local function.
When allocating use the variable instead of the type in sizeof().
dselect: Rename variable r to pkgbin.
libdpkg, dpkg: Rename r variables to fnn.
libdpkg: Rename ret variable to next.
libdpkg: Cleanup fsys module symbol names.
libdpkg: Rename pkg_db symbols to pkg_hash.
libdpkg: Add new warning printer setter function.
Prompted by Julian Andres Klode .
libdpkg: Add new DPKG_ERROR_OBJECT macro.
Build system:
get-version: Use a format string with printf.
run-script: Use $() instead of deprecated ``.
run-script: Remove unused PERL_PROFILE variable, PERL5OPT can be used
instead, and does not require leaving an unquoted variable around.
run-script: Add «set -e».
Build.PL: Set environment variables only for CPAN tests.
Build.PL: Set locale for CPAN tests to C. Fixes CPAN#127314.
configure: Split AM_INIT_AUTOMAKE arguments into different lines.
Packaging:
Bump Standards-Version to 4.2.1 (no changes needed).
Switch to debhelper compatibility level 11.
Create the log file in postinst only if it does not exist.
Prompted by Johannes Schauer .
Add superficial autopkgtest functional tests.
Test suite:
Add new shellcheck author test.
Add descriptions for the shellcheck exclude codes.
Update cppcheck supressions.

[ Updated programs translations ]

Dutch (Frans Spiesschaert). Closes: #912023
German (Sven Joachim).
Italian (Milo Casagrande). Closes: #915610
Portuguese (Miguel Figueiredo). Closes: #917813

[ Updated scripts translations ]

German (Helge Kreutzmann).

[ Updated man pages translations ]

Dutch (Frans Spiesschaert). Closes: #912024
German (Helge Kreutzmann).

-- Guillem Jover Tue, 22 Jan 2019 14:26:04 +0100

Signed-off-by: Tim Smith <tsmith@chef.io>