### PR TITLE
[relx] update to latest (3.29.0)

### DIFF
--- a/relx/plan.sh
+++ b/relx/plan.sh
@@ -1,11 +1,13 @@
 pkg_origin=core
 pkg_name=relx
-pkg_version=3.23.1
+pkg_version=3.29.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="A release assembler for Erlang."
 pkg_license=(Apache-2.0)
 pkg_source=https://github.com/erlware/${pkg_name}/archive/v${pkg_version}.tar.gz
-pkg_shasum=55b9af46c0a2ad8f9f38cc3345ccb78d42b31f7a42ed1dce14fdedca38774441
-pkg_deps=(core/erlang)
+pkg_upstream_url="https://github.com/erlware/relx"
+pkg_shasum=d64eca52e17ba3c6ffde695900054eb5ad8e679fd1f941981d85711664b0305f
+pkg_deps=(core/erlang core/coreutils)
 pkg_build_deps=(core/rebar3)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
@@ -18,4 +20,5 @@ do_build() {
 do_install() {
   cp -R "_build/default/"* "${pkg_prefix}"
   chmod +x "${pkg_prefix}/bin/relx"
+  fix_interpreter "${pkg_prefix}"/bin/relx core/coreutils bin/env
 }


### PR DESCRIPTION
With the change of core/erlang to version 21, relx builds would fail with 
```
===> Compiling _build/default/lib/erlware_commons/src/ec_plists.erl failed
_build/default/lib/erlware_commons/src/ec_plists.erl:834: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
_build/default/lib/erlware_commons/src/ec_plists.erl:836: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
```

This updates relx to the most recent version to resolve the build issues.  Additionally, it adds `core/coreutils` to the dependencies to allow relx to function. Previous versions of the package would fail as below because the relx escript started with `#!/usr/bin/env escript` . The output of before and after are shown below: 

```
[22][default:/src:1]# hab pkg exec core/relx relx
✗✗✗
✗✗✗ No such file or directory (os error 2)
✗✗✗
[23][default:/src:1]# hab pkg exec smacfarlane/relx relx
===> Starting relx build process ...
===> Resolving OTP Applications from directories:
          /hab/pkgs/core/erlang/21.3/20190327152504/lib/erlang/lib
===> No releases have been specified in the system!
```
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>