### PR TITLE
[telegraf] Update telegraf to 1.9.4, add tests

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,14 +1,17 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version="1.3.5"
+pkg_version="1.9.4"
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum="3c44bf10fc689e723c6f62f28babd8317331af507d1178100cdb16ee15b5a490"
+pkg_shasum="56ec9a88a4f306a79f6dd2503ef358b0e25eba27c8c79dd891171c98973cf116"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config $pkg_svc_config_path/telegraf.conf"
-pkg_build_deps=(core/wget core/tar)
+pkg_build_deps=(
+  core/wget
+  core/tar
+)
 pkg_deps=()
 pkg_bin_dirs=(bin)
 

--- a/telegraf/tests/test.bats
+++ b/telegraf/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(telegraf version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/telegraf/tests/test.sh
+++ b/telegraf/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This supersedes #2184

### Testing

```
hab studio enter
./telegraf/tests/test.sh
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```