### PR TITLE
[buildkite-cli] Update to 0.4.0

### DIFF
--- a/buildkite-cli/plan.sh
+++ b/buildkite-cli/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=buildkite-cli
 pkg_origin=core
-pkg_version="0.3.0"
+pkg_version="0.4.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
 pkg_description="A command line interface for Buildkite"
@@ -8,7 +8,7 @@ pkg_build_deps=(core/go core/coreutils core/gcc)
 pkg_deps=(core/glibc core/git core/buildkite-agent)
 pkg_source="https://github.com/buildkite/cli/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=9536eebccdbacf00d5f23f5e981cd79ca7c56a2338a9d7cba73ae67f44f3d2e9
+pkg_shasum=8e3da5aa23a6f8bc92f69cb924ed6513d23ef85a813d4a949f14d0b7b25fd921
 pkg_upstream_url="https://buildkite.com"
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Release Notes: https://github.com/buildkite/cli/releases/tag/v0.4.0

Signed-off-by: Tom Duffield <tom@chef.io>