### PR TITLE
[redis4] Update Redis4 to 4.0.14

### DIFF
--- a/redis/plan.sh
+++ b/redis/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=redis
 pkg_dist_name=redis
 pkg_origin=core
-pkg_version="4.0.10"
+pkg_version="4.0.14"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io/"
 pkg_license=("BSD-3-Clause")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
-pkg_shasum="1db67435a704f8d18aec9b9637b373c34aa233d65b6e174bdac4c1b161f38ca4"
+pkg_shasum="1e1e18420a86cfb285933123b04a82e1ebda20bfb0a289472745a087587e93a7"
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
   core/make

--- a/redis4/plan.sh
+++ b/redis4/plan.sh
@@ -2,11 +2,11 @@ source '../redis/plan.sh'
 
 pkg_name=redis4
 pkg_origin=core
-pkg_version="4.0.10"
+pkg_version="4.0.14"
 pkg_description="Persistent key-value database, with built-in net interface"
 pkg_upstream_url="http://redis.io"
 pkg_license=("BSD-3-Clause")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.redis.io/releases/${pkg_dist_name}-${pkg_version}.tar.gz"
-pkg_shasum="1db67435a704f8d18aec9b9637b373c34aa233d65b6e174bdac4c1b161f38ca4"
+pkg_shasum="1e1e18420a86cfb285933123b04a82e1ebda20bfb0a289472745a087587e93a7"
 pkg_dirname="${pkg_dist_name}-${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build redis4

source results/last_build.env
hab svc load ${pkg_ident}

hab pkg install --binlink core/busybox-static
netstat -peanut | grep redis
```

### Sample output

```
# netstat -peanut | grep redis 
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      108/redis-server *:
tcp        0      0 :::6379                 :::*                    LISTEN      108/redis-server *:
```