### PR TITLE
[dotnet-471-dev-pack] Include all required metadata 

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -237,6 +237,8 @@ plan_path = "docker-compose"
 plan_path = "docutils"
 [dosfstools]
 plan_path = "dosfstools"
+[dotnet-471-dev-pack]
+path_plan = "dotnet-471-dev-pack"
 [dotnet-472-dev-pack]
 plan_path = "dotnet-472-dev-pack"
 [dotnet-asp-core]

--- a/dotnet-471-dev-pack/plan.ps1
+++ b/dotnet-471-dev-pack/plan.ps1
@@ -1,7 +1,11 @@
 . "..\dotnet-47-dev-pack\plan.ps1"
 
 $pkg_name="dotnet-471-dev-pack"
+$pkg_origin="core"
 $pkg_version="4.7.1"
 $pkg_description=".NET 4.7.1 Targeting Pack and the .NET 4.7.1 SDK."
+$pkg_upstream_url="https://www.microsoft.com/net/download/all"
+$pkg_license=@("Microsoft Software License")
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://download.microsoft.com/download/9/0/1/901B684B-659E-4CBD-BEC8-B3F06967C2E7/NDP471-DevPack-ENU.exe"
 $pkg_shasum="a615488d2c5229aff3b97c56f7e5519cc7ac4f58b638a8e159b19c5c3d455c7b"


### PR DESCRIPTION
This updates the donet-471-dev-pack plan.ps1 to include all required metadata so that we are able to connect it to Builder.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>