### PR TITLE
[openssh] Fix hook/init script to inject full path to ssh-keygen:

### DIFF
--- a/openssh/hooks/init
+++ b/openssh/hooks/init
@@ -3,17 +3,17 @@
 # Generate the keys if they do not exist - restarting sshd would cause
 # this to fail, e.g., on package upgrade
 if [ ! -f {{pkg.svc_config_path}}/ssh_host_dsa_key ]; then
-  ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
+  {{pkg.path}}/bin/ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
 fi
 
 if [ ! -f {{pkg.svc_config_path}}/ssh_host_rsa_key ]; then
-  ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
+  {{pkg.path}}/bin/ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
 fi
 
 if [ ! -f {{pkg.svc_config_path}}/ssh_host_ed25519_key ]; then
-  ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
+  {{pkg.path}}/bin/ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
 fi
 
 if [ ! -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key ]; then
-  ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""
+  {{pkg.path}}/bin/ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""
 fi


### PR DESCRIPTION
In other words, instead of referencing ssh-keygen use {{pkg.path}}/bin/ssh-keygen.  This fix was initially added as part of https://github.com/habitat-sh/core-plans/pull/2375, but has been pulled out into this its own separate PR.

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>