### PR TITLE
[rabbitmq] Upgrade rabbitmq to 3.7.14

### DIFF
--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=rabbitmq
 pkg_distname="${pkg_name}-server"
 pkg_origin=core
-pkg_version=3.7.8
+pkg_version=3.7.14
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL')
 pkg_description="Open source multi-protocol messaging broker"
 pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source="https://github.com/rabbitmq/rabbitmq-server/releases/download/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz"
-pkg_shasum=bed39fd72b8c932fe5f356fbbc7d30a19d651213e1667d81f084bc31468f5a02
+pkg_shasum=6790812bd05c6c28314fc01f3813cfd29ffa645c89161c9d4d0fce8464249d8a
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/coreutils

--- a/rabbitmq/tests/test.sh
+++ b/rabbitmq/tests/test.sh
@@ -18,7 +18,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
 
   set -e
   pushd "${PLANDIR}" > /dev/null
-  build
+  DO_CHECK=1 build
   source results/last_build.env
   hab pkg install --binlink --force "results/${pkg_artifact}"
   hab svc load "${pkg_ident}"
@@ -26,7 +26,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 
   # Give some time for the service to start up
-  sleep 6
+  sleep 30
 fi
 
 bats "${TESTDIR}/test.bats"

--- a/rabbitmq/tests/test.sh
+++ b/rabbitmq/tests/test.sh
@@ -18,7 +18,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
 
   set -e
   pushd "${PLANDIR}" > /dev/null
-  DO_CHECK=1 build
+  build
   source results/last_build.env
   hab pkg install --binlink --force "results/${pkg_artifact}"
   hab svc load "${pkg_ident}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Fixes #2341 

* [Changelog](https://www.rabbitmq.com/changelog.html)

### Testing

```
hab studio enter
./rabbitmq/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Service is running
 ✓ Listening on port 4369, 5672, 25672

3 tests, 0 failures
```