### PR TITLE
[metricbeat] added metricbeat

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -827,6 +827,8 @@ plan_path = "mercurial"
 plan_path = "mesa"
 [meson]
 plan_path = "meson"
+[metricbeat]
+plan_path = "metricbeat"
 [mg]
 plan_path = "mg"
 [minio]

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -1,0 +1,27 @@
+# metricbeat
+
+Metricbeat is a lightweight shipper for metrics with Elasticsearch.
+
+## Maintainers
+
+The Habitat Maintainers (humans@habitat.sh).
+
+## Type of package
+
+Service package.
+
+## Usage
+
+```
+hab svc load core/metricbeat
+```
+
+Metricbeat will run with the default configuration which puts logs at `{{svc_var_path}}/log/*.log`. The default configuration may not match your needs, and you can replace all of the configuration by providing a user.toml.
+
+## Topologies
+
+Recommended topology is `standalone`.
+
+## Update Strategies
+
+Recommended update strategy is `at-once`.

--- a/metricbeat/config/metricbeat.yml
+++ b/metricbeat/config/metricbeat.yml
@@ -1,0 +1,1 @@
+{{toYaml cfg}}

--- a/metricbeat/default.toml
+++ b/metricbeat/default.toml
@@ -1,0 +1,56 @@
+tags = []
+
+[metricbeat]
+max_start_delay = "10s"
+
+#============================  Config Reloading ===============================
+[metricbeat.config]
+[metricbeat.config.modules]
+[metricbeat.config.modules.reload]
+enabled = false
+
+#==========================  Modules configuration ============================
+[[metricbeat.modules]]
+module = "system"
+period = "10s"
+metricsets = [
+  "cpu",
+  "load",
+  "memory",
+  "network",
+  "process",
+  "process_summary"
+]
+[metricbeat.modules.process]
+[metricbeat.modules.process.include_top_n]
+by_cpu = 5
+by_memory = 5
+
+[[metricbeat.modules]]
+module = "system"
+period = "1m"
+metricsets = [
+  "filesystem",
+  "fsstat"
+]
+[[metricbeat.modules.processors]]
+[metricbeat.modules.processors."drop_event.when.regexp"]
+"system.filesystem.mount_point" = "^/(sys|cgroup|proc|dev|etc|host|lib)($|/)"
+
+[[metricbeat.modules]]
+module = "system"
+period = "15m"
+metricsets = ["uptime"]
+
+#================================ Output ======================================
+[output]
+[output.elasticsearch]
+hosts = ["localhost:9200"]
+
+#================================ Logging ======================================
+
+[logging]
+to_files = true
+[logging.files]
+path = "var/logs"
+name = "metricbeat.log"

--- a/metricbeat/hooks/init
+++ b/metricbeat/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+mkdir -p "{{pkg.svc_var_path}}/logs"

--- a/metricbeat/hooks/run
+++ b/metricbeat/hooks/run
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+exec 2>&1
+
+exec metricbeat \
+  -c "{{pkg.svc_config_path}}/metricbeat.yml" \
+  --path.config "{{pkg.svc_config_path}}" \
+  --path.data "{{pkg.svc_data_path}}" \
+  --path.home "{{pkg.svc_path}}" \
+  --path.logs "{{pkg.svc_var_path}}/logs"

--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,0 +1,35 @@
+pkg_name=metricbeat
+pkg_origin=core
+pkg_version="6.6.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/go core/git core/make core/gcc)
+pkg_bin_dirs=(bin)
+pkg_svc_user=root
+pkg_svc_group=root
+pkg_description="Metricbeat is a lightweight shipper for metrics with Elasticsearch."
+pkg_upstream_url="https://elastic.co/products/beats/metricbeat"
+
+do_download() {
+  GOPATH="$(dirname "${HAB_CACHE_SRC_PATH}")"
+  export GOPATH
+  go get github.com/elastic/beats/metricbeat
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat" > /dev/null || exit 1
+  git checkout "v${pkg_version}"
+  popd > /dev/null || exit 1
+}
+
+do_unpack() {
+  return 0
+}
+
+do_build() {
+  pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat" > /dev/null || exit 1
+  make
+  popd > /dev/null || exit 1
+}
+
+do_install() {
+  install -D "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat/${pkg_name}" "${pkg_prefix}/bin/${pkg_name}"
+}

--- a/metricbeat/tests/test.bats
+++ b/metricbeat/tests/test.bats
@@ -1,0 +1,24 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Command is on path" {
+  [ "$(command -v metricbeat)" ]
+}
+
+@test "Version matches" {
+  result="$(metricbeat version | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run metricbeat --help
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "metricbeat\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep -v "test" | grep metricbeat | wc -l)"
+  [ "${result}" -eq 1 ]
+}

--- a/metricbeat/tests/test.sh
+++ b/metricbeat/tests/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static wc
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+    # Unload the service if its already loaded.
+    hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+    set -e
+    pushd "${PLANDIR}" > /dev/null
+    build
+    source results/last_build.env
+    hab pkg install --binlink --force "results/${pkg_artifact}"
+    hab svc load "${pkg_ident}"
+    popd > /dev/null
+    set +e
+
+    # Give some time for the service to start up
+    sleep 5
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

Adding a new plan for metricbeat. This is very similar to filebeat in operation and structure.

Includes tests and tested this on a live elasticsearch cluster.

```
curl 10.1.1.188:9200/_cat/indices
yellow open metricbeat-6.6.0-2019.02.20 mssQCM1OSZu571zBKA1CUg 5 1 1753 0 1.8mb 1.8mb
```



![excited-kid-birthday](https://user-images.githubusercontent.com/3253989/53129364-2fded580-351c-11e9-8b7e-4abbec0ed168.gif)
