### PR TITLE
[sensu] Update to 1.6.2 and fix library linking issues

### DIFF
--- a/sensu/Gemfile
+++ b/sensu/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sensu', '= 1.4.3'
-gem 'sensu-plugin', '= 2.5.0'
+gem 'sensu', '= 1.6.2'
+gem 'sensu-plugin', '= 3.0.1'

--- a/sensu/README.md
+++ b/sensu/README.md
@@ -1,22 +1,22 @@
 # Sensu Habitat Plan
 
-### Description
+## Description
+
 This plan runs both Sensu server and Sensu client based on a habitat config flag.
 
 Sensu-plugin is also included in the vendored gems.
 
-### Server Usage
+## Server Usage
 
 * Start RabbitMQ `docker run -it --rm -e HAB_RABBITMQ="rabbitmq = { default_user='sensu', default_pass='sensu', default_vhost='/sensu'}" core/rabbitmq`
 * Start Redis `docker run -it --rm -e HAB_REDIS="protected-mode='no'" core/redis --peer 172.17.0.3`
 * Start Sensu server `docker run -it --rm -e HAB_SENSU="log_level='debug'" core/sensu --peer 172.17.0.3 --bind rabbitmq:rabbitmq.default --bind redis:redis.default`
 
-
-### Client Usage
+## Client Usage
 
 * Start RabbitMQ `docker run -it --rm -e HAB_RABBITMQ="rabbitmq = { default_user='sensu', default_pass='sensu', default_vhost='/sensu'}" core/rabbitmq`
 * Start Sensu client `docker run -it --rm -e HAB_SENSU="mode='client'" core/sensu --peer 172.17.0.3 --bind rabbitmq:rabbitmq.default --bind redis:redis.default`
 
-### Docker-compose environment
+## Docker-compose environment
 
 * docker-compose up

--- a/sensu/hooks/run
+++ b/sensu/hooks/run
@@ -4,7 +4,6 @@ exec 2>&1
 
 export GEM_HOME="{{pkg.path}}/vendor/bundle/ruby/2.5.0"
 export GEM_PATH="{{pkgPathFor "core/ruby"}}/lib/ruby/gems/2.5.0:{{pkgPathFor "core/bundler"}}:$GEM_HOME"
-export LD_LIBRARY_PATH="{{pkgPathFor "core/gcc-libs"}}/lib:{{pkgPathFor "core/libffi"}}/lib:{{pkgPathFor "core/openssl"}}/lib"
 export CONFIG_DIR="{{pkg.svc_config_path}}"
 
 if [ "{{cfg.mode}}" == "client" ]; then


### PR DESCRIPTION
- Updated sensu to 1.6.2
- Fixed library linking issues
- Minor plan cleanup
- Updated plan so it actually runs the build from HAB_CACHE_SRC, so it doesn't dump bundler files into the source directory
- Cleaned up readme headers

This resolves #2227 

It looks like the run hook was setting LD_LIBRARY_PATH due to bad rpaths. Removed this as extensions are now properly linked