### PR TITLE
[msodbcsql17] Fixed file type for msodbcsql patchelf

### DIFF
--- a/msodbcsql17/plan.sh
+++ b/msodbcsql17/plan.sh
@@ -36,7 +36,7 @@ do_build() {
   build_line "Fixing rpath for lib:"
 
   find . -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-sharedlib; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "x-pie-executable; charset=binary"' _ {} \; \
     -print \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
 }


### PR DESCRIPTION
Looks like newer versions of file recognize the ODBC driver as application/x-pie-executable rather than application/x-sharedlib, which was causing the patchelf to fail.

This resolves #2223 