### PR TITLE
Fetch master at the start of pipeline generation

### DIFF
--- a/.expeditor/generate_verify_pipeline.sh
+++ b/.expeditor/generate_verify_pipeline.sh
@@ -10,6 +10,9 @@
 
 set -euo pipefail
 
+# Ensure master is always up to date when generating our pipeline
+git fetch origin master --quiet
+
 # Determine the files changed between this PR and master.
 # Group them by plan and use that as the unit of work in
 # downstream steps.

--- a/.expeditor/templates/verify.pipeline.yml
+++ b/.expeditor/templates/verify.pipeline.yml
@@ -7,3 +7,4 @@ expeditor:
           limit: 1
 
 steps:
+  - wait 


### PR DESCRIPTION
This will hopefully resolve issues like https://buildkite.com/chef-oss/habitat-sh-core-plans-master-verify/builds/49#a8ad4c8c-ff90-41e2-b347-e213045f1c8b where the pipeline is generating pipeline steps unrelated to the PR.   Ref: https://github.com/habitat-sh/core-plans/pull/2386#discussion_r269819442

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>