### PR TITLE
[haproxy] Compile with USE_GETADDRINFO=1

### DIFF
--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -35,6 +35,7 @@ do_build() {
        TARGET=linux2628 \
        USE_OPENSSL=1 \
        USE_ZLIB=1 \
+       USE_GETADDRINFO=1 \
        ADDINC="$CFLAGS" \
        ADDLIB="$LDFLAGS"
 }


### PR DESCRIPTION
The current build of haproxy cannot resolve IPv6 only hosts.  If you
try to proxy to hostname that only has IPv6 entries you'll get:

```
haproxy.default(O): [ALERT] 051/143308 (2616) : parsing
[config/haproxy.conf:15] : 'server atest' : could not resolve address
'ipv6.test-ipv6.com'.
```

From
https://github.com/haproxy/haproxy/blob/fba74ea7b0bc55dfd8a84ba5ecb78ff363e61bc4/INSTALL#L420-L429:

> Recent systems can resolve IPv6 host names using getaddrinfo(). This primitive
> is not present in all libcs and does not work in all of them either. Support in
> glibc was broken before 2.3. Some embedded libs may not properly work either,
> thus, support is disabled by default, meaning that some host names which only
> resolve as IPv6 addresses will not resolve and configs might emit an error
> during parsing. If you know that your OS libc has reliable support for
> getaddrinfo(), you can add USE_GETADDRINFO=1 on the make command line to enable
> it. This is the recommended option for most Linux distro packagers since it's
> working fine on all recent mainstream distros. It is automatically enabled on
> Solaris 8 and above, as it's known to work.

Signed-off-by: Steven Danna <steve@chef.io>