### PR TITLE
[clang] Fix clang bins from segfaulting

### DIFF
--- a/clang/plan.sh
+++ b/clang/plan.sh
@@ -85,6 +85,7 @@ do_build() {
   cmake \
     -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
     -DCLANG_BUILD_EXAMPLES=ON \
+    -DLLVM_ENABLE_RTTI=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -G "Ninja" \
     ..


### PR DESCRIPTION
Add in `-DLLVM_ENABLE_RTTI=ON` since this flag was also enabled from `core/llvm`.  This will close #2270. 

Note: Looked at Archlinux [PKGBUILD](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/llvm#n43) and choosing not to use shared libs.  Rationale: most builds in hab are deterministic.

## Testing

```bash
hab studio enter
DO_CHECK=1 clang/tests/test.sh
```

## Expected

```bash
...
   clang: I love it when a plan.sh comes together.
   clang:
   clang: Build time: 76m26s
...
 ✓ Commands are on path
 ✓ Version matches
 ✓ Help Command Check
 ✓ Check libclang.so exists
 ✓ Check libclang.so does not have any "not found" shared libs

5 tests, 0 failures
```

Note: the version test tries to execute `clang --version`, so if that fails then there is most likely a segfault.

Signed-off-by: Ben Dang <me@bdang.it>
