### PR TITLE
[httpd] Update httpd to 2.4.38, Fix tests to allow for ipv6 listening

### DIFF
--- a/httpd/plan.sh
+++ b/httpd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=httpd
 pkg_origin=core
-pkg_version=2.4.35
+pkg_version=2.4.38
 pkg_description="The Apache HTTP Server"
 pkg_upstream_url="http://httpd.apache.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://archive.apache.org/dist/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=31c2c82c9cd34749cbb60d04619d9aa3fb0814ab22246ad588d2426dde90c72c
+pkg_shasum=38d0b73aa313c28065bf58faf64cec12bf7c7d5196146107df2ad07541aa26a6
 pkg_deps=(
   core/apr
   core/apr-util
@@ -38,17 +38,18 @@ pkg_svc_user="root"
 pkg_svc_group="root"
 
 do_build() {
-    ./configure --prefix="$pkg_prefix" \
-                --with-expat="$(pkg_path_for core/expat)" \
-                --with-iconv="$(pkg_path_for core/libiconv)" \
-                --with-pcre="$(pkg_path_for core/pcre)" \
-                --with-apr="$(pkg_path_for core/apr)" \
-                --with-apr-util="$(pkg_path_for core/apr-util)" \
-                --with-z="$(pkg_path_for core/zlib)" \
-                --with-ssl="$(pkg_path_for core/openssl)" \
-                --enable-modules="none" \
-                --enable-mods-static="none" \
-                --enable-mods-shared="reallyall" \
-                --enable-mpms-shared="prefork event worker"
+    ./configure \
+      --prefix="$pkg_prefix" \
+      --with-expat="$(pkg_path_for core/expat)" \
+      --with-iconv="$(pkg_path_for core/libiconv)" \
+      --with-pcre="$(pkg_path_for core/pcre)" \
+      --with-apr="$(pkg_path_for core/apr)" \
+      --with-apr-util="$(pkg_path_for core/apr-util)" \
+      --with-z="$(pkg_path_for core/zlib)" \
+      --with-ssl="$(pkg_path_for core/openssl)" \
+      --enable-modules="none" \
+      --enable-mods-static="none" \
+      --enable-mods-shared="reallyall" \
+      --enable-mpms-shared="prefork event worker"
     make
 }

--- a/httpd/tests/test.bats
+++ b/httpd/tests/test.bats
@@ -26,6 +26,6 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 }
 
 @test "Listening on port 80" {
-  result="$(netstat -peanut | grep httpd | awk '{print $4}' | awk -F':' '{print $2}')"
+  result="$(netstat -peanut | grep httpd | awk '{print $4}' | awk -F':' '{print $NF}')"
   [ "${result}" -eq 80 ]
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://svn.apache.org/repos/asf/httpd/httpd/branches/2.4.x/CHANGES)

### Testing

```
hab studio enter
./httpd/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Multiple processes
 ✓ Listening on port 80

6 tests, 0 failures
```

![tenor-140908061](https://user-images.githubusercontent.com/24568/55123364-8e175d80-5145-11e9-8a35-e25305229585.gif)
