### PR TITLE
[hspec-discover] Added hspec discover plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -509,6 +509,8 @@ paths = [
 plan_path = "harfbuzz"
 [helm]
 plan_path = "helm"
+[hspec-discover]
+plan_path = "hspec-discover"
 [htop]
 plan_path = "htop"
 [httpd]

--- a/hspec-discover/README.md
+++ b/hspec-discover/README.md
@@ -1,0 +1,17 @@
+# hspec-discover
+
+Automatically discover and run Hspec tests.
+
+It is a useful convention to have one spec file for each source file. That way it is straightforward to find the corresponding spec for a given piece of code. But it requires error prone, and neither challenging nor interesting boiler plate code. So it should be automated. Hspec provides a solution for that. It makes creative use of GHC's support for custom preprocessors.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/hspec-discover/README.md
+++ b/hspec-discover/README.md
@@ -2,7 +2,10 @@
 
 Automatically discover and run Hspec tests.
 
-It is a useful convention to have one spec file for each source file. That way it is straightforward to find the corresponding spec for a given piece of code. But it requires error prone, and neither challenging nor interesting boiler plate code. So it should be automated. Hspec provides a solution for that. It makes creative use of GHC's support for custom preprocessors.
+It is a useful convention to have one spec file for each source file. That way it is straightforward to find the
+corresponding spec for a given piece of code. But it requires error prone, and neither challenging nor interesting
+boiler plate code. So it should be automated. Hspec provides a solution for that. It makes creative use of GHC's support
+for custom preprocessors.
 
 ## Maintainers
 
@@ -14,4 +17,6 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Include `core/hspec-discover` in your `pkg_build_deps` in order to allow cabal to take advantage of it for automatic
+hspec detection. If your haskell project is setup to use `hspec-discover`, a `cabal test` in your project's `do_check`
+will automatically use it when appropriate.

--- a/hspec-discover/plan.sh
+++ b/hspec-discover/plan.sh
@@ -30,19 +30,23 @@ do_clean() {
 }
 
 do_build() {
-  cabal sandbox init
-  cabal update
+  cabal v1-sandbox init
+  cabal v1-update
 
   # Install dependencies
-  cabal install --only-dependencies
+  cabal v1-install --only-dependencies --enable-tests
 
   # Configure and Build
-  cabal configure --prefix="$pkg_prefix" \
+  cabal v1-configure --prefix="$pkg_prefix" \
     --disable-executable-dynamic \
     --disable-shared
-  cabal build
+  cabal v1-build
+}
+
+do_check() {
+  cabal v1-test
 }
 
 do_install() {
-  cabal copy
+  cabal v1-copy
 }

--- a/hspec-discover/plan.sh
+++ b/hspec-discover/plan.sh
@@ -1,0 +1,48 @@
+pkg_name=hspec-discover
+pkg_origin=core
+pkg_version=2.7.0
+pkg_license=('MIT')
+pkg_upstream_url="https://hspec.github.io/"
+pkg_description="Automatically discover and run Hspec tests"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="1cb6d6cd494a191b74aa54465005929c73911bf8cd79bb8f7773f4611bf06bd8"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+pkg_deps=(
+  core/glibc
+  core/gmp
+  core/libffi
+)
+
+pkg_build_deps=(
+  core/cabal-install
+  core/ghc
+)
+
+do_clean() {
+  do_default_clean
+
+  # Strip any previous cabal config/cache
+  rm -rf /root/.cabal
+}
+
+do_build() {
+  cabal sandbox init
+  cabal update
+
+  # Install dependencies
+  cabal install --only-dependencies
+
+  # Configure and Build
+  cabal configure --prefix="$pkg_prefix" \
+    --disable-executable-dynamic \
+    --disable-shared
+  cabal build
+}
+
+do_install() {
+  cabal copy
+}


### PR DESCRIPTION
Adds hspec-discover which is a binary used by GHC and hspec to dynamically discover and run Hspec tests.  

Using cabal flags:
```
--disable-executable-dynamic \
--disable-shared
```

To prevent dynamic linking of haskell libraries and the publishing of libraries that link to internal GHC libraries, as we only care about the binary. This is likely to fix to shellcheck issue #2228. I'll need to update that plan and confirm.