### PR TITLE
Disable Shellcheck SC1117

### DIFF
--- a/bin/ci/shellcheck.sh
+++ b/bin/ci/shellcheck.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Exclude the following shellcheck issues since they're pervasive and innocuous:
 # https://github.com/koalaman/shellcheck/wiki/SC1090
 # https://github.com/koalaman/shellcheck/wiki/SC1091
+# https://github.com/koalaman/shellcheck/wiki/SC1117
 # https://github.com/koalaman/shellcheck/wiki/SC2034
 # https://github.com/koalaman/shellcheck/wiki/SC2039
 # https://github.com/koalaman/shellcheck/wiki/SC2140
@@ -20,7 +21,7 @@ set -euo pipefail
 # https://github.com/koalaman/shellcheck/wiki/SC2154
 # https://github.com/koalaman/shellcheck/wiki/SC2164
 
-SHELLCHECK_IGNORE="SC1090,SC1091,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"
+SHELLCHECK_IGNORE="SC1090,SC1091,SC1117,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"
 
 plan_path="$1"
 


### PR DESCRIPTION
SC1117 is considered "too pedantic" by the Shellcheck author and has been retired in versions > 0.5.0.  Since we are currently running 0.5.0 in Buildkite, this check causes a lot of erroneous failures. 

Ref: #2395
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>