### PR TITLE
[tmux] Upgrade tmux to 2.8, add tests

### DIFF
--- a/tmux/plan.sh
+++ b/tmux/plan.sh
@@ -1,12 +1,19 @@
 pkg_name=tmux
 pkg_origin=core
-pkg_version=2.7
+pkg_version=2.8
 pkg_description="A terminal multiplexer"
 pkg_upstream_url=https://tmux.github.io/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/tmux/tmux/releases/download/${pkg_version}/tmux-${pkg_version}.tar.gz"
-pkg_shasum=9ded7d100313f6bc5a87404a4048b3745d61f2332f99ec1400a7c4ed9485d452
-pkg_deps=(core/glibc core/libevent core/ncurses)
-pkg_build_deps=(core/gcc core/make)
+pkg_shasum=7f6bf335634fafecff878d78de389562ea7f73a7367f268b66d37ea13617a2ba
+pkg_deps=(
+  core/glibc
+  core/libevent
+  core/ncurses
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
 pkg_bin_dirs=(bin)

--- a/tmux/tests/test.bats
+++ b/tmux/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(tmux -V | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/tmux/tests/test.sh
+++ b/tmux/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://raw.githubusercontent.com/tmux/tmux/2.8/CHANGES)

### Testing

```
hab studio enter
./tmux/tests/test.sh
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```