### PR TITLE
[rebar/rebar3] rebar3 update to 3.9.0, deprecate rebar

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1170,8 +1170,6 @@ plan_path = "readline6"
 paths = [
   "readline/*",
 ]
-[rebar]
-plan_path = "rebar"
 [rebar3]
 plan_path = "rebar3"
 [recordproto]

--- a/rebar/README.md
+++ b/rebar/README.md
@@ -1,4 +1,6 @@
-# rebar
+# rebar (deprecated)
+
+**Deprecation Notice**: This package has been deprecated by the upstream developer. Please consider migration to use the `core/rebar3` plan.
 
 rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.
 

--- a/rebar3/plan.sh
+++ b/rebar3/plan.sh
@@ -1,3 +1,4 @@
+pkg_deprecated=true
 pkg_origin=core
 pkg_name=rebar3
 pkg_version=3.9.0

--- a/rebar3/plan.sh
+++ b/rebar3/plan.sh
@@ -1,11 +1,16 @@
 pkg_origin=core
 pkg_name=rebar3
-pkg_version=3.4.2
+pkg_version=3.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=(Apache-2.0)
-pkg_source=https://github.com/erlang/${pkg_name}/archive/${pkg_version}.tar.gz
-pkg_shasum=f4d38d01671af6a7eb4777654d1543b42c873dad32046e444434c64d929fc789
-pkg_deps=(core/erlang core/busybox-static)
+pkg_license=('Apache-2.0')
+pkg_source="https://github.com/erlang/${pkg_name}/archive/${pkg_version}.tar.gz"
+pkg_description="rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases."
+pkg_upstream_url="https://github.com/rebar/rebar3"
+pkg_shasum=9ea73ce4e60ad4b3108641eae73b4098fadb510142e672ad8e3a793f57e9f992
+pkg_deps=(
+  core/erlang
+  core/busybox-static
+)
 pkg_build_deps=(core/coreutils)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
@@ -24,6 +29,7 @@ do_build() {
 
 do_install() {
   cp -R "_build/default/"* "${pkg_prefix}"
+  cp -R "_build/prod/bin" "${pkg_prefix}"
   fix_interpreter "${pkg_prefix}/bin/"* core/busybox-static bin/env
   chmod +x "${pkg_prefix}/bin/rebar3"
 }

--- a/rebar3/tests/test.bats
+++ b/rebar3/tests/test.bats
@@ -1,0 +1,12 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(rebar3 version | head -1 | awk '{print $2}')"
+  [ $? -eq 0 ]
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run rebar3 help
+  [ $status -eq 0 ]
+}

--- a/rebar3/tests/test.sh
+++ b/rebar3/tests/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+hab pkg install --binlink core/erlang
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
This PR:

* Updates rebar3 to 3.9.0
* Deprecates rebar

Following merge, according to [RFC7](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0007-deprecating-packages.md) we need to:

* Mark `core/rebar` as private
* Disconnect `core/rebar` from builder

### Testing

```
hab studio enter
./rebar3/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```