### PR TITLE
[metricbeat] minor version up 6.7.1

### DIFF
--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=metricbeat
 pkg_origin=core
-pkg_version=6.7.0
+pkg_version=6.7.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

* [Changelog 6.7.1](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.7.1.html)

### Testing

```
hab studio enter
./metricbeat/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

5 tests, 0 failures
```