### PR TITLE
[postgresql11-client] Remove reference to xlog executables

### DIFF
--- a/postgresql11-client/plan.ps1
+++ b/postgresql11-client/plan.ps1
@@ -21,12 +21,10 @@ $server_execs=@(
     "initdb.exe"
     "pg_archivecleanup.exe"
     "pg_controldata.exe"
-    "pg_resetxlog.exe"
     "pg_rewind.exe"
     "pg_test_fsync.exe"
     "pg_test_timing.exe"
     "pg_upgrade.exe"
-    "pg_xlogdump.exe"
 )
 
 $server_includes=@(


### PR DESCRIPTION
xlog executables are not part of the pg11 package for windows provided by upstream. This removes the attempted removal during our install phase. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>