### PR TITLE
[graphviz] Add libtool to runtime deps, add bin dir

### DIFF
--- a/graphviz/plan.sh
+++ b/graphviz/plan.sh
@@ -10,6 +10,7 @@ pkg_source="https://gitlab.com/graphviz/graphviz/-/archive/stable_release_${pkg_
 pkg_shasum="92f654c95b412920777ceddf90e6564ffa871a77e4f6155ab437a2d3a2129e2b"
 pkg_deps=(
   core/glibc
+  core/libtool
 )
 pkg_build_deps=(
     core/autoconf
@@ -19,10 +20,10 @@ pkg_build_deps=(
     core/diffutils
     core/flex
     core/gcc
-    core/libtool
     core/make
     core/pkg-config
 )
+pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 

--- a/graphviz/tests/input.dot
+++ b/graphviz/tests/input.dot
@@ -1,0 +1,5 @@
+digraph "a graph" {
+a -> b
+a -> c
+b -> c
+}

--- a/graphviz/tests/test.bats
+++ b/graphviz/tests/test.bats
@@ -1,0 +1,12 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "dot is on the path" {
+  [ "$(command -v dot)" ]
+}
+
+@test "minimal dot to svg works" {
+  run dot -Tsvg -o ${BATS_TEST_DIRNAME}/output.svg < "${BATS_TEST_DIRNAME}/input.dot"
+  [ $status -eq 0 ]
+  [ -f "${BATS_TEST_DIRNAME}/output.svg" ]
+  rm -rf "${BATS_TEST_DIRNAME}/otuput.svg"
+}

--- a/graphviz/tests/test.sh
+++ b/graphviz/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
The current build of this package is rather broken.  First, expected
executables are not available via `hab pkg exec`

```
hab pkg exec core/graphviz dot
✗✗✗
✗✗✗ `dot' was not found on the filesystem or in PATH
✗✗✗
```

If you call the executables directly, they fail because the package is
missing dependencies:

```
ldd /hab/pkgs/core/graphviz/2.40.1/20190116235243/bin/dot
	linux-vdso.so.1 (0x00007ffecbae5000)
	libgvc.so.6 => /hab/pkgs/core/graphviz/2.40.1/20190116235243/lib/libgvc.so.6 (0x00007fd50fb89000)
	libltdl.so.7 => not found
	libdl.so.2 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libdl.so.2 (0x00007fd50fb82000)
	libxdot.so.4 => /hab/pkgs/core/graphviz/2.40.1/20190116235243/lib/libxdot.so.4 (0x00007fd50fb7a000)
	libcgraph.so.6 => /hab/pkgs/core/graphviz/2.40.1/20190116235243/lib/libcgraph.so.6 (0x00007fd50fb5d000)
	libpathplan.so.4 => /hab/pkgs/core/graphviz/2.40.1/20190116235243/lib/libpathplan.so.4 (0x00007fd50fb50000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007fd50f9bb000)
	libcdt.so.5 => /hab/pkgs/core/graphviz/2.40.1/20190116235243/lib/libcdt.so.5 (0x00007fd50f9b2000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007fd50f7fa000)
	/hab/pkgs/core/glibc/2.27/20190115002733/lib/ld-linux-x86-64.so.2 (0x00007fd50fc55000)
	libltdl.so.7 => not found
```

This PR fixes those issues.  While I am not able to test this
extensively, the `dot` executable is now able to produce an SVG from a
dot file.

Signed-off-by: Steven Danna <steve@chef.io>