### PR TITLE
[vault] Upgrade vault to 1.1.1

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=1.1.0
+pkg_version=1.1.1
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=65d665ee7ba08fb41a7113a2ae3c1d5fd7e0b530b59644ed7dc8a01870b2d73f
+pkg_shasum=134261417c8129a92992cba75bf7ebce8ee4d6100de18b722cce7507782e272c
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md)

### Testing

```
hab studio enter
./vault/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 8200, 8201
 ✓ Good response from /sys/health endpoint

6 tests, 0 failures
```