### PR TITLE
Fix for scaffolding-node plan not detecting .npmrc files.

### DIFF
--- a/scaffolding-node/lib/scaffolding.sh
+++ b/scaffolding-node/lib/scaffolding.sh
@@ -116,7 +116,7 @@ scaffolding_modules_install() {
       if [[ ! -f "$CACHE_PATH/package.json" ]]; then
         cp -av package.json "$CACHE_PATH/"
       fi
-      if [[ -c ".npmrc" ]]; then
+      if [[ -f ".npmrc" ]]; then
         cp -av .npmrc "$CACHE_PATH/"
       fi
       if [[ -f "npm-shrinkwrap.json" ]]; then

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.14"
+pkg_version="0.6.15"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"

--- a/scaffolding-node/plan.sh
+++ b/scaffolding-node/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-node
 pkg_origin=core
-pkg_version="0.6.15"
+pkg_version="0.6.14"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Node.js Applications"


### PR DESCRIPTION
- Change bash if check file test from -c to -f. This changes from testing if the .npmrc file is a character special file (/dev/random, /dev/null, etc...) to testing if the file exists.

Can see changes with scottvidmar/scaffolding-node in public builder

Signed-off-by: Scott Vidmar <svidmar@chef.io>