### PR TITLE
Add Initial PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/major-version-up.md
+++ b/.github/PULL_REQUEST_TEMPLATE/major-version-up.md
@@ -1,0 +1,20 @@
+---
+name: Major Version Up
+about: I'd like to increment the major version of a core plan
+labels: C-major-version-up
+
+---
+
+Hello - thanks for contributing to Habitat Core Plans!
+
+You've indicated that you're incrementing the major version of software packaged as a Habitat Core Plan. Please review and include the following information:
+
+- [ ] A link to the upstream Release notes or Changelog.
+
+If the Plan doesn't include a tests directory, please describe how we can verify that the resulting package is working as intended.  If this version includes new features, please include those in the description. Please read [RFC0004](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0004-testing-pull-requests.md) for more details
+
+- [ ] Description of how to validate the package **OR** addition of tests to validate the package.
+
+If the upstream source of the software supports multiple major versions,  please apply [RFC0003](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0003-tracking-package-versions.md) and add Plans to track those major versions.
+
+- [ ] Add additional plans to track previous Major versions (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE/minor-version-up.md
+++ b/.github/PULL_REQUEST_TEMPLATE/minor-version-up.md
@@ -1,0 +1,16 @@
+---
+name: Minor Version Up
+about: I'd like to increment the minor version of a core plan
+labels: C-minor-version-up
+
+---
+
+Hello - thanks for contributing to Habitat Core Plans!
+
+You've indicated that you're incrementing the minor version of software packaged as a Habitat Core Plan. Please review and include the following information:
+
+- [ ] A link to the upstream Release notes or Changelog.
+
+If the Plan doesn't include a tests directory, please describe how we can verify that the resulting package is working as intended.  If this version includes new features, please include those in the description.
+
+- [ ] Description of how to validate the package **OR** addition of tests to validate the package.

--- a/.github/PULL_REQUEST_TEMPLATE/new-plan.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-plan.md
@@ -1,0 +1,29 @@
+---
+name: New Plan
+about: I'd like add a new Core Plan
+labels: C-new-plan
+
+---
+
+Hello - thanks for contributing to Habitat Core Plans!
+
+You've indicated that you'd like to add new software to be tracked and packaged as part of Habitat Core Plans. Please review and include the following information:
+
+- [ ] A short description of the functionality this software provides
+- [ ] README.md included. Please follow this [template](https://github.com/habitat-sh/core-plans/blob/master/README_TEMPLATE_FOR_PLANS.md)
+
+Please describe how we can verify that the resulting package is working as intended. Consider adding tests to automate the verification of the package.  Please read [RFC0004](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0004-testing-pull-requests.md) for more details.
+
+- [ ] Description of how to validate the package **OR** addition of tests to validate the package.
+
+Please verify the license is correct and allows for redistribution
+
+- [ ] pkg_license is correct and allows for redistribution
+
+Habitat Builder uses a `.bldr.toml` file in this repository to provide hints for what should be built when a PR merges. Please add this plan to the `.bldr.toml`
+
+- [ ] Add `.bldr.toml` entry (alphabetical)
+
+If the package is a service, please ensure the service runs with the provided defaults. We also prefer that configuration complexity be kept to a minimum. Please read [RFC0009](https://github.com/habitat-sh/core-plans-rfcs/blob/master/_RFCs/0009-plan-configuration-complexity.md) for more details.
+
+- [ ] Service runs with provided defaults (if applicable)


### PR DESCRIPTION
This PR adds [PR Templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates) for three frequent contribution scenarios.  The goal is to make the expectations for a contribution more transparent to the contributor and provide links to more detailed documentation for why we have set these expectations.  Hopefully maintainers will also benefit from having a checklist as part of each PR.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>