### PR TITLE
[OpenVPN] Bump plan to latest version of OpenVPN, apply "best practices"

### DIFF
--- a/openvpn/hooks/run
+++ b/openvpn/hooks/run
@@ -1,3 +1,4 @@
 #!/bin/sh
-#
-{{pkgPathFor "core/openvpn"}}/bin/openvpn --config {{pkg.svc_config_path}}/server.conf
+
+exec 2>&1
+exec openvpn --config {{pkg.svc_config_path}}/server.conf

--- a/openvpn/plan.sh
+++ b/openvpn/plan.sh
@@ -1,22 +1,27 @@
-pkg_name=openvpn
-pkg_origin=core
-pkg_version=2.3.11
+pkg_name="openvpn"
+pkg_origin="core"
+pkg_version=2.4.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="OpenVPN provides flexible VPN solutions to secure your data communications"
 pkg_license=('gplv2')
+pkg_upstream_url="https://openvpn.net"
 pkg_source=https://swupdate.openvpn.org/community/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=9117a4434fd35e61cf94f9ee7ef84b7aecbc6fa556f779ff599560f219756163
+pkg_shasum="73dce542ed3d6f0553674f49025dfbdff18348eb8a25e6215135d686b165423c"
 pkg_deps=(core/glibc core/openssl core/lzo)
 pkg_build_deps=(core/gcc core/coreutils core/make core/busybox-static)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+pkg_svc_user="root"
+pkg_svc_group="${pkg_svc_user}"
+
 do_build() {
   ./configure \
     --disable-plugin-auth-pam \
-    --prefix=${pkg_prefix} \
-    --exec-prefix=${pkg_prefix} \
-    --sbindir=${pkg_prefix}/bin \
+    --prefix="${pkg_prefix}" \
+    --exec-prefix="${pkg_prefix}" \
+    --sbindir="${pkg_prefix}/bin" \
     --enable-iproute2
   make
 }


### PR DESCRIPTION
Current version of OpenVPN plan is a bit old, this PR bumps the version to the latest and employs some "Habitat best practices" (such as `exec`ing the `openvpn` process)