### PR TITLE
[filebeat] Update filebeat to 6.7.0, minor cleanup

### DIFF
--- a/filebeat/plan.sh
+++ b/filebeat/plan.sh
@@ -1,10 +1,15 @@
 pkg_name=filebeat
 pkg_origin=core
-pkg_version="6.5.3"
+pkg_version=6.7.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/go core/git core/make core/gcc)
+pkg_build_deps=(
+  core/go
+  core/git
+  core/make
+  core/gcc
+)
 pkg_bin_dirs=(bin)
 pkg_binds_optional=(
   [kibana]="port"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog 6.7.0](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.7.0.html)
* [Changelog 6.6.2](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.6.2.html)
* [Changelog 6.6.1](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.6.1.html)
* [Changelog 6.6.0](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.6.0.html)

### Testing

```
hab studio enter
./filebeat/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

5 tests, 0 failures
```