### PR TITLE
[libmaxminddb] Added the libmaxminddb plan.

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -691,6 +691,8 @@ plan_path = "libimagequant"
 plan_path = "libjpeg-turbo"
 [libksba]
 plan_path = "libksba"
+[libmaxminddb]
+plan_path = "libmaxminddb"
 [libmpc]
 plan_path = "libmpc"
 [libnl]

--- a/libmaxminddb/README.md
+++ b/libmaxminddb/README.md
@@ -1,0 +1,27 @@
+# libmaxminddb
+
+C library for the MaxMind DB file format
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary and library package
+
+## Usage
+
+This package includes The GeoLite2 City, Country, And ASN mmdb files.
+
+Example usage:
+
+```
+mmdblookup --file $(hab pkg path core/libmaxminddb)/share/GeoIP/GeoLite2-City_20190409/GeoLite2-City.mmdb --ip 8.8.8.8
+mmdblookup --file $(hab pkg path core/libmaxminddb)/share/GeoIP/GeoLite2-Country_20190409/GeoLite2-Country.mmdb --ip 8.8.8.8
+mmdblookup --file $(hab pkg path core/libmaxminddb)/share/GeoIP/GeoLite2-ASN_20190402/GeoLite2-ASN.mmdb --ip 8.8.8.8
+```
+
+## Included GeoLite data
+
+This product includes GeoLite data created by MaxMind, available from [http://www.maxmind.com](http://www.maxmind.com).

--- a/libmaxminddb/plan.sh
+++ b/libmaxminddb/plan.sh
@@ -1,0 +1,87 @@
+pkg_origin=core
+pkg_name=libmaxminddb
+pkg_version=1.3.2
+pkg_license=('Apache')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/maxmind/libmaxminddb/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="e6f881aa6bd8cfa154a44d965450620df1f714c6dc9dd9971ad98f6e04f6c0f0"
+pkg_upstream_url="https://github.com/maxmind/libmaxminddb"
+pkg_description="C library for the MaxMind DB file format"
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/file
+  core/gcc
+  core/make
+  core/perl
+  )
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+geolite_city_filename="GeoLite2-City.tar.gz"
+geolite_city_archive="https://geolite.maxmind.com/download/geoip/database/${geolite_city_filename}"
+geolite_city_sha256sum="589b8603a6cd98cf134f96de24618ba1d986a954e40409a67f398eb1edbf6084"
+
+geolite_country_filename="GeoLite2-Country.tar.gz"
+geolite_country_archive="https://geolite.maxmind.com/download/geoip/database/${geolite_country_filename}"
+geolite_country_sha256sum="1b627bd7a575500cbf9e675630ab2c9b1632c3727f3eab29a06e50568341bdfa"
+
+geolite_asn_filename="GeoLite2-ASN.tar.gz"
+geolite_asn_archive="https://geolite.maxmind.com/download/geoip/database/${geolite_asn_filename}"
+geolite_asn_sha256sum="6fc0855cdc3514c5b7cf19fe1a2681c5b1bbc5009c3a89b1453b64c8c235ba2a"
+
+do_check() {
+  make check
+}
+
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+
+  interpreter_old="/usr/bin/env"
+  interpreter_new="$(pkg_path_for coreutils)/bin/env"
+
+  grep -nrlI '\#\!/usr/bin/env' "$HAB_CACHE_SRC_PATH/${pkg_dirname}/t" | while read -r fileToFix; do
+    build_line "Setting interpreter for ${fileToFix} to ${interpreter_new}"
+    sed -e "s|#!${interpreter_old}|#!${interpreter_new}|" -i "$fileToFix"
+  done
+}
+
+do_install() {
+  do_default_install
+
+  local geoip_install_path="${pkg_prefix}/share/GeoIP"
+
+  mkdir -p "${geoip_install_path}"
+  cd "${geoip_install_path}"
+
+  build_line "Installing GeoIP City Files"
+  download_file $geolite_city_archive "${geoip_install_path}/${geolite_city_filename}" $geolite_city_sha256sum
+  tar -xf ${geolite_city_filename}
+  rm ${geolite_city_filename}
+
+  build_line "Installing GeoIP Country Files"
+  mkdir -p "${geoip_install_path}"
+  download_file $geolite_country_archive "${geoip_install_path}/${geolite_country_filename}" $geolite_country_sha256sum
+  tar -xf ${geolite_country_filename}
+  rm ${geolite_country_filename}
+
+  build_line "Installing GeoIP ASN Files"
+  mkdir -p "${geoip_install_path}"
+  download_file $geolite_asn_archive "${geoip_install_path}/${geolite_asn_filename}" $geolite_asn_sha256sum
+  tar -xf ${geolite_asn_filename}
+  rm ${geolite_asn_filename}
+}
+
+do_end() {
+  if [[ -n "$_clean_file" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}

--- a/libmaxminddb/tests/test.bats
+++ b/libmaxminddb/tests/test.bats
@@ -1,0 +1,29 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(mmdblookup --version | head -2 | tail -n 1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help flag works" {
+  run mmdblookup --help
+  [ $status -eq 0 ]
+}
+
+@test "City lookup successful" {
+  source results/last_build.env
+  run mmdblookup --file $(hab pkg path ${pkg_origin}/libmaxminddb)/share/GeoIP/GeoLite2-City_20190409/GeoLite2-City.mmdb --ip 8.8.8.8
+  [ $status -eq 0 ]
+}
+
+@test "Country lookup successful" {
+  source results/last_build.env
+  run mmdblookup --file $(hab pkg path ${pkg_origin}/libmaxminddb)/share/GeoIP/GeoLite2-Country_20190409/GeoLite2-Country.mmdb --ip 8.8.8.8
+  [ $status -eq 0 ]
+}
+
+@test "ASN lookup successful" {
+  source results/last_build.env
+  run mmdblookup --file $(hab pkg path ${pkg_origin}/libmaxminddb)/share/GeoIP/GeoLite2-ASN_20190402/GeoLite2-ASN.mmdb --ip 8.8.8.8
+  [ $status -eq 0 ]
+}

--- a/libmaxminddb/tests/test.sh
+++ b/libmaxminddb/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
@smacfarlane This is the replacement for `geoip`.
When running with `DO_CHECK=true`, I get one test failure that is 32-bit dependent:

```
ok 1 - open ./maxmind-db/test-data/MaxMind-DB-test-mixed-32.mmdb status is success - mmap mode
ok 2 - mmdb struct has been set for ./maxmind-db/test-data/MaxMind-DB-test-mixed-32.mmdb - mmap mode
libgcc_s.so.1 must be installed for pthread_cancel to work
/bin/sh: line 5:  9355 Aborted                 (core dumped) ${dir}$tst
FAIL: threads_t
```

Signed-off-by: Meade Kincke <thedarkula2049@gmail.com>