### PR TITLE
[gcc7] new plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -324,6 +324,13 @@ plan_path = "gcc-libs"
 paths = [
   "gcc/*",
 ]
+[gcc7]
+plan_path = "gcc7"
+[gcc7-libs]
+plan_path = "gcc7-libs"
+paths = [
+  "gcc7/*",
+]
 [gdal]
 plan_path = "gdal"
 [gdb]

--- a/gcc7-libs/README.md
+++ b/gcc7-libs/README.md
@@ -1,0 +1,15 @@
+# gcc7-libs
+
+The GNU Compiler Collection
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gcc7-libs/no-sys-dirs.patch
+++ b/gcc7-libs/no-sys-dirs.patch
@@ -1,0 +1,28 @@
+diff -ru gcc-5.2.0.orig/gcc/cppdefault.c gcc-5.2.0/gcc/cppdefault.c
+--- gcc-5.2.0.orig/gcc/cppdefault.c	2015-01-05 12:33:28.000000000 +0000
++++ gcc-5.2.0/gcc/cppdefault.c	2015-12-23 20:18:54.631026327 +0000
+@@ -35,6 +35,8 @@
+ # undef CROSS_INCLUDE_DIR
+ #endif
+ 
++#undef LOCAL_INCLUDE_DIR
++
+ const struct default_include cpp_include_defaults[]
+ #ifdef INCLUDE_DEFAULTS
+ = INCLUDE_DEFAULTS;
+diff -ru gcc-5.2.0.orig/gcc/gcc.c gcc-5.2.0/gcc/gcc.c
+--- gcc-5.2.0.orig/gcc/gcc.c	2015-03-10 09:37:41.000000000 +0000
++++ gcc-5.2.0/gcc/gcc.c	2015-12-23 20:20:08.027026327 +0000
+@@ -1261,10 +1261,10 @@
+ /* Default prefixes to attach to command names.  */
+ 
+ #ifndef STANDARD_STARTFILE_PREFIX_1
+-#define STANDARD_STARTFILE_PREFIX_1 "/lib/"
++#define STANDARD_STARTFILE_PREFIX_1 ""
+ #endif
+ #ifndef STANDARD_STARTFILE_PREFIX_2
+-#define STANDARD_STARTFILE_PREFIX_2 "/usr/lib/"
++#define STANDARD_STARTFILE_PREFIX_2 ""
+ #endif
+ 
+ #ifdef CROSS_DIRECTORY_STRUCTURE  /* Don't use these prefixes for a cross compiler.  */

--- a/gcc7-libs/plan.sh
+++ b/gcc7-libs/plan.sh
@@ -1,0 +1,88 @@
+source ../gcc7/plan.sh
+
+pkg_name=gcc7-libs
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Runtime libraries shipped by GCC."
+pkg_upstream_url="https://gcc.gnu.org/"
+pkg_license=('GPL-2.0')
+
+# The shared libraries only depend on core/glibc
+pkg_deps=(
+  core/glibc
+)
+# Add the same version of the full gcc package as a build dep
+pkg_build_deps=(
+  "core/gcc7/$pkg_version"
+  core/patchelf
+)
+
+# Zero out the bin and include paths, as we're only shipping shared libs
+pkg_bin_dirs=()
+pkg_include_dirs=()
+
+# The list of GCC libraries to copy
+_gcc_libs=(
+  libasan
+  libatomic
+  libgcc_s
+  libgfortran
+  libgomp
+  libitm
+  liblsan
+  libquadmath
+  libstdc++
+  libtsan
+  libubsan
+  libvtv
+)
+
+do_install() {
+  mkdir -pv "$pkg_prefix/lib"
+  for lib in "${_gcc_libs[@]}"; do
+    cp -av "$(pkg_path_for bdangit/gcc7)/lib/${lib}".* "$pkg_prefix/lib"/
+  done
+  rm -fv "$pkg_prefix/lib"/*.spec "$pkg_prefix/lib"/*.py
+
+  mkdir -pv "$pkg_prefix/share/licenses"
+  cp -av "$(pkg_path_for bdangit/gcc7)"/share/licenses/RUNTIME.LIBRARY.EXCEPTION \
+    "$pkg_prefix/share/licenses/"
+
+  # Due to the copy-from-package trick above, the resulting `RUNPATH` entries
+  # have more path entries than are actually being used (for mpfr, libmpc,
+  # etc), so we'll use `patchelf` trim these unused path entries for each
+  # shared library.
+  find "$pkg_prefix/lib" \
+    -type f \
+    -name '*.so.*' \
+    -exec patchelf --set-rpath "$(pkg_path_for glibc)/lib:$pkg_prefix/lib" {} \;
+  find "$pkg_prefix/lib" \
+    -type f \
+    -name '*.so.*' \
+    -exec patchelf --shrink-rpath {} \;
+}
+
+# Turn the remaining default phases into no-ops
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+# We will rely on tests from `gcc`, so skip them here
+unset -f do_check

--- a/gcc7/README.md
+++ b/gcc7/README.md
@@ -1,0 +1,15 @@
+# gcc7
+
+The GNU Compiler Collection
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/gcc7/cc-wrapper.sh
+++ b/gcc7/cc-wrapper.sh
@@ -1,0 +1,133 @@
+#!@shell@
+#
+# # Usage
+#
+# ```
+# $ @program@ [ARG ..]
+# ```
+#
+# # Synopsis
+#
+# This program takes the place of
+# @program@
+# so that additional options can be added before invoking it.
+#
+# The idea and implementation which this is based upon is thanks to the nixpkgs
+# project, specifically in the `cc-wrapper` package. For more details, see:
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+#
+# # Environment Variables
+#
+# There is one environment variables that is consumed by this program:
+#
+# * `$DEBUG` (*Optional*): If set, this program will output the original and
+#    extra flags added to standard error
+#
+#
+
+# # Main program
+
+# Fail whenever a command returns a non-zero exit code.
+set -e
+
+# The `-B$libc/lib/` flag is a quick hack to force gcc to link against the
+# crt1.o from our own glibc, rather than the one in `/usr/lib`.
+#
+# Unfortunately, setting `-B` appears to override the default search path.
+# Thus, the gcc-specific `../includes-fixed` directory is now longer searched
+# and glibc's `<limits.h>` header fails to compile, because it uses
+# `#include_next <limits.h>` to find the limits.h file in ../includes-fixed. To
+# remedy the problem, another `-idirafter` is necessary to add that directory
+# again.
+libc_cflags="-B@glibc@/lib/"
+libc_cflags="$libc_cflags -idirafter @glibc@/include"
+libc_cflags="$libc_cflags -idirafter @gcc@/lib/gcc/*/*/include-fixed"
+
+# Force gcc to use our ld wrapper from binutils when calling `ld`
+libc_cflags="$libc_cflags -B@binutils@/bin/"
+
+# Figure out if linker flags should be passed.  GCC prints annoying
+# warnings when they are not needed.
+dontLink=0
+getVersion=0
+nonFlagArgs=0
+
+# Determine is we add dynamic linker arguments to the extra arguments by
+# looking at the calling arguments to this program. This may not work 100% of
+# the time, but it has shown to be fairly reliable
+for i in "$@"; do
+  if [ "$i" = -c ]; then
+    dontLink=1
+  elif [ "$i" = -S ]; then
+    dontLink=1
+  elif [ "$i" = -E ]; then
+    dontLink=1
+  elif [ "$i" = -E ]; then
+    dontLink=1
+  elif [ "$i" = -M ]; then
+    dontLink=1
+  elif [ "$i" = -MM ]; then
+    dontLink=1
+  elif [ "$i" = -x ]; then
+    # At least for the cases c-header or c++-header we should set dontLink.
+    # I expect no one use -x other than making precompiled headers.
+    dontLink=1
+  elif [ "${i:0:1}" != - ]; then
+    nonFlagArgs=1
+  fi
+done
+
+# If we pass a flag like -Wl, then gcc will call the linker unless it
+# can figure out that it has to do something else (e.g., because of a
+# "-c" flag).  So if no non-flag arguments are given, don't pass any
+# linker flags.  This catches cases like "gcc" (should just print
+# "gcc: no input files") and "gcc -v" (should print the version).
+if [ "$nonFlagArgs" = 0 ]; then
+  dontLink=1
+fi
+
+params=("$@")
+
+# If we are calling a c/g++ style program, set additional flags.
+if [[ "$(basename @program@)" = *++ ]]; then
+  if  echo "$@" | grep -qv -- -nostdlib; then
+    libc_cflags="$libc_cflags -isystem @gcc@/include/c++/*"
+    libc_cflags="$libc_cflags -isystem @gcc@/include/c++/*/$(@gcc@/bin/gcc -dumpmachine)"
+  fi
+fi
+
+# Add the flags for the C compiler proper.
+extraBefore=()
+extraAfter=($libc_cflags)
+
+if [ "$dontLink" != 1 ]; then
+  extraBefore+=("-Wl,-dynamic-linker" "-Wl,@dynamic_linker@")
+fi
+
+# As a very special hack, if the arguments are just `-v', then don't
+# add anything.  This is to prevent `gcc -v' (which normally prints
+# out the version number and returns exit code 0) from printing out
+# `No input files specified' and returning exit code 1.
+if [ "$*" = -v ]; then
+  extraAfter=()
+  extraBefore=()
+fi
+
+# Optionally print debug info.
+if [ -n "$DEBUG" ]; then
+  echo "original flags to @program@:" >&2
+  for i in "${params[@]}"; do
+    echo "  $i" >&2
+  done
+  echo "extraBefore flags to @program@:" >&2
+  for i in ${extraBefore[@]}; do
+    echo "  $i" >&2
+  done
+  echo "extraAfter flags to @program@:" >&2
+  for i in ${extraAfter[@]}; do
+    echo "  $i" >&2
+  done
+fi
+
+# Become the underlying real program
+exec @program@ ${extraBefore[@]} "${params[@]}" "${extraAfter[@]}"

--- a/gcc7/no-sys-dirs.patch
+++ b/gcc7/no-sys-dirs.patch
@@ -1,0 +1,28 @@
+diff -ru gcc-5.2.0.orig/gcc/cppdefault.c gcc-5.2.0/gcc/cppdefault.c
+--- gcc-5.2.0.orig/gcc/cppdefault.c	2015-01-05 12:33:28.000000000 +0000
++++ gcc-5.2.0/gcc/cppdefault.c	2015-12-23 20:18:54.631026327 +0000
+@@ -35,6 +35,8 @@
+ # undef CROSS_INCLUDE_DIR
+ #endif
+ 
++#undef LOCAL_INCLUDE_DIR
++
+ const struct default_include cpp_include_defaults[]
+ #ifdef INCLUDE_DEFAULTS
+ = INCLUDE_DEFAULTS;
+diff -ru gcc-5.2.0.orig/gcc/gcc.c gcc-5.2.0/gcc/gcc.c
+--- gcc-5.2.0.orig/gcc/gcc.c	2015-03-10 09:37:41.000000000 +0000
++++ gcc-5.2.0/gcc/gcc.c	2015-12-23 20:20:08.027026327 +0000
+@@ -1261,10 +1261,10 @@
+ /* Default prefixes to attach to command names.  */
+ 
+ #ifndef STANDARD_STARTFILE_PREFIX_1
+-#define STANDARD_STARTFILE_PREFIX_1 "/lib/"
++#define STANDARD_STARTFILE_PREFIX_1 ""
+ #endif
+ #ifndef STANDARD_STARTFILE_PREFIX_2
+-#define STANDARD_STARTFILE_PREFIX_2 "/usr/lib/"
++#define STANDARD_STARTFILE_PREFIX_2 ""
+ #endif
+ 
+ #ifdef CROSS_DIRECTORY_STRUCTURE  /* Don't use these prefixes for a cross compiler.  */

--- a/gcc7/plan.sh
+++ b/gcc7/plan.sh
@@ -1,0 +1,327 @@
+pkg_name=gcc7
+_distname=gcc
+pkg_origin=core
+pkg_version=7.3.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+The GNU Compiler Collection (GCC) is a compiler system produced by the GNU \
+Project supporting various programming languages. GCC is a key component of \
+the GNU toolchain and the standard compiler for most Unix-like operating \
+systems.\
+"
+pkg_upstream_url="https://gcc.gnu.org/"
+pkg_license=('GPL-2.0')
+pkg_source="http://ftp.gnu.org/gnu/$_distname/${_distname}-${pkg_version}/${_distname}-${pkg_version}.tar.xz"
+pkg_shasum="832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/glibc
+  core/zlib
+  core/gmp
+  core/mpfr
+  core/libmpc
+  core/binutils
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/file
+  core/make
+  core/gcc
+  core/gawk
+  core/m4
+  core/texinfo
+  core/perl
+  core/inetutils
+  core/expect
+  core/dejagnu
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  glibc="$(pkg_path_for glibc)"
+  binutils="$(pkg_path_for binutils)"
+  headers="$glibc/include"
+
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
+  LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+  build_line "Updating LDFLAGS=$LDFLAGS"
+
+  # Remove glibc include directories from `$CFLAGS` as their contents will be
+  # included in the `--with-native-system-header-dir` configure option
+  orig_cflags="$CFLAGS"
+  CFLAGS=
+  for include in $orig_cflags; do
+    if ! echo "$include" | grep -q "${glibc}" > /dev/null; then
+      CFLAGS="$CFLAGS $include"
+    fi
+  done
+  export CFLAGS
+  build_line "Updating CFLAGS=$CFLAGS"
+
+  # Set `CXXFLAGS` for the c++ code
+  export CXXFLAGS="$CFLAGS"
+  build_line "Setting CXXFLAGS=$CXXFLAGS"
+
+  # Set `CPPFLAGS` which is set by the build system
+  export CPPFLAGS="$CFLAGS"
+  build_line "Setting CPPFLAGS=$CPPFLAGS"
+
+  # Ensure gcc can find the headers for zlib
+  CPATH="$(pkg_path_for zlib)/include"
+  export CPATH
+  build_line "Setting CPATH=$CPATH"
+
+  # Ensure gcc can find the shared libs for zlib
+  LIBRARY_PATH="$(pkg_path_for zlib)/lib"
+  export LIBRARY_PATH
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
+  # TODO: For the wrapper scripts to function correctly, we need the full
+  # path to bash. Until a bash plan is created, we're going to wing this...
+  bash=/bin/bash
+
+  # Tell gcc not to look under the default `/lib/` and `/usr/lib/` directories
+  # for libraries
+  #
+  # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/no-sys-dirs.patch
+  patch -p1 < "$PLAN_CONTEXT/no-sys-dirs.patch"
+
+  # Patch the configure script so it finds glibc headers
+  #
+  # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/builder.sh
+  sed -i \
+    -e "s,glibc_header_dir=/usr/include,glibc_header_dir=${headers}," \
+    gcc/configure
+
+  # Use the correct path to the dynamic linker instead of the default
+  # `lib/ld*.so`
+  #
+  # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/5/default.nix
+  build_line "Fixing the GLIBC_DYNAMIC_LINKER and UCLIBC_DYNAMIC_LINKER macros"
+  for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h; do
+    grep -q LIBC_DYNAMIC_LINKER "$header" || continue
+    build_line "  Fixing $header"
+    sed -i "$header" \
+      -e 's|define[[:blank:]]*\([UCG]\+\)LIBC_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define \1LIBC_DYNAMIC_LINKER\2 "'"${glibc}"'\3"|g' \
+      -e 's|/lib64/ld-linux-|/lib/ld-linux-|g'
+  done
+
+  # Installs x86_64 libraries under `lib/` vs the default `lib64/`
+  #
+  # Thanks to: https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/gcc
+  sed -i '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
+
+  # Update all references to the `/usr/bin/file` absolute path with `file`
+  # which will be on `$PATH` due to file being a build dependency.
+  grep -lr /usr/bin/file ./* | while read -r f; do
+    sed -i -e "s,/usr/bin/file,file,g" "$f"
+  done
+
+  # Build up the build cflags that will be set for multiple environment
+  # variables in the `make` command
+  build_cflags="-O2"
+  build_cflags="$build_cflags -I${headers}"
+  build_cflags="$build_cflags -B${glibc}/lib/"
+  build_cflags="$build_cflags -idirafter"
+  build_cflags="$build_cflags ${headers}"
+  build_cflags="$build_cflags -idirafter"
+  build_cflags="$build_cflags ${pkg_prefix}/lib/gcc/*/*/include-fixed"
+  build_cflags="$build_cflags -Wl,-L${glibc}/lib"
+  build_cflags="$build_cflags -Wl,-rpath"
+  build_cflags="$build_cflags -Wl,${glibc}/lib"
+  build_cflags="$build_cflags -Wl,-L${glibc}/lib"
+  build_cflags="$build_cflags -Wl,-dynamic-linker"
+  build_cflags="$build_cflags -Wl,${dynamic_linker}"
+
+  # Build up the target ldflags that will be used in the `make` command
+  target_ldflags="-Wl,-L${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-rpath"
+  target_ldflags="$target_ldflags -Wl,${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-L${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-dynamic-linker"
+  target_ldflags="$target_ldflags -Wl,${dynamic_linker}"
+  target_ldflags="$target_ldflags -Wl,-L${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-rpath"
+  target_ldflags="$target_ldflags -Wl,${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-L${glibc}/lib"
+  target_ldflags="$target_ldflags -Wl,-dynamic-linker"
+  target_ldflags="$target_ldflags -Wl,${dynamic_linker}"
+}
+
+do_build() {
+  rm -rf "../${pkg_name}-build"
+  mkdir "../${pkg_name}-build"
+  pushd "../${pkg_name}-build" > /dev/null
+    SED=sed \
+    LD="$(pkg_path_for binutils)/bin/ld" \
+    AS="$(pkg_path_for binutils)/bin/as" \
+    "../$pkg_dirname/configure" \
+      --prefix="$pkg_prefix" \
+      --with-gmp="$(pkg_path_for gmp)" \
+      --with-mpfr="$(pkg_path_for mpfr)" \
+      --with-mpc="$(pkg_path_for libmpc)" \
+      --with-native-system-header-dir="$headers" \
+      --enable-languages=c,c++,fortran \
+      --enable-lto \
+      --enable-plugin \
+      --enable-shared \
+      --enable-threads=posix \
+      --enable-install-libiberty \
+      --enable-vtable-verify \
+      --disable-werror \
+      --disable-multilib \
+      --with-system-zlib \
+      --disable-libstdcxx-pch
+
+    # Don't store the configure flags in the resulting executables.
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/builder.sh
+    sed -e '/TOPLEVEL_CONFIGURE_ARGUMENTS=/d' -i Makefile
+
+    # CFLAGS_FOR_TARGET are needed for the libstdc++ configure script to find
+    # the startfiles.
+    # FLAGS_FOR_TARGET are needed for the target libraries to receive the -Bxxx
+    # for the startfiles.
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/builder.sh
+    make \
+      -j"$(nproc)" \
+      NATIVE_SYSTEM_HEADER_DIR="$headers" \
+      SYSTEM_HEADER_DIR="$headers" \
+      CFLAGS_FOR_BUILD="$build_cflags" \
+      CXXFLAGS_FOR_BUILD="$build_cflags" \
+      CFLAGS_FOR_TARGET="$build_cflags" \
+      CXXFLAGS_FOR_TARGET="$build_cflags" \
+      FLAGS_FOR_TARGET="$build_cflags" \
+      LDFLAGS_FOR_BUILD="$build_cflags" \
+      LDFLAGS_FOR_TARGET="$target_ldflags" \
+      BOOT_CFLAGS="$build_cflags" \
+      BOOT_LDFLAGS="$build_cflags" \
+      LIMITS_H_TEST=true \
+      profiledbootstrap
+  popd > /dev/null
+}
+
+do_check() {
+  pushd "../${pkg_name}-build" > /dev/null
+    # One set of tests in the GCC test suite is known to exhaust the stack,
+    # so increase the stack size prior to running the tests
+    ulimit -s 32768
+
+    unset CPATH LIBRARY_PATH
+    export LIBRARY_PATH="$LD_RUN_PATH"
+    # Do not abort on error as some are "expected"
+    # Currently, the tests will report the following unexpected errors:
+    #
+    # gcc:
+    #
+    #  FAIL: c-c++-common/tsan/thread_leak1.c   -O0  output pattern test
+    #  FAIL: c-c++-common/tsan/thread_leak1.c   -O2  output pattern test
+    #
+    # g++:
+    #
+    #  FAIL: c-c++-common/tsan/thread_leak1.c   -O0  output pattern test
+    #  FAIL: c-c++-common/tsan/thread_leak1.c   -O2  output pattern test
+    #
+    # libstdc++:
+    #
+    #  FAIL: libstdc++-abi/abi_check
+    #  FAIL: 22_locale/codecvt/encoding/wchar_t/2.cc execution test
+    #  FAIL: 22_locale/codecvt/encoding/wchar_t/3.cc execution test
+    #  FAIL: 22_locale/codecvt/in/wchar_t/2.cc execution test
+    #  FAIL: 22_locale/codecvt/length/wchar_t/2.cc execution test
+    #  FAIL: 22_locale/codecvt/length/wchar_t/3.cc execution test
+    #  FAIL: 22_locale/codecvt/max_length/wchar_t/2.cc execution test
+    #  FAIL: 22_locale/codecvt/max_length/wchar_t/3.cc execution test
+    #  FAIL: 22_locale/codecvt/out/wchar_t/2.cc execution test
+    #  FAIL: 22_locale/codecvt/out/wchar_t/7.cc execution test
+    #  FAIL: 22_locale/ctype/widen/wchar_t/2.cc execution test
+    #  FAIL: experimental/filesystem/iterators/directory_iterator.cc execution test
+    #  FAIL: experimental/filesystem/iterators/recursive_directory_iterator.cc execution test
+    #  FAIL: experimental/filesystem/operations/exists.cc execution test
+    #  FAIL: experimental/filesystem/operations/is_empty.cc execution test
+    #  FAIL: experimental/filesystem/operations/remove.cc execution test
+    #  FAIL: experimental/filesystem/operations/temp_directory_path.cc execution test
+
+    make -k check || true
+    unset LIBRARY_PATH
+
+    build_line "Displaying Test Summary"
+    "../$pkg_dirname/contrib/test_summary"
+  popd > /dev/null
+}
+
+do_install() {
+  pushd "../${pkg_name}-build" > /dev/null
+    # Make 'lib64' a symlink to 'lib'
+    mkdir -pv "$pkg_prefix/lib"
+    ln -sv lib "$pkg_prefix/lib64"
+
+    make install
+
+    # Install PIC version of libiberty which lets Binutils successfully build.
+    # As of some point in the near past (2015+ ?), the GCC distribution
+    # maintains the libiberty code and not Binutils (they each used to
+    # potentially install `libiberty.a` which was confusing as to the "owner").
+    #
+    # Thanks to: https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/gcc
+    install -v -m644 libiberty/pic/libiberty.a "$pkg_prefix/lib"
+
+    # Install Runtime Library Exception
+    install -Dm644 "../$pkg_dirname/COPYING.RUNTIME" \
+      "$pkg_prefix/share/licenses/RUNTIME.LIBRARY.EXCEPTION"
+
+    # Replace hard links for x86_64-unknown-linux-gnu etc. with symlinks
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/compilers/gcc/builder.sh
+    for bin in "$pkg_prefix/bin/"*-gcc*; do
+      if cmp -s "$pkg_prefix/bin/gcc" "$bin"; then
+        ln -sfnv gcc "$bin"
+      fi
+    done
+
+    # Replace hard links for x86_64-unknown-linux-g++ etc. with symlinks
+    for bin in "$pkg_prefix/bin/c++" "$pkg_prefix/bin/"*-c++* "$pkg_prefix/bin/"*-g++*; do
+      if cmp -s "$pkg_prefix/bin/g++" "$bin"; then
+        ln -sfn g++ "$bin"
+      fi
+    done
+
+    # Many packages use the name cc to call the C compiler
+    ln -sv gcc "$pkg_prefix/bin/cc"
+
+    # Wrap key binaries so we can add some arguments and flags to the real
+    # underlying binary. This should make Plan author's lives a bit easier
+    # as they won't have to worry about setting the correct dynamic linker
+    # (from glibc) and finding the correct path to the special linker object
+    # files such as `crt1.o` and gang.
+    #
+    # Thanks to: https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+    # Thanks to: https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html
+    wrap_binary gcc
+    wrap_binary g++
+    wrap_binary cpp
+  popd > /dev/null
+}
+
+wrap_binary() {
+  local bin="$pkg_prefix/bin/$1"
+  build_line "Adding wrapper $bin to ${bin}.real"
+  mv -v "$bin" "${bin}.real"
+  sed "$PLAN_CONTEXT/cc-wrapper.sh" \
+    -e "s^@shell@^${bash}^g" \
+    -e "s^@glibc@^${glibc}^g" \
+    -e "s^@binutils@^${binutils}^g" \
+    -e "s^@gcc@^${pkg_prefix}^g" \
+    -e "s^@dynamic_linker@^${dynamic_linker}^g" \
+    -e "s^@program@^${bin}.real^g" \
+    > "$bin"
+  chmod 755 "$bin"
+}


### PR DESCRIPTION
This plan adds gcc7 and gcc7-libs.  I decided to copy and paste the plans from gcc and gcc-libs instead of sourcing them and overwriting - in the name of simplicity.  Furthermore, I removed the stage1 check for this plan since this package is to be built after stage1 is complete.

Note, the check will fail due to `cc-wrapper.sh`.  This was purely copied.

Signed-off-by: Ben Dang <me@bdang.it>