### PR TITLE
[CI] Move check for .bldr.toml entry to 'shared' pipeline

### DIFF
--- a/.expeditor/templates/verify_linux_pipeline.yml
+++ b/.expeditor/templates/verify_linux_pipeline.yml
@@ -19,13 +19,6 @@
       executor:
         docker:
 
-  - label: "[@@plan@@] :linux: :habicat: Check for .bldr.toml entry"
-    command:
-      - bin/ci/check-bldr-toml.sh @@plan@@
-    expeditor:
-      executor:
-        docker:
-
   - label: "[@@plan@@] :linux: :habicat: Build with DO_CHECK=true"
     command:
       - bin/ci/verify-pr-build.sh @@plan@@

--- a/.expeditor/templates/verify_shared_pipeline.yml
+++ b/.expeditor/templates/verify_shared_pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+  - label: "[@@plan@@] :habicat: Check for .bldr.toml entry"
+    command:
+      - bin/ci/check-bldr-toml.sh @@plan@@
+    expeditor:
+      executor:
+        docker:


### PR DESCRIPTION
Ref #2414 

This moves the check for a .bldr.toml entry to a "shared" pipeline. This can be used for checks that need to happen that are independent of platform, but only need to be executed once. 
