### PR TITLE
[dotnet-472-dev-pack] Include all required metadata 

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -237,6 +237,8 @@ plan_path = "docker-compose"
 plan_path = "docutils"
 [dosfstools]
 plan_path = "dosfstools"
+[dotnet-472-dev-pack]
+plan_path = "dotnet-472-dev-pack"
 [dotnet-asp-core]
 path_plan = "dotnet-asp-core"
 [dotnet-core]

--- a/dotnet-472-dev-pack/plan.ps1
+++ b/dotnet-472-dev-pack/plan.ps1
@@ -1,7 +1,11 @@
 . "..\dotnet-47-dev-pack\plan.ps1"
 
 $pkg_name="dotnet-472-dev-pack"
+$pkg_origin="core"
 $pkg_version="4.7.2"
 $pkg_description=".NET 4.7.2 Targeting Pack and the .NET 4.7.2 SDK."
+$pkg_upstream_url="https://www.microsoft.com/net/download/all"
+$pkg_license=@("Microsoft Software License")
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://download.microsoft.com/download/5/F/E/5FE505D0-E753-4F1A-B8D6-D9E73C0C28C7/NDP472-DevPack-ENU.exe"
 $pkg_shasum="15916f064a0ad061463ace80d9405f2d80d29655a13516f3676d421d0337d756"


### PR DESCRIPTION
This updates the donet-472-dev-pack plan.ps1 to include all required metadata so that we are able to connect it to Builder.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>