### PR TITLE
[ruby24][ruby23] Updates packages to the latest releases to resolve multiple CVEs

### DIFF
--- a/ruby23/README.md
+++ b/ruby23/README.md
@@ -1,6 +1,6 @@
 # ruby23
 
-A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
 
 ## Maintainers
 

--- a/ruby23/plan.sh
+++ b/ruby23/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby23
 pkg_origin=core
-pkg_version=2.3.6
+pkg_version=2.3.8
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,5 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e
+pkg_shasum=b5016d61440e939045d4e22979e04708ed6c8e1c52e7edb2553cf40b73c59abf
 pkg_dirname="ruby-$pkg_version"

--- a/ruby24/README.md
+++ b/ruby24/README.md
@@ -1,6 +1,6 @@
 # ruby24
 
-A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
 
 ## Maintainers
 

--- a/ruby24/plan.sh
+++ b/ruby24/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby24
 pkg_origin=core
-pkg_version=2.4.3
+pkg_version=2.4.5
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,5 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98
+pkg_shasum=6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198
 pkg_dirname="ruby-$pkg_version"

--- a/ruby25/README.md
+++ b/ruby25/README.md
@@ -1,6 +1,6 @@
 # ruby25
 
-A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
 
 ## Maintainers
 


### PR DESCRIPTION
There are multiple CVEs in the existing packages that have been fixed since last March.

[5][default:/src/ruby23:130]# /hab/pkgs/tas50/ruby23/2.3.8/20190226234706/bin/gem list

*** LOCAL GEMS ***

bigdecimal (default: 1.2.8)
bundler (default: 1.16.6)
did_you_mean (1.0.0)
io-console (default: 0.4.5)
json (default: 1.8.3.1)
minitest (5.8.5)
net-telnet (0.1.1)
power_assert (0.2.6)
psych (default: 2.1.0.1)
rake (10.4.2)
rb-readline (0.5.5)
rdoc (default: 4.2.1)
rubygems-update (2.7.8)
test-unit (3.1.5)

[9][default:/src/ruby24:0]# /hab/pkgs/tas50/ruby24/2.4.5/20190226235513/bin/gem list

*** LOCAL GEMS ***

bigdecimal (default: 1.3.2)
bundler (default: 1.16.6)
did_you_mean (1.1.0)
io-console (default: 0.4.6)
json (default: 2.0.4)
minitest (5.10.1)
net-telnet (0.1.1)
openssl (default: 2.0.9)
power_assert (0.4.1)
psych (default: 2.2.2)
rake (12.0.0)
rb-readline (0.5.5)
rdoc (default: 5.0.0)
rubygems-update (2.7.8)
test-unit (3.2.3)
xmlrpc (0.2.1)

Signed-off-by: Tim Smith <tsmith@chef.io>