### PR TITLE
[Artifactory] Update to 6.9.0 and added tests

### DIFF
--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.6.5
+pkg_version=6.9.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum="9ad0ef5360fc725731960aeaece64bef0849393898ec0454b9a660341da5fb74"
+pkg_shasum="10a1a5caa24b3a8d76b34b9696cf6577ef48c36c806b41802b0b12586b70a6c3"
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port

--- a/artifactory/tests/helpers.bash
+++ b/artifactory/tests/helpers.bash
@@ -1,0 +1,24 @@
+# Usage: test_listen <protocol> <port> [wait-duration]
+# protocol: tcp or udp
+# port: int
+# wait-duration: time in seconds
+test_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-3}
+  nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
+  return $?
+}
+
+wait_listen() {
+  local proto="-z"
+  if [ "${1}" == "udp" ]; then
+    proto="-u"
+  fi
+  local wait=${3:-1}
+  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
+    sleep 1
+  done
+}

--- a/artifactory/tests/test.bats
+++ b/artifactory/tests/test.bats
@@ -1,0 +1,7 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+load helpers
+
+@test "Port Listen TCP/8081" {
+  test_listen tcp 8081
+  [ "$?" -eq 0 ]
+}

--- a/artifactory/tests/test.sh
+++ b/artifactory/tests/test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+source "${TESTDIR}/helpers.bash"
+
+hab pkg install --binlink core/bats
+
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+
+# Wait for supervisor to start
+echo "Waiting for supervisor to start"
+wait_listen tcp 9632 30
+
+source "${PLANDIR}/plan.sh"
+# Unload the service if its already loaded.
+hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
+  popd > /dev/null
+  set +e
+fi
+
+# Wait for 30 seconds on first check, to ensure service is up.
+echo "Waiting for Artifactory to start"
+wait_listen tcp 8081 90
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Hey all,

This update brings Artifactory OSS to 6.9.0 and adds tests. To test this build, please enter the studio and run:
```
./tests/test.sh
```

The result should be:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Please let me know if there are any questions or comments. Thanks! 