### PR TITLE
[alsa-lib] update alsa-lib 1.1.7 -> 1.1.8

### DIFF
--- a/alsa-lib/plan.sh
+++ b/alsa-lib/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=alsa-lib
 pkg_origin=core
-pkg_version=1.1.7
+pkg_version=1.1.8
 pkg_description="The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system."
 pkg_upstream_url="http://alsa-project.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-2.1-or-later')
 pkg_source="ftp://ftp.alsa-project.org/pub/lib/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="9d6000b882a3b2df56300521225d69717be6741b71269e488bb20a20783bdc09"
+pkg_shasum="3cdc3a93a6427a26d8efab4ada2152e64dd89140d981f6ffa003e85be707aedf"
 pkg_deps=(
   core/glibc
 )


### PR DESCRIPTION
   alsa-lib:
   alsa-lib: Source Path: /hab/cache/src/alsa-lib-1.1.8
   alsa-lib: Installed Path: /hab/pkgs/tas50/alsa-lib/1.1.8/20190205044343
   alsa-lib: Artifact: /src/alsa-lib/results/tas50-alsa-lib-1.1.8-20190205044343-x86_64-linux.hart
   alsa-lib: Build Report: /src/alsa-lib/results/last_build.env
   alsa-lib: SHA256 Checksum: 19610cb86c99fd2994f2616d83935ab2dfeaef0753a2bb99f380a8fa078ed693
   alsa-lib: Blake2b Checksum: aa86629e0d86a025484491605c1121f2d1c730b86c68f4180e26902b05f1eb99
   alsa-lib:
   alsa-lib: I love it when a plan.sh comes together.
   alsa-lib:
   alsa-lib: Build time: 0m49s

Changes

Core

    Release v1.1.8
    conf: rename snd_conf_load1() to _snd_config_load_with_include()
    conf/ucm: bytcht-es8316: Add long-name UCM profiles
    conf/ucm: Add UCM profile for bytcht-es8316 boards
    Create shared {En,Dis}ableSeq.conf components for rt5645 variants
    conf/ucm: bytcr-rt5651: Add bytcr-rt5651-stereo-spk-dmic-mic config
    conf/ucm: kblrt5660: Add ucm setting for Dell Edge IoT platform
    conf/ucm: chtrt5650: Add UCM config for chtrt5650
    ucm: Set default include path
    conf: Move UCM profile snippets into components subdirectory
    initial version of .travis.yml file

Control API

    control: fix the assert() in snd_ctl_elem_set_bytes

PCM API

    pcm: ioplug: Fix the regression of pulse plugin drain
    pcm: extplug: Keep format and channels the same if requested
    pcm: dshare: Fix segfault when not binding channel 0
    pcm: dmix: Add option to allow alignment of slave pointers
    pcm: interval: Interpret (x x+1] correctly and return x+1

Use Case Manager API

    conf: rename snd_conf_load1() to _snd_config_load_with_include()
    ucm: Set default include path
    conf: Move UCM profile snippets into components subdirectory

Configuration

    conf: rename snd_conf_load1() to _snd_config_load_with_include()
    conf/ucm: bytcht-es8316: Add long-name UCM profiles
    conf/ucm: Add UCM profile for bytcht-es8316 boards
    Create device component for rt5645 Internal Analog Mic UCM
    Factor out rt5645 variants Headset+Digital Mic UCM shared {en,dis}able sequences
    Factor out rt5645 variants Speaker+Headphones shared UCM enable sequences
    Create shared {En,Dis}ableSeq.conf components for rt5645 variants
    Update chtrt5645 ucm variants to use bytcr/PlatformEnableSeq.conf component
    conf/ucm: bytcr-rt5651: Document mono speaker wiring
    conf/ucm: bytcr-rt5651: Add bytcr-rt5651-stereo-spk-dmic-mic config
    conf/ucm: bytcr-rt5651: Add digital mic support
    conf/ucm: bytcr-rt5651: Add support for a headset-mic on IN2
    conf/ucm: bytcr-rt5651: Enable Stereo? ADC MIXL ADC? switches when enabling inputs
    conf/ucm: kblrt5660: Add ucm setting for Dell Edge IoT platform
    conf/ucm: chtrt5650: Add UCM config for chtrt5650
    ucm: Set default include path
    conf: Move UCM profile snippets into components subdirectory
    conf: USB-Audio: Add Dell WD19 Dock in the IEC958 blacklist
    conf/ucm/Dell-WD15-Dock: Fix incorrect device names

Documentation

    README.md: add link to www.alsa-project.org
    initial version of README.md for github

External PCM Filter Plugin SDK

    pcm: extplug: Keep format and channels the same if requested

Test/Example code

    test/audio_time: remove unused variables
    test: rename code to more approriate mixtest
    test/code: make it work again
    test/latecy: fix typo in tstamp compare

Utils

    utils/alsa.m4: conditionally enable libdl in AM_PATH_ALSA m4 macro

Signed-off-by: Tim Smith <tsmith@chef.io>