### PR TITLE
[redis3] Update Redis3 to 3.2.13

### DIFF
--- a/redis3/plan.sh
+++ b/redis3/plan.sh
@@ -2,11 +2,11 @@ source '../redis/plan.sh'
 
 pkg_name=redis3
 pkg_origin=core
-pkg_version="3.2.12"
+pkg_version="3.2.13"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io"
 pkg_license=("BSD-3-Clause")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
-pkg_shasum="98c4254ae1be4e452aa7884245471501c9aa657993e0318d88f048093e7f88fd"
+pkg_shasum="862979c9853fdb1d275d9eb9077f34621596fec1843e3e7f2e2f09ce09a387ba"
 pkg_dirname="${pkg_dist_name}-${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build redis3

source results/last_build.env
hab svc load ${pkg_ident}

hab pkg install --binlink core/busybox-static
netstat -peanut | grep redis
```

### Sample output

```
# netstat -peanut | grep redis
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      4890/redis-server *
tcp        0      0 :::6379                 :::*                    LISTEN      4890/redis-server *
```