### PR TITLE
[cerebro] Update Cerebro to 0.8.2, reduce testing wait

### DIFF
--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=cerebro
 pkg_origin=core
-pkg_version="0.8.1"
+pkg_version="0.8.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum="11451e6a8253556d0b9118bb54e2d5f989038180daad99154a8081a835d22224"
+pkg_shasum="c9212ada47ff77f7f6fca2be13d65471b2a8e03a0b9e393bda4b17a030bc2df3"
 pkg_deps=(core/coreutils core/jre8)
 pkg_bin_dirs=(bin)
 pkg_exports=(

--- a/cerebro/tests/test.bats
+++ b/cerebro/tests/test.bats
@@ -1,10 +1,10 @@
 source "${BATS_TEST_DIRNAME}/../plan.sh"
 
+@test "Service is running" {
+  [ "$(hab svc status | grep "cerebro\.default" | awk '{print $4}' | grep up)" ]
+}
+
 @test "Version matches" {
   result="$(curl http://localhost:9000 | grep appVersion | awk '{print $6}' | tr -d "'\"\>" | tr -d 'v')"
   [ "$result" = "${pkg_version}" ]
-}
-
-@test "Service is running" {
-  [ "$(hab svc status | grep "cerebro\.default" | awk '{print $4}' | grep up)" ]
 }

--- a/cerebro/tests/test.sh
+++ b/cerebro/tests/test.sh
@@ -21,7 +21,7 @@ fi
 
 hab svc load "${pkg_ident}"
 hab svc start "${pkg_ident}"
-sleep 120
+sleep 30
 
 bats "${TESTDIR}/test.bats"
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Also change test order to make sense.

### Testing

```
hab studio enter
./cerebro/tests/test.sh
```

### Sample output

```
 ✓ Service is running
 ✓ Version matches

2 tests, 0 failures
```