### PR TITLE
[elasticsearch5] Add do_install to elasticsearch5

### DIFF
--- a/elasticsearch5/plan.sh
+++ b/elasticsearch5/plan.sh
@@ -11,3 +11,17 @@ pkg_license=('Revised BSD')
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_distname}/${pkg_distname}-${pkg_version}.tar.gz
 pkg_shasum=6c8b46498186bb2f4183660d8653375fc38bddd043302ddb20c516b42ab0125e
 pkg_dirname="elasticsearch-${pkg_version}"
+
+do_install() {
+  install -vDm644 README.textile "${pkg_prefix}/README.textile"
+  install -vDm644 LICENSE.txt "${pkg_prefix}/LICENSE.txt"
+  install -vDm644 NOTICE.txt "${pkg_prefix}/NOTICE.txt"
+
+  # Elasticsearch is greedy when grabbing config files from /bin/..
+  # so we need to put the untemplated config dir out of reach
+  mkdir -p "${pkg_prefix}/es"
+  cp -a ./* "${pkg_prefix}/es"
+
+  # Delete unused binaries to save space
+  rm "${pkg_prefix}/es/bin/"*.bat "${pkg_prefix}/es/bin/"*.exe
+}


### PR DESCRIPTION
This defines the do_install function inside the elasticsearch5 plan.  Previously it relied on the sourced definition from Elasticsearch.  Necessary changes to the build of that package were made that are unfortunately incomparable with elasticsearch5. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>