### PR TITLE
[dotnet-core-sdk] Updated Linux and Windows plans to 2.2.202

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="2.2.101"
+$pkg_version="2.2.202"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/25d4104d-1776-41cb-b96e-dff9e9bf1542/b878c013de90f0e6c91f6f3c98a2d592/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="fe13ce1eac2ebbc73fb069506d4951c57178935952a30ede029bf849279b4079"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/1c2407a4-feb7-471a-82f0-bd3fa32ad967/74db7ac9a886ae58d779c89cf2777657/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_shasum="4a83be23efaed263f6a1fa07bd144c0a590e08d0e40d464550e0c3ec87e4f77d"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=2.2.101
+pkg_version=2.2.202
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/80e1d007-d6f0-402f-b047-779464dd989b/9ae5e2df9aa166b720bdb92d19977044/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=2b14129d8e0fa01ba027145022e0580796604f091a52fcb86d23c0fa1fa438e9
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/2cecc1f4-5c77-4a9f-a2fa-8bfcee4d4bf0/4e68e8e0e0aac72711eb34c3a9988e45/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=3e3fdf2e6c8053a87f07c16f6e9c55d1be6d28d8273a67cce3207a9f58c14de1
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Hey all,

This updates the Linux and Windows plans to 2.2.202. To test the Linux build, enter the Hab studio and run:
```
./tests/test.sh
```

The results should be:
```
 ✓ Version matches
 ✓ Info command

2 tests, 0 failures
```

Please let me know if there are any questions or comments. Thanks! 