### PR TITLE
[CI] Remove 'steps' from shared pipeline definition

### DIFF
--- a/.expeditor/templates/verify_shared_pipeline.yml
+++ b/.expeditor/templates/verify_shared_pipeline.yml
@@ -1,4 +1,3 @@
-steps:
   - label: "[@@plan@@] :habicat: Check for .bldr.toml entry"
     command:
       - bin/ci/check-bldr-toml.sh @@plan@@


### PR DESCRIPTION
Specifying 'steps' more than once in a buildkite pipeline definition results in only the last set being run.  This removes the steps key from the shared pipeline definition and relies on its presence in the `verify.pipeline.yml`
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>