### PR TITLE
[rust] [rust-nightly] Fixed missing runtime dependencies

### DIFF
--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -26,7 +26,10 @@ pkg_build_deps=(
   core/coreutils
 )
 pkg_bin_dirs=(bin)
-pkg_lib_dirs=(lib)
+pkg_lib_dirs=(
+  lib
+  lib/rustlib/x86_64-unknown-linux-gnu/lib # Libraries needed for llvm bins live here
+)
 
 _target_sources=(
   $_url_base/${pkg_name}-std-${pkg_version}-x86_64-unknown-linux-musl.tar.gz
@@ -74,19 +77,20 @@ do_build() {
 do_install() {
   ./install.sh --prefix="$pkg_prefix" --disable-ldconfig
 
-  # Update the dynamic linker & set `RUNPATH` for all ELF binaries under `bin/`
-  for b in rustc cargo rustdoc cargo-fmt rls rustfmt; do
-    patchelf \
-      --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
-      --set-rpath "$LD_RUN_PATH" \
-      "$pkg_prefix/bin/$b"
-  done; unset b
+  # Update the dynamic linker & set `RUNPATH` for all ELF binaries under `bin/` and `lib/`
+  build_line "Fixing rpath for bins:"
+  find "$pkg_prefix/bin" "$pkg_prefix/lib" -type f -perm +0100 \
+    -exec sh -c 'file -i "$1" | grep -v .so | grep -q "executable; charset=binary"' _ {} \; \
+    -print \
+    -exec patchelf \
+    --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
+    --set-rpath "$LD_RUN_PATH" {} \;
 
   # Set `RUNPATH` for all shared libraries under `lib/`
-  find "$pkg_prefix/lib" -name "*.so" -print0 \
-    | xargs -0 -I '%' patchelf \
-      --set-rpath "$LD_RUN_PATH" \
-      %
+  build_line "Fixing rpath for libs:"
+  find "$pkg_prefix/lib" -name "*.so" \
+    -print \
+    -exec patchelf --set-rpath "$LD_RUN_PATH" {} \;
 
   # Install all targets
   local dir


### PR DESCRIPTION
- Set elfing for rust to use find rather than explicitly listing all bins

This makes it so we don't have to manually update the plan for upstream binary changes.

This resolves #2226 

Signed-off-by: W. Duncan Fraser <duncan@wduncanfraser.com>