### PR TITLE
[mesa] Additional patch build against llvm 7.0.1

### DIFF
--- a/mesa/patches/001-llvm-enable-new-fast-math-flags.patch
+++ b/mesa/patches/001-llvm-enable-new-fast-math-flags.patch
@@ -1,0 +1,15 @@
+--- src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
++++ src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+@@ -830,7 +830,11 @@  
+    lp_create_builder(LLVMContextRef ctx, enum lp_float_mode float_mode)
+       llvm::unwrap(builder)->setFastMathFlags(flags);
+       break;
+    case LP_FLOAT_MODE_UNSAFE_FP_MATH:
++#if HAVE_LLVM >= 0x0600
++      flags.setFast();
++#else
+       flags.setUnsafeAlgebra();
++#endif
+       llvm::unwrap(builder)->setFastMathFlags(flags);
+       break;
+    }

--- a/mesa/plan.sh
+++ b/mesa/plan.sh
@@ -59,6 +59,8 @@ do_prepare() {
 
   # https://patchwork.freedesktop.org/patch/214086/
   patch -p0 < "$PLAN_CONTEXT"/patches/000-llvm7-support.patch
+  # https://patchwork.freedesktop.org/patch/186737/
+  patch -p0 < "$PLAN_CONTEXT"/patches/001-llvm-enable-new-fast-math-flags.patch
 }
 
 do_build() {


### PR DESCRIPTION
This is a follow-on to #2288.   

Mesa contains only libraries, so this was tested by building libepoxy against a build with this patch applied.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>