### PR TITLE
[telegraf] Update telegraf to 1.10.0

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version="1.9.4"
+pkg_version="1.10.0"
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum="56ec9a88a4f306a79f6dd2503ef358b0e25eba27c8c79dd891171c98973cf116"
+pkg_shasum="3a08f4c4e933175b728e23125128cbd9afa2952e2ee7a699914f57f7dbe9b850"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config $pkg_svc_config_path/telegraf.conf"
 pkg_build_deps=(


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./telegraf/tests/test.sh
```

### Sample Output

```
 ✓ Version matches

1 test, 0 failures
```