### PR TITLE
[scaffolding-chef] [scaffolding-inspec] WIP: allow inspec to react to new converged chef-client

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -75,6 +75,8 @@ exec 2>&1
 sleep \$SPLAY_FIRST_RUN_DURATION
 chef_client_cmd
 
+cp {{pkg.svc_config_path}}/chef_client_pkg_ident.current {{pkg.svc_data_path}}/chef_client_pkg_ident.current
+
 while true; do
 
 sleep \$SPLAY_DURATION
@@ -139,6 +141,11 @@ data_collector.server_url "{{cfg.data_collector.server_url}}"
 EOF
   chmod 0640 "$pkg_prefix/config/client-config.rb"
 
+  cat << EOF >> "$pkg_prefix/config/chef_client_pkg_ident.current"
+{{pkg.ident}}
+EOF
+  chmod 0640 "$pkg_prefix/config/chef_client_pkg_ident.current"
+
   cat << EOF >> "$pkg_prefix/config/attributes.json"
 {{#if cfg.attributes ~}}
 {{toJson cfg.attributes}}
@@ -151,7 +158,7 @@ EOF
   cat << EOF >> "$pkg_prefix/default.toml"
 interval = 1800
 splay = 1800
-splay_first_run = 0
+splay_first_run = 1
 run_lock_timeout = 1800
 log_level = "warn"
 chef_client_ident = "" # this is blank by default so it can be populated from the bind

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.5.0"
+pkg_version="0.6.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope

--- a/scaffolding-inspec/plan.sh
+++ b/scaffolding-inspec/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-inspec
 pkg_description="Scaffolding for InSpec"
 pkg_origin=core
-pkg_version="0.1.0"
+pkg_version="0.2.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_upstream_url="https://www.inspec.io"
@@ -17,5 +17,5 @@ do_build() {
 }
 
 do_install() {
-    return 0;
+    install -D -m 0644 "$PLAN_CONTEXT/lib/scaffolding.sh" "$pkg_prefix/lib/scaffolding.sh"
 }


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

DO NOT MERGE, WIP.

This is the basic idea for fixing #2203 

Unfortunately I ran out of time on this and will need to revisit it later.

One thing I realized is that the method of where to read the file on disk is a little harder than I thought. For the reasons mentioned in #2203 I was trying to avoid using gossip or curl the hab http endpoint. Hmmm.... anyone have ideas about a good way to do this? (You can see in this current WIP, I just have the path hardcoded to something dumb).

Perhaps there's a better method than this entirely, but I think the code here should give you an idea of what I'm going for and why the order here is important.