### PR TITLE
Update telegraf to 1.10.2, add minimal service test

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version="1.10.0"
+pkg_version="1.10.2"
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum="3a08f4c4e933175b728e23125128cbd9afa2952e2ee7a699914f57f7dbe9b850"
+pkg_shasum="e97c17f79a9f4562b8379ec8d51e4e9085a71889306b49200aaf9903554eb63e"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config $pkg_svc_config_path/telegraf.conf"
 pkg_build_deps=(

--- a/telegraf/tests/test.bats
+++ b/telegraf/tests/test.bats
@@ -4,3 +4,7 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   result="$(telegraf version | head -1 | awk '{print $2}')"
   [ "$result" = "${pkg_version}" ]
 }
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "telegraf\.default" | awk '{print $4}' | grep up)" ]
+}

--- a/telegraf/tests/test.sh
+++ b/telegraf/tests/test.sh
@@ -6,14 +6,17 @@ SKIPBUILD=${SKIPBUILD:-0}
 
 hab pkg install --binlink core/bats
 
-source "${PLANDIR}/plan.sh"
-
 if [ "${SKIPBUILD}" -eq 0 ]; then
+  source "${PLANDIR}/plan.sh"
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
   set -e
   pushd "${PLANDIR}" > /dev/null
   build
   source results/last_build.env
   hab pkg install --binlink --force "results/${pkg_artifact}"
+  hab svc load "${pkg_ident}"
   popd > /dev/null
   set +e
 fi

--- a/telegraf/tests/test.sh
+++ b/telegraf/tests/test.sh
@@ -19,6 +19,9 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   hab svc load "${pkg_ident}"
   popd > /dev/null
   set +e
+
+  # Wait for service to start
+  sleep 10
 fi
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
./telegraf/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running

2 tests, 0 failures
```