### PR TITLE
[node/node11] Update node to 11.13.0

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="11.12.0"
+$pkg_version="11.13.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="1f2de3ac2c6141158a2f72c2acfd692cb54d89eb37c487e110e975fc3632efb2"
+$pkg_shasum="8d0963f62059526146ffbd2a4fba36276399fcb5580ba7f1def8cc2b4a35fe76"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=11.12.0
+pkg_version=11.13.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=7d408dcd485f7193ab37e1f36d0a38676d5dbc9c91329c775e5afe6c687393b8
+pkg_shasum=4c29d24de0e6d2bdf7fbac6d37938696a124501d3710b7f6ecdadb0ef5925fb2
 pkg_deps=(core/glibc core/gcc-libs core/python2 core/bash)
 pkg_build_deps=(core/gcc core/grep core/make)
 pkg_bin_dirs=(bin)

--- a/node11/plan.ps1
+++ b/node11/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node11"
 $pkg_origin="core"
-$pkg_version="11.12.0"
+$pkg_version="11.13.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="1f2de3ac2c6141158a2f72c2acfd692cb54d89eb37c487e110e975fc3632efb2"
+$pkg_shasum="8d0963f62059526146ffbd2a4fba36276399fcb5580ba7f1def8cc2b4a35fe76"

--- a/node11/plan.sh
+++ b/node11/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node11
 pkg_origin=core
-pkg_version=11.12.0
+pkg_version=11.13.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=7d408dcd485f7193ab37e1f36d0a38676d5dbc9c91329c775e5afe6c687393b8
+pkg_shasum=4c29d24de0e6d2bdf7fbac6d37938696a124501d3710b7f6ecdadb0ef5925fb2
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
build node
source results/last_build.env
hab pkg install results/${pkg_artifact}
node --version
```

### Sample output

```
v11.13.0
```

![tenor-100167410](https://user-images.githubusercontent.com/24568/55202539-2fb4b280-520b-11e9-8b17-7e697bf4a285.gif)
