### PR TITLE
[openssl] Update plans to 1.0.2r to patch the latest CVE

### DIFF
--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="openssl"
 $pkg_origin="core"
-$pkg_version="1.0.2q"
+$pkg_version="1.0.2r"
 $_pkg_version_text=($pkg_version).Replace(".", "_")
 $pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
 $pkg_upstream_url="https://www.openssl.org"
 $pkg_license=@("OpenSSL")
 $pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
-$pkg_shasum="8165e0b480555e55387b9901f540999015227948894e397e474f90a83dd89751"
+$pkg_shasum="06d0aba3a24097fc2db0050814ffeb5e99d104d61b50fddf1cc7a8f136341fde"
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
 $pkg_bin_dirs=@("bin")
 $pkg_include_dirs=@("include")

--- a/openssl/plan.sh
+++ b/openssl/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=openssl
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.2q
+pkg_version=1.0.2r
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 OpenSSL is an open source project that provides a robust, commercial-grade, \
@@ -12,7 +12,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://www.openssl.org/source/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684"
+pkg_shasum="ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
   openssl: hab-plan-build cleanup
   openssl:
   openssl: Source Path: /hab/cache/src/openssl-1.0.2r
   openssl: Installed Path: /hab/pkgs/tas50/openssl/1.0.2r/20190227000817
   openssl: Artifact: /src/openssl/results/tas50-openssl-1.0.2r-20190227000817-x86_64-linux.hart
   openssl: Build Report: /src/openssl/results/last_build.env
   openssl: SHA256 Checksum: 2dfc0984cc15dfb0ebdeb9604752ce448f8e13778e07f39b6bd489da54ad3ea9
   openssl: Blake2b Checksum: bdd39174be5c43741a684aaa483f16c7288bd0483828e1e475c40161fd7689b8
   openssl:
   openssl: I love it when a plan.sh comes together.
   openssl:
   openssl: Build time: 2m57s

Signed-off-by: Tim Smith <tsmith@chef.io>