### PR TITLE
[erlang] Update erlang to 21.3

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -273,6 +273,10 @@ plan_path = "erlang16"
 plan_path = "erlang18"
 [erlang19]
 plan_path = "erlang19"
+[erlang20]
+plan_path = "erlang20"
+[erlang21]
+plan_path = "erlang21"
 [etcd]
 plan_path = "etcd"
 [eudev]

--- a/erlang/plan.sh
+++ b/erlang/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=erlang
 pkg_origin=core
-pkg_version=20.2
+pkg_version=21.3
 pkg_description="A programming language for massively scalable soft real-time systems."
 pkg_upstream_url="http://www.erlang.org/"
-pkg_dirname=otp_src_${pkg_version}
+pkg_dirname="otp_src_${pkg_version}"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz
-pkg_filename=otp_src_${pkg_version}.tar.gz
-pkg_shasum=24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23
+pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
+pkg_filename="otp_src_${pkg_version}.tar.gz"
+pkg_shasum=69a743c4f23b2243e06170b1937558122142e47c8ebe652be143199bfafad6e4
 pkg_build_deps=(
   core/coreutils
   core/gcc
@@ -44,16 +44,17 @@ do_prepare() {
 do_build() {
   sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure.in
   sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure
-  ./configure --prefix="${pkg_prefix}" \
-              --enable-threads \
-              --enable-smp-support \
-              --enable-kernel-poll \
-              --enable-dynamic-ssl-lib \
-              --enable-shared-zlib \
-              --enable-hipe \
-              --with-ssl="$(pkg_path_for openssl)" \
-              --with-ssl-include="$(pkg_path_for openssl)/include" \
-              --without-javac
+  CFLAGS="${CFLAGS} -O2" ./configure \
+    --prefix="${pkg_prefix}" \
+    --enable-threads \
+    --enable-smp-support \
+    --enable-kernel-poll \
+    --enable-dynamic-ssl-lib \
+    --enable-shared-zlib \
+    --enable-hipe \
+    --with-ssl="$(pkg_path_for openssl)" \
+    --with-ssl-include="$(pkg_path_for openssl)/include" \
+    --without-javac
   make
 }
 

--- a/erlang20/README.md
+++ b/erlang20/README.md
@@ -1,0 +1,20 @@
+# erlang20
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Simple example of invoking `erl`:
+
+```
+hab pkg install core/erlang20
+hab pkg exec core/erlang20 erl
+```

--- a/erlang20/plan.sh
+++ b/erlang20/plan.sh
@@ -1,0 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../erlang/plan.sh"
+
+pkg_name=erlang20
+pkg_origin=core
+pkg_version=20.2
+pkg_description="A programming language for massively scalable soft real-time systems."
+pkg_upstream_url="http://www.erlang.org/"
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
+pkg_filename="otp_src_${pkg_version}.tar.gz"
+pkg_shasum=24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23
+pkg_dirname="otp_src_${pkg_version}"

--- a/erlang20/tests/test.bats
+++ b/erlang20/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/erlang20/tests/test.sh
+++ b/erlang20/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"

--- a/erlang21/README.md
+++ b/erlang21/README.md
@@ -1,0 +1,20 @@
+# erlang21
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Simple example of invoking `erl`:
+
+```
+hab pkg install core/erlang20
+hab pkg exec core/erlang20 erl
+```

--- a/erlang21/plan.sh
+++ b/erlang21/plan.sh
@@ -1,0 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../erlang/plan.sh"
+
+pkg_name=erlang21
+pkg_origin=core
+pkg_version=21.3
+pkg_description="A programming language for massively scalable soft real-time systems."
+pkg_upstream_url="http://www.erlang.org/"
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
+pkg_filename="otp_src_${pkg_version}.tar.gz"
+pkg_shasum=69a743c4f23b2243e06170b1937558122142e47c8ebe652be143199bfafad6e4
+pkg_dirname="otp_src_${pkg_version}"

--- a/erlang21/tests/test.bats
+++ b/erlang21/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/erlang21/tests/test.sh
+++ b/erlang21/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./erlang/tests/test.sh
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```

This is a decent test, as it uses erlang itself to evaluate the version.

![tenor-257369356](https://user-images.githubusercontent.com/24568/54962757-74411380-4fa9-11e9-9e74-c0fa6a48b2aa.gif)
