### PR TITLE
[ed] Update ed from 1.14.2 -> 1.15

### DIFF
--- a/ed/plan.sh
+++ b/ed/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ed
 pkg_origin=core
-pkg_version=1.14.2
+pkg_version=1.15
 pkg_description="The standard text editor."
 pkg_upstream_url="https://www.gnu.org/software/ed/"
 pkg_license=('GPL-3.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ftp.gnu.org/gnu/ed/ed-${pkg_version}.tar.lz"
-pkg_shasum=f57962ba930d70d02fc71d6be5c5f2346b16992a455ab9c43be7061dec9810db
+pkg_shasum=ad4489c0ad7a108c514262da28e6c2a426946fb408a3977ef1ed34308bdfd174
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/lzip core/diffutils)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
   ed: Source Path: /hab/cache/src/ed-1.15
   ed: Installed Path: /hab/pkgs/tas50/ed/1.15/20190201003722
   ed: Artifact: /src/ed/results/tas50-ed-1.15-20190201003722-x86_64-linux.hart
   ed: Build Report: /src/ed/results/last_build.env
   ed: SHA256 Checksum: be8b3a8d98f4ce7b6c5a09be149e7589833b01b36f13cf83a9d781b9f97a62c8
   ed: Blake2b Checksum: 4b8483112b9a95b916fc578912bcb0694f143423bbe44c93a773080f243b3d05
   ed:
   ed: I love it when a plan.sh comes together.
   ed:
   ed: Build time: 0m4s

[27][default:/src/ed:1]# /hab/pkgs/tas50/ed/1.15/20190201003722/bin/ed --help
GNU ed is a line-oriented text editor. It is used to create, display,
modify and otherwise manipulate text files, both interactively and via
shell scripts. A restricted version of ed, red, can only edit files in
the current directory and cannot execute shell commands. Ed is the
'standard' text editor in the sense that it is the original editor for
Unix, and thus widely available. For most purposes, however, it is
superseded by full-screen editors such as GNU Emacs or GNU Moe.

Changes:
    4 	* io.c (print_line): Make 'l' command print '\\' before every
    5 	  '$' within the text. (Reported by Ori Avtalion).
    6 	* main_loop.c (extract_addresses): Fixed address ',,' to mean
    7 	  '$,$' instead of '1,$'. (Reported by Matthieu Felix).
    8 	* regex.c (extract_replacement): Allow newlines even if global.
    9 	* main_loop.c (exec_command): Make 'c' command reject address 0.
   10 	* ed.texi: Minor fixes.
   11 	* configure: Accept appending to CFLAGS, 'CFLAGS+=OPTIONS'.

Signed-off-by: Tim Smith <tsmith@chef.io>