### PR TITLE
[luajit] Change LuaJIT plan name to luajit

### DIFF
--- a/luajit/plan.sh
+++ b/luajit/plan.sh
@@ -1,21 +1,28 @@
 pkg_origin=core
-pkg_name=LuaJIT
+pkg_name=luajit
 pkg_version=2.0.5
 pkg_description="LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language."
-pkg_upstream_url="http://luajit.org/"
+pkg_upstream_url=http://luajit.org/
 pkg_license=("MIT")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://luajit.org/download/LuaJIT-${pkg_version}.tar.gz"
+pkg_dirname="LuaJIT-${pkg_version}"
 pkg_shasum=874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979
-pkg_deps=(core/glibc core/gcc-libs)
-pkg_build_deps=(core/gcc core/make)
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
 do_prepare() {
-  export TARGET_CFLAGS=${CFLAGS}
-  export TARGET_LDFLAGS=${CFLAGS}
+  export TARGET_CFLAGS="${CFLAGS}"
+  export TARGET_LDFLAGS="${CFLAGS}"
 }
 
 do_build() {

--- a/luajit/tests/test.bats
+++ b/luajit/tests/test.bats
@@ -1,0 +1,11 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result=$(luajit -v | awk '{print $2}')
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Hello World" {
+  result=$(luajit -e 'print("Hello Habitat")')
+  [ "$result" = "Hello Habitat" ]
+}

--- a/luajit/tests/test.sh
+++ b/luajit/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This changes the plan name from `LuaJIT` to `luajit`.

Open for discussion, but I feel this makes more sense. The binary is `luajit`.

### Testing

```
hab studio enter
build luajit
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}
luajit -v
```

### Sample output

```
LuaJIT 2.0.5 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/
```