### PR TITLE
[e2fsprogs] Update e2fsprogs from 1.44.1 -> 1.44.5

### DIFF
--- a/e2fsprogs/plan.sh
+++ b/e2fsprogs/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=e2fsprogs
 pkg_origin=core
-pkg_version="1.44.1"
+pkg_version="1.44.5"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Ext2/3/4 filesystem userspace utilities"
 pkg_license=('GPL-2.0')
 pkg_upstream_url="http://e2fsprogs.sourceforge.net/"
 pkg_source="https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-${pkg_version}.tar.gz"
-pkg_shasum="1531c91198520d6868d1106b6b508c5fc780533952f63c2dfd2afec282aa7097"
+pkg_shasum="da54ead3366d2f9f5951c6250c8b6d5d7305216dd5edc11a089370c58387abe7"
 pkg_deps=(
   core/glibc
 )

--- a/e2fsprogs/tests/test.bats
+++ b/e2fsprogs/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "uuidgen exit code check" {
+  run uuidgen -t
+  [ $status -eq 0 ]
+}

--- a/e2fsprogs/tests/test.sh
+++ b/e2fsprogs/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
I added a basic bats test while I was in here.

   e2fsprogs: Source Path: /hab/cache/src/e2fsprogs-1.44.5
   e2fsprogs: Installed Path: /hab/pkgs/tas50/e2fsprogs/1.44.5/20190201010257
   e2fsprogs: Artifact: /src/e2fsprogs/results/tas50-e2fsprogs-1.44.5-20190201010257-x86_64-linux.hart
   e2fsprogs: Build Report: /src/e2fsprogs/results/last_build.env
   e2fsprogs: SHA256 Checksum: 6917720de69747ab136de8f59a1ebb2793daade0475bc86dfa48391c434d3437
   e2fsprogs: Blake2b Checksum: de099acaf64b299b7d0a8c7294e0181499df9b5b38b266a3d5875ed7c146f912
   e2fsprogs:
   e2fsprogs: I love it when a plan.sh comes together.
   e2fsprogs:
   e2fsprogs: Build time: 0m42s

/hab/pkgs/tas50/e2fsprogs/1.44.5/20190201010257/bin/uuidgen -t
95d2a56a-25bd-11e9-a057-0242ac110003

E2fsprogs 1.44.5 (December 15, 2018)
UI and Features

When e2fsck notices it could optimize an extent tree, it will now ask "Optimize?" instead of "Fix?", which was confusing some users since it implied that something was broken.
Fixes

Use 64-bit counters to track the number of files that are defragmented using in e4defrag, to avoid overflows when more than 2**32 files are defragmented. (Addresses Debian Bug: #888899)

Correctly translate Posix ACL's. This was a regression introduced in v1.44.4. (Addresses Launchpad Bug: #1807288)

Use the online free block counts so e2freefrag's percentages are correct.

Fix a false warning that tune2fs will take long time to change a UUID if the metadata_csum feature is not enabled.

E2fsck will only offer to set the inline_data feature flag when the inline flag is set on the inode, *and* the system.data xattr is present.

E4defrag will handle the case where it is running as root and it can't find the file system to open more gracefully. (Addresses Debian Bug: #907634)

Fix a bug where resize2fs was failing to update the extent tree checksums in an corner case. (Addresses Launchpad Bug: #1798562)

Fix fuse2fs's command line parsing when options are specified after the target device/image.

Fix a bug which could cause e2fsprogs tools to segfault on a corrupted file system where the journal's s_nr_users is impossibly large.

E2image now includes the mmp block (if needed) when creating a metadata-only image.

Fix various Verity handling bugs which made it completely unusable in e2fsprogs 1.44.4.

Fox a bug in tune2fs where it would dereference of freed memory after replaying the journal.
Performance, Internal Implementation, Development Support etc.

Synchronized changes from Android's AOSP e2fsprogs tree.

Fix groff formatting nits in various man pages. (Addresses Debian Bug: #916188)

Fixed various debian packaging issues (Addresses Debian Bug: #915942)

Adjusted the copyright license for lib/blkid/version.c to be LGPL (and consistent with the rest of files in that directory).

Fix various clang warnings.

Fix "make install" when configure was run with --enable-subset.

Make sure the regression tests clean up their tmpfile if the test script exits.

Fix build failures on non-glibc systems.
E2fsprogs 1.44.4 (August 18, 2018)
UI and Features

Add basic support for the ext4 verity feature (aka fsverity). It is a read-only compatibility feature which uses Merkle trees to add functionality much like dm-verity on a per-file basis. For this release we simply allow e2fsck to accept file systems with the verity feature enable (no special handling is needed) and mke2fs to create file systems with the verity feature.
Fixes

E2fsck will now properly repair a file system that has both the resize_inode and meta_bg features enabled simultaneously (which is never supposed to happen, but it could happen in versions of mke2fs before 1.44.3 when it was given parameters where more than 75% of the block group was used for group descriptor tables).

Avoid a floating point exception crash when libblkid tries probing a maliciously corrupted HFS+ superblock.

Debugfs's ncheck command now properly will handle inodes that have multiple hard links.

On platforms that don't supply strdup, the replacement function for strdup() had a bug which would cause it to crash if it was used. (Fortunately this only happens if the [scratch_files] feature in e2fsck is used.)

Fixed support for devices which have non-512 byte block sizes on Apple Darwin.

E2fsprogs 1.44.3 would fail to compile on very old versions of gcc. This is now fixed.

Update and clarify man pages. (Addresses Debian Bug: #757831)
Performance, Internal Implementation, Development Support etc.

Synchronized changes from Android's AOSP e2fsprogs tree.

Instead of building the subset e2fsprogs-libs tar file, add a new configure option, --enable-subset. This along with other changes (such as dropping obsolete files that aren't shipped as part of e2fsprogs-X.YY.tar.gz) allows us to be able to build the tarball using the "git archive" command.

Fixed various debian packaging issues (Addresses Debian Bug: #905195)

Update Danish, Spanish, and Swedish translations.
E2fsprogs 1.44.3 (July 10, 2018)
UI and Features

The debugfs inode_dump command can now print a hex dump of the i_block array and the extra space in the inode, as a convenience to someone investigating a corrupted inode.

The debugfs block_dump and inode_dump command can now print low-level dump of extended attribute data structures in the block or inode.

The dumpe2fs command can now print out information in the Multi-Mount Protection (MMP) block. This is also available as e2mmpstatus command for compatibility with the Lustre utilities.

The debugfs command can now operate on some file systems with corrupted superblocks so they can be fixed. This includes file systems with a corrupted inodes count field and file systems where not all of the allocation bitmaps have valid locations or are not readable.
Fixes

The inode's project ID is now properly byte-swapped on big-endian systems.

E2fsprogs now ignores s_desc_size for file systems that do not have the 64-bit feature set. This makes it more consistent with the kernel, so it can now operate on file systems that the kernel is willing to mount.

E2fsck now considers device inodes with the extents flag as corrupt and offer to clear them.

E2fsck more properly handles cases where s_inodes_count is corrupted.

E2fsck no longer spews large number of errors when the superblock badly corrupted (restoring its behavior pre-1.43).

E2fsck will now offer to set the dir_nlink feature if it is not set and file system requires the dir_nlink feature because there are too many subdirectories in a directory.

E2fsck will no longer loop infinitely due to a maliciously crafted file system which has a fully uninitialized inode table in the first block group.

E2fsck will no longer hang if the last block in the file system is a fixed-metadata block. (Very rare, but could happen.)

E2fsck no longer allows initialized blocks to exist past i_size. This is something the Linux implementation of ext4 has never done (and should never do).

While replaying the journal in e2fsck, certain errors would previously cause e2fsck to print a non-sensical error message (e.g., "Unknown code ____ 251 while recovering journal"). This has been fixed.

In cases where more than 75% of the block group will be used for group descriptor table, mke2fs would previously create an invalid file system with both the meta_bg and resize_inode features enabled. It will now disable the resize_inode feature.

The mke2fs program now properly creates a file system which is exactly 1 << 32 blocks. Previously the s_inodes_count field would overflow, and the file system would be created with a minimal number of inodes.

Recent kernels will report errors on a file or block device which occurred before the file or block device was opened via fsync() or close(). This will cause e2fsck to incorrectly report a failure. Work around this by calling fsync() immediately after the file or block device is opened in the unix_io layer, and throwing away the error.

Filefrag will no longer ignore errors returned by fsync.

Debugfs will no longer print spurious checksum errors when failing to open a file system for unrelated reasons.

Updated/fixed various man pages. (Addresses Launchpad Bug: #1743553)
Performance, Internal Implementation, Development Support, etc.

Synchronized changes from Android's AOSP e2fsprogs tree.

Debugfs's mknod command now works correctly on some 32-bit systems where previously it had a portability problem caused by some object files being compiled with LFS, and some without. This fixes some regression test failures on 32-bit MIPS (for example).

Various clean ups, portability, and performance improvements to e2fsprogs's regression test framework.

Fixed Coverity, sparse, gcc -Wall, and clang warnings/nits.

Update Czech, Dutch, Spanish, French, Polish, Swedish, Ukrainian, and Vietnamese translations.
E2fsprogs 1.44.2 (May 14, 2018)
Fixes

E2fsck now prints a warning message if broken_system_clock is set in e2fsck.conf and this causes the check interval to be ignored so it is clear to the user.

Fix e2image handling of e2i files on big endian systems

Add sanity checks for inodes containing xattr values to prevent maliciously crafted file systems from causing crashes caused by infinite recursion from causing e2fsck and debugfs to crash.

Fix e2fsck so that quota usage is adjusted when clearing orphaned inodes.

Fix filefrag so that unknown flags returned by FIEMAP won't cause a buffer overrun.

Fix mke2fs to print a more useful/correct error message if ext2fs_close_free() at the end of the file system creation process.

Improve chattr's man page.
Performance, Internal Implementation, Development Support, etc.

Demote e2fsprogs in debian packaging from Essential: yes to XB-Important: yes (Addresses Debian Bug #474540)

Fix intl/Makefile so it uses @AR@ instead of a hard-coded 'ar' (which matters when cross compiling).

Update Polish translation file.

Fix the address of the FSF in various GPL/LGPL copyright licenses.

Clean up the i_bitmaps test so it doesn't leave temporary files behind.

Remove use of /dev/stdin in the regression tests since not all systems have /dev/stdin.

Fix the f_bigalloc_badinode and f_bigalloc_orphan_list regression tests so they uses mke2fs and ebugfs from the build tree. They may not exist in the users PATH, and if they not or if they are extremely old/obsolete, those tests would fail.

Signed-off-by: Tim Smith <tsmith@chef.io>