### PR TITLE
[CI] Rewrite check-bad-patterns ci script

### DIFF
--- a/.expeditor/templates/verify.pipeline.yml
+++ b/.expeditor/templates/verify.pipeline.yml
@@ -7,4 +7,4 @@ expeditor:
           limit: 1
 
 steps:
-  - wait 
+  - wait

--- a/.expeditor/templates/verify_linux_pipeline.yml
+++ b/.expeditor/templates/verify_linux_pipeline.yml
@@ -1,10 +1,3 @@
-  - label: "[@@plan@@] :linux: :habicat: Check for bad patterns"
-    command:
-      - bin/ci/check-bad-patterns.sh @@plan@@
-    expeditor:
-      executor:
-        docker:
-
   - label: "[@@plan@@] :linux: :habicat: Shellcheck"
     command:
       - bin/ci/shellcheck.sh @@plan@@

--- a/.expeditor/templates/verify_shared_pipeline.yml
+++ b/.expeditor/templates/verify_shared_pipeline.yml
@@ -4,3 +4,10 @@
     expeditor:
       executor:
         docker:
+
+  - label: "[@@plan@@] :linux: :habicat: Check for bad patterns"
+    command:
+      - bin/ci/check-bad-patterns.sh @@plan@@
+    expeditor:
+      executor:
+        docker:

--- a/.expeditor/templates/verify_shared_pipeline.yml
+++ b/.expeditor/templates/verify_shared_pipeline.yml
@@ -5,7 +5,7 @@
       executor:
         docker:
 
-  - label: "[@@plan@@] :linux: :habicat: Check for bad patterns"
+  - label: "[@@plan@@] :habicat: Check for bad patterns"
     command:
       - bin/ci/check-bad-patterns.sh @@plan@@
     expeditor:

--- a/bin/ci/check-bad-patterns.sh
+++ b/bin/ci/check-bad-patterns.sh
@@ -8,98 +8,79 @@
 
 set -eu
 plan_path=$1
-# If we source files in our hook scripts, we need to check them too.
-additional=()
-sleeps=0
-habs=0
 
-# Obviously we shouldn't hit any missing sources, but it's easy enough to check
-missing_source=()
+hab_usage=()
+sleep_usage=()
+exit_code=0 
 
-add_sourced() {
-  sourced=${1//\"}
-  # we can't do much with template expansion here.
-  if [[ $sourced =~ ^\{\{ ]]; then
-    echo "Unable to check included file: ${sourced}"
-    return
+# Until the following PRs land, we cannot sleep in a lifecycle hook
+# with the exception of 'run'
+# habitat-sh/habitat#5954
+# habitat-sh/habitat#5955
+# habitat-sh/habitat#5956
+# habitat-sh/habitat#5957
+# habitat-sh/habitat#5958
+# habitat-sh/habitat#5959
+check_for_sleep() {
+  local file
+
+  file="$1"
+  # Match lines containing `sleep N`, ignoring comments
+  match="^([^#])*sleep [0-9]+"
+
+  if grep -qE "$match" "$file"; then 
+    echo "$file contains 'sleep'"
+    sleep_usage+=("$file")
+    exit_code=1
   fi
-  additional+=($sourced)
 }
 
-file_check() {
-  if [ ! -f "$1" ]; then
-    missing_source+=($1)
-    return 1
+check_for_hab() {
+  local file
+
+  file="$1"
+  # Match anything that looks like we're attempting to call the hab cli
+  # inoring comments
+  match="^([^#])*(\(\s*|\s+)hab\s"
+  if egrep -q "$match" "$file"; then
+    echo "$file appears to call 'hab'"
+    hab_usage+=("$file")
+    exit_code=1
   fi
-  while read -r line; do
-    # skip comments
-    if [[ $line =~ ^\#.* ]]; then continue; fi
-
-    # we're sourcing another file, so we need to check that file too
-    if [[ $line == ". "* ]]; then
-      sourced=${line##. }
-      add_sourced "$sourced"
-      continue
-    fi
-
-    if [[ $line == "source "* ]]; then
-      sourced=${line##source }
-      add_sourced "$sourced"
-      continue
-    fi
-
-    # It's OK to block in the run hook, but nowhere else.
-    if [[ ${1##*/} != "run" && $line == *"sleep"* ]]; then
-      sleeps=$((sleeps + 1))
-      continue
-    fi
-
-    if [[ $line == *"\$(hab "* || $line == *"\`hab "* ]]; then
-      habs=$((habs + 1))
-      continue
-    fi
-  done < "$1"
 }
 
 echo "--- :thinking_face: [$plan_path] Checking for bad patterns"
+readarray -t files < <(find "$plan_path" -type f)
 
-file_check "$plan_path"/plan.sh
+for file in "${files[@]}"; do 
+  case $file in
+    */plan.sh | */plan.ps1 )
+      check_for_sleep $file
+      ;;
+    *hooks/run )
+      check_for_hab $file
+      ;;
+    *hooks/*)
+      check_for_hab $file 
+      check_for_sleep $file
+      ;;
+    **)
+      echo "Skipping $file"
+      ;;
+  esac
+done
 
-if [[ ${#additional[@]} -gt 0 ]]; then
-  for file in "${additional[@]}"; do
-    file_check "$file"
-  done
+if [[ "${#hab_usage[@]}" -ne 0 ]]; then 
+  echo "--- :habicat: The following files appear to be calling 'hab'"
+  printf "%s\n" "${hab_usage[@]}"
 fi
 
-if [[ $sleeps -gt 0 || $habs -gt 0 || ${#missing_source[@]} -gt 0 ]]; then
-  files=$(printf "; %s" "${requested[@]}")
-  if [[ ${#additional[@]} -gt 0 ]]; then
-    files+=$(printf "; %s" "${additional[@]}")
-  fi
-  files=${files:2}
-  if [[ ${#missing_source[@]} -gt 0 ]]; then
-    sourced=$(printf ", %s" "${missing_source[@]}")
-    sourced=${sourced:2}
-  fi
-  echo "--- :octagonal_sign: Error detected by Check Bad Patterns."
-  echo "We checked these files: ${files}."
-  echo ""
-  if [[ ${#missing_source[@]} -gt 0 ]]; then
-    echo "  Found sourced files that don't exist: ${sourced}"
-    echo ""
-  fi
-  if [[ $sleeps -gt 0 ]]; then
-    echo "  Found sleep $sleeps times in hook scripts"
-    echo ""
-  fi
-  if [[ $habs -gt 0 ]]; then
-    echo "  Found shell out to hab command $habs times"
-    echo ""
-  fi
-  echo ""
-  exit 1
+if [[ "${#sleep_usage[@]}" -ne 0 ]]; then 
+  echo "--- :sleep: The following files appear to be calling 'sleep'"
+  printf "%s\n" $sleep_usage
 fi
 
-echo "--- :smiling_face: No bad patterns found"
-
-exit 0
+if [[ "$exit_code" -eq 0 ]]; then 
+  echo "--- :smiling_face: [$plan_path] No bad patterns found!"
+fi
+exit "$exit_code"

--- a/bin/ci/check-bad-patterns.sh
+++ b/bin/ci/check-bad-patterns.sh
@@ -11,7 +11,7 @@ plan_path=$1
 
 hab_usage=()
 sleep_usage=()
-exit_code=0 
+exit_code=0
 
 # Until the following PRs land, we cannot sleep in a lifecycle hook
 # with the exception of 'run'
@@ -28,8 +28,7 @@ check_for_sleep() {
   # Match lines containing `sleep N`, ignoring comments
   match="^([^#])*sleep [0-9]+"
 
-  if grep -qE "$match" "$file"; then 
-    echo "$file contains 'sleep'"
+  if grep -qE "$match" "$file"; then
     sleep_usage+=("$file")
     exit_code=1
   fi
@@ -42,8 +41,7 @@ check_for_hab() {
   # Match anything that looks like we're attempting to call the hab cli
   # inoring comments
   match="^([^#])*(\(\s*|\s+)hab\s"
-  if egrep -q "$match" "$file"; then
-    echo "$file appears to call 'hab'"
+  if grep -E -q "$match" "$file"; then
     hab_usage+=("$file")
     exit_code=1
   fi
@@ -52,17 +50,17 @@ check_for_hab() {
 echo "--- :thinking_face: [$plan_path] Checking for bad patterns"
 readarray -t files < <(find "$plan_path" -type f)
 
-for file in "${files[@]}"; do 
+for file in "${files[@]}"; do
   case $file in
     */plan.sh | */plan.ps1 )
-      check_for_sleep $file
+      check_for_sleep "$file"
       ;;
     *hooks/run )
-      check_for_hab $file
+      check_for_hab "$file"
       ;;
     *hooks/*)
-      check_for_hab $file 
-      check_for_sleep $file
+      check_for_hab "$file"
+      check_for_sleep "$file"
       ;;
     **)
       echo "Skipping $file"
@@ -70,17 +68,17 @@ for file in "${files[@]}"; do
   esac
 done
 
-if [[ "${#hab_usage[@]}" -ne 0 ]]; then 
+if [[ "${#hab_usage[@]}" -ne 0 ]]; then
   echo "--- :habicat: The following files appear to be calling 'hab'"
   printf "%s\n" "${hab_usage[@]}"
 fi
 
-if [[ "${#sleep_usage[@]}" -ne 0 ]]; then 
+if [[ "${#sleep_usage[@]}" -ne 0 ]]; then
   echo "--- :sleep: The following files appear to be calling 'sleep'"
-  printf "%s\n" $sleep_usage
+  printf "%s\n" "${sleep_usage[@]}"
 fi
 
-if [[ "$exit_code" -eq 0 ]]; then 
+if [[ "$exit_code" -eq 0 ]]; then
   echo "--- :smiling_face: [$plan_path] No bad patterns found!"
 fi
 exit "$exit_code"


### PR DESCRIPTION
This PR rewrites the the check-bad-patterns script to consider `plan.sh/ps1` and any files in `hooks`  The reason behind this change is previous versions of this script started with the plan.sh and attempted follow any source files. This could cause errors if script wasn't executed from the expected path, for example with node11.  

There was also a bug introduced with the migration to Buildkite that it was no longer checking any files except the plan.sh.   

The rationale behind only checking hooks and plan.sh/ps1 is that those are the only files that are strictly habitat.  Files in config, patch files or other metadata have external requirements imposed upon them, and can't be evaluated for the same patterns as Habitat-specific files. 

Additionally,  since we are now considering a directory as a whole, rather than a set of changed files, we no longer need to attempt to follow "sourced" files removing a lot of complexity around evaluating the contents of the files. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>