### PR TITLE
[libsodium] Update plans to 1.0.17

### DIFF
--- a/libsodium/plan.ps1
+++ b/libsodium/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="libsodium"
 $pkg_origin="core"
-$pkg_version="1.0.13"
+$pkg_version="1.0.17"
 $_pkg_version_text=($pkg_version).Replace(".", "_")
 $pkg_description="Sodium is a new, easy-to-use software library for encryption, decryption, signatures, password hashing and more. It is a portable, cross-compilable, installable, packageable fork of NaCl, with a compatible API, and an extended API to improve usability even further."
 $pkg_upstream_url="https://github.com/jedisct1/libsodium"
 $pkg_license=@("ISC")
 $pkg_source="https://github.com/jedisct1/libsodium/archive/$pkg_version.zip"
-$pkg_shasum="1a9d20aa5f06ad208dee765fd6ce7a2b06eab067ed5ca15f9caaf247f4358e67"
+$pkg_shasum="a1734796725f9a2b5ca0316ace3ea0c02f3b239c4e61009ceb672a8d7de18465"
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015")
 $pkg_bin_dirs=@("bin")
 $pkg_lib_dirs=@("lib")

--- a/libsodium/plan.sh
+++ b/libsodium/plan.sh
@@ -1,7 +1,6 @@
 pkg_name=libsodium
-_distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.16
+pkg_version=1.0.17
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Sodium is a new, easy-to-use software library for encryption, decryption, \
@@ -11,9 +10,9 @@ API to improve usability even further.\
 "
 pkg_upstream_url="https://github.com/jedisct1/libsodium"
 pkg_license=('ISC')
-pkg_source="https://download.libsodium.org/libsodium/releases/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533"
-pkg_dirname="${_distname}-${pkg_version}"
+pkg_source="https://download.libsodium.org/libsodium/releases/libsodium-${pkg_version}.tar.gz"
+pkg_shasum="0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1"
+pkg_dirname="libsodium-${pkg_version}"
 pkg_deps=(
   core/glibc
 )


### PR DESCRIPTION
I have no ability to test the windows plan, but here's the linux plan:

   libsodium: hab-plan-build cleanup
   libsodium:
   libsodium: Source Path: /hab/cache/src/libsodium-1.0.17
   libsodium: Installed Path: /hab/pkgs/tas50/libsodium/1.0.17/20190226233714
   libsodium: Artifact: /src/libsodium/results/tas50-libsodium-1.0.17-20190226233714-x86_64-linux.hart
   libsodium: Build Report: /src/libsodium/results/last_build.env
   libsodium: SHA256 Checksum: ede0f268f650fa6fb438d257dbc74c4cb7fd3e6f05ec1cca9faf5b115a6f0792
   libsodium: Blake2b Checksum: 579b9a23cc0f453e71ec9c0814d6cda5a498c6828b1cbb509f5a1e606728d8e0
   libsodium:
   libsodium: I love it when a plan.sh comes together.
   libsodium:
   libsodium: Build time: 1m42s

Signed-off-by: Tim Smith <tsmith@chef.io>