### PR TITLE
[hugo] Update hugo to 0.55.0 - Add more complete testing

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.54.0"
+pkg_version="0.55.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -4,3 +4,16 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   result="$(hugo version | awk '{print $5}')"
   [ "$result" = "v${pkg_version}" ]
 }
+
+@test "Help command" {
+  run hugo help
+  [ "$status" -eq 0 ]
+}
+
+@test "Generate new site" {
+  run hugo new site testsite
+  [ "$status" -eq 0 ]
+  [ -d testsite ]
+  [ -f testsite/config.toml ]
+  rm -rf testsite
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/gohugoio/hugo/releases/tag/v0.55.0)

### Testing

```
hab studio enter
./hugo/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```