### PR TITLE
[openresty] Update OpenResty to 1.13.6.2

### DIFF
--- a/openresty/plan.sh
+++ b/openresty/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=openresty
 pkg_origin=core
-pkg_version=1.13.6.1
+pkg_version=1.13.6.2
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://openresty.org/download/${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b
+pkg_shasum=946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942
 pkg_deps=(core/glibc core/gcc-libs core/libxml2 core/libxslt core/zlib core/bzip2 core/openssl core/pcre core/coreutils core/perl core/which)
 pkg_build_deps=(core/gcc core/make)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build openresty
source results/last_build.env
hab svc load ${pkg_ident}

hab pkg install --binlink core/curl
hab pkg install core/busybox-static
hab pkg binlink core/busybox-static netstat

netstat -peanut
curl http://localhost
```

### Sample output

```
# netstat -peanut
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      16641/nginx.conf
tcp        0      0 0.0.0.0:9631            0.0.0.0:*               LISTEN      81/hab-sup
tcp        0      0 127.0.0.1:9632          0.0.0.0:*               LISTEN      81/hab-sup
tcp        0      0 0.0.0.0:9638            0.0.0.0:*               LISTEN      81/hab-sup
tcp        0      0 127.0.0.1:9632          127.0.0.1:47414         TIME_WAIT   -
udp        0      0 0.0.0.0:9638            0.0.0.0:*                           81/hab-sup

# curl http://localhost
<!DOCTYPE html>
<html>
<head>
<title>Welcome to OpenResty!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to OpenResty!</h1>
<p>If you see this page, the OpenResty web platform is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="https://openresty.org/">openresty.org</a>.<br/>
Commercial support is available at
<a href="https://openresty.com/">openresty.com</a>.</p>

<p><em>Thank you for flying OpenResty.</em></p>
</body>
</html>

```