### PR TITLE
[bdwgc*] Fix pkg_names to match folder name

### DIFF
--- a/bdwgc7/README.md
+++ b/bdwgc7/README.md
@@ -1,4 +1,4 @@
-# bdwgc
+# bdwgc7
 
 A garbage collector for C and C++
 

--- a/bdwgc7/plan.sh
+++ b/bdwgc7/plan.sh
@@ -1,6 +1,6 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../bdwgc/plan.sh"
 
-pkg_name=bdwgc
+pkg_name=bdwgc7
 pkg_origin=core
 pkg_version=7.6.10
 pkg_description="A garbage collector for C and C++"

--- a/bdwgc8/README.md
+++ b/bdwgc8/README.md
@@ -1,4 +1,4 @@
-# bdwgc
+# bdwgc8
 
 A garbage collector for C and C++
 

--- a/bdwgc8/plan.sh
+++ b/bdwgc8/plan.sh
@@ -1,6 +1,6 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../bdwgc/plan.sh"
 
-pkg_name=bdwgc
+pkg_name=bdwgc8
 pkg_origin=core
 pkg_version=8.0.2
 pkg_description="A garbage collector for C and C++"


### PR DESCRIPTION
The `pkg_name` for `bdwgc7` and `bdwgc8` did not correspond to what the folder name was.  This fixes that.  Closes #2311 

Signed-off-by: Ben Dang <me@bdang.it>
