### PR TITLE
[Artifactory Pro] Updated to 6.9.0

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.8.2
+pkg_version=6.9.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=0e04beecbd0731b8d2c0a8c7e650d048840c767e7fdc48b46fd50c6d0c572eea
+pkg_shasum=6ae08f84f94b6a57305416144e8d71291ed9ffec9f845973b5412f4fd8aee1c3
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hey all,

This update brings Artifactory Pro to version 6.9.0. To test this build, enter the Studio and run:
```
./tests/test.sh
```

The output should return:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

Please let me know if there are any questions or suggestions. Thanks!