### PR TITLE
[cabal-install] Added gcc-libs as a runtime dep for cabal-install

### DIFF
--- a/cabal-install/plan.sh
+++ b/cabal-install/plan.sh
@@ -11,6 +11,7 @@ pkg_shasum="69bcb2b54a064982412e1587c3c5c1b4fada3344b41b568aab25730034cb21ad"
 pkg_bin_dirs=(bin)
 
 pkg_deps=(
+  core/gcc-libs
   core/glibc
   core/gmp
   core/libffi


### PR DESCRIPTION
This should fix the random pthread_cancel errors we have been seeing over the last year when building packages with cabal-install. It looks like depending on the studio environment, this would either work properly or not, depending on the underlying gcc-libs.

https://buildkite.com/chef-oss/habitat-sh-core-plans-master-verify/builds/14#ffc1dd5c-3c8a-47d5-aaa3-b224d77dcff5/161-449 for an example failure.

Credit to @smacfarlane for digging into this.