### PR TITLE
[dotnet-asp-core] Updating Linux plan to 2.2.2

### DIFF
--- a/dotnet-asp-core/plan.sh
+++ b/dotnet-asp-core/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=dotnet-asp-core
 pkg_origin=core
-pkg_version=2.1.6
+pkg_version=2.2.2
 pkg_license=('MIT')
 pkg_upstream_url=https://docs.microsoft.com/en-us/aspnet/core
 pkg_description="ASP.NET Core is a cross-platform, high-performance, open-source framework for building modern, cloud-based, Internet-connected applications."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/5ecfed21-c776-4924-b734-126400fd324a/4e1bfb9c870ffcf99b1bf953b91ef072/aspnetcore-runtime-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=3d4a4135627c07716447fd058b91c8c45de6b5c385f1245cae8a7a62dec93ce9
-pkg_filename="asp-dotnet-debian-x64.${pkg_version}.tar.gz"
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/168bba07-32dc-4612-ab01-7632d412c4cd/e1ecbf16d84e504c1d66d7a7573c9171/aspnetcore-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=c3249eb70b2f74f7ce6481ae1928553034f7b18b04f7b8ed96d60cb9528afdcf
+pkg_filename="aspnetcore-runtime-${pkg_version}-linux-x64.tar.gz"
 pkg_deps=(
   core/curl
   core/gcc-libs


### PR DESCRIPTION
Hey all,

This is just a version bump, bringing the Linux plan up to the latest version (2.2.2). To test this build, enter the studio and run:
```
./tests/test.sh
```

The results should be:
```
 ✓ Version matches
 ✓ Help command
 ✓ ASP check

3 tests, 0 failures
```

Let me know if there are any questions or comments. 