### PR TITLE
[Artifactory Pro] Updating Artifactory Pro to 6.8.2

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.6.5
+pkg_version=6.8.2
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=4c4f71a8bbf950a404b0ec15ab2baba3570ba52d9fccd06ce5f41bb119079f3a
+pkg_shasum=0e04beecbd0731b8d2c0a8c7e650d048840c767e7fdc48b46fd50c6d0c572eea
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hey all,

This is a simple version bump. To test this, please enter the studio and run:
```
./tests/test.sh
```

The result should be: 
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Please let me know if there are questions or comments. 