### PR TITLE
Use HEAD instead of BUILDKITE_BRANCH

### DIFF
--- a/.expeditor/generate_verify_pipeline.sh
+++ b/.expeditor/generate_verify_pipeline.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Group them by plan and use that as the unit of work in
 # downstream steps.
 plans_changed() {
-  git diff --name-only "${BUILDKITE_BRANCH}" "$(git merge-base "${BUILDKITE_BRANCH}" master)" \
+  git diff --name-only ${TEST_BRANCH:-HEAD} "$(git merge-base ${TEST_BRANCH:-HEAD} origin/master)" \
   | cut -f1 -d/ \
   | sort \
   | uniq


### PR DESCRIPTION
`git merge-base $BUILDKITE_BRANCH master` returns "" in the context it is executed in in the pipeline.   This addresses that by using HEAD which will always give us the thing that we want to test. 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>