### PR TITLE
[node10] Update Node10 to 10.15.2 (required for Kibana)

### DIFF
--- a/node10/plan.ps1
+++ b/node10/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node10"
 $pkg_origin="core"
-$pkg_version="10.15.0"
+$pkg_version="10.15.2"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="1cf90ea486607a1e4e3191e4880d4e6a256168d800fe33a6e46680149b88e3ed"
+$pkg_shasum="12a802653c0737a4ba882a06511ad1fb58cfe038bf55b082c7fe6243bdf03cf5"

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node10
 pkg_origin=core
-pkg_version=10.15.0
+pkg_version=10.15.2
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=dbe467e3dabb6854fcb0cd96e04082268cb1e313ce97a4b7100b2ed152b0a0ab
+pkg_shasum=3b81ea6b0ae1c887ed4215d6a0b9349284c811bd98c8ddd7a0370f6cc9eb8182
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* (Changelog 10.15.1)[https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.15.1]
* (Changelog 10.15.2)[https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.15.2]

### Testing

```
hab studio enter
build node10
source results/last_build.env
hab pkg install --binlinkresults/${pkg_artifact}
node --version
```

### Sample output

```
v10.15.2
```

Note: While this is not the latest version, to update Kibana to 6.7.0, it needs 10.15.2, so I'm submitting this PR for acceptance and promotion, before doing Node 10.15.3.