### PR TITLE
[mesa] Patch mesa to build with llvm7

### DIFF
--- a/mesa/patches/000-llvm7-support.patch
+++ b/mesa/patches/000-llvm7-support.patch
@@ -8,5 +8,3 @@
 +#include <llvm-c/Transforms/Utils.h>
 +#endif
  #include <llvm-c/BitWriter.h>
-
-

--- a/mesa/patches/000-llvm7-support.patch
+++ b/mesa/patches/000-llvm7-support.patch
@@ -1,0 +1,12 @@
+--- src/gallium/auxiliary/gallivm/lp_bld_init.c	2019-02-08 21:20:46.868917000 +0000
++++ src/gallium/auxiliary/gallivm/lp_bld_init.c	2019-02-08 21:21:38.467729000 +0000
+@@ -40,6 +40,9 @@
+
+ #include <llvm-c/Analysis.h>
+ #include <llvm-c/Transforms/Scalar.h>
++#if HAVE_LLVM >= 0x0700
++#include <llvm-c/Transforms/Utils.h>
++#endif
+ #include <llvm-c/BitWriter.h>
+
+

--- a/mesa/plan.sh
+++ b/mesa/plan.sh
@@ -36,12 +36,13 @@ pkg_build_deps=(
   core/glproto
   core/kbproto
   core/libpthread-stubs
-  core/llvm5
+  core/llvm
   core/make
   core/pkg-config
   core/python2
   core/xextproto
   core/xproto
+  core/patch
 )
 pkg_include_dirs=(include)
 pkg_lib_dirs=(
@@ -55,6 +56,8 @@ do_prepare() {
     ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
     _clean_file=true
   fi
+
+  patch -p0 < "$PLAN_CONTEXT"/patches/000-llvm7-support.patch
 }
 
 do_build() {

--- a/mesa/plan.sh
+++ b/mesa/plan.sh
@@ -57,6 +57,7 @@ do_prepare() {
     _clean_file=true
   fi
 
+  # https://patchwork.freedesktop.org/patch/214086/
   patch -p0 < "$PLAN_CONTEXT"/patches/000-llvm7-support.patch
 }
 


### PR DESCRIPTION
closes #2241 

This patches the current version of mesa to build with llvm7.  

There is a new major version of mesa available, however it requires X libraries that we currently don't have in the core origin. This is a temporary workaround to allow downstream dependencies (libepoxy, gtk) to build again after our update to gcc8. 

Package contains no binaries to test, so I built a dependency (`core/libepoxy`) against it to verify.


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>