### PR TITLE
[tap-xunit] Added tap-xunit

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1358,6 +1358,8 @@ plan_path = "swig"
 plan_path = "sysstat"
 [systemd]
 plan_path = "systemd"
+[tap-xunit]
+plan_path = "tap-xunit"
 [tar]
 plan_path = "tar"
 [tcl]

--- a/tap-xunit/README.md
+++ b/tap-xunit/README.md
@@ -1,0 +1,47 @@
+# tap-xunit
+
+TAP to xUnit XML converter.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Install the package
+
+```
+hab pkg install core/tap-xunit
+```
+
+Convert your test output!
+
+```
+echo "1..4
+ok 1 - Input file opened
+not ok 2 - First line of the input valid
+ok 3 - Read the rest of the file
+not ok 4 - Summarized correctly # TODO Not written yet" | hab pkg exec core/tap-xunit tap-xunit
+```
+
+Sample output:
+
+```
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite tests="4" skipped="1" failures="1" errors="0" name="Default">
+    <testcase name="#1 Input file opened"/>
+    <testcase name="#2 First line of the input valid">
+      <failure/>
+    </testcase>
+    <testcase name="#3 Read the rest of the file"/>
+    <testcase name="#4 Summarized correctly">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>
+```

--- a/tap-xunit/plan.sh
+++ b/tap-xunit/plan.sh
@@ -1,0 +1,26 @@
+pkg_name=tap-xunit
+pkg_origin=core
+pkg_version=2.3.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("MIT")
+pkg_source="https://github.com/aghassemi/tap-xunit/archive/${pkg_version}.tar.gz"
+pkg_shasum=2ab6d5bbe47cc01cc12bbb8df6e3c0f1f24b8b9b17c52cad246a291f7468612f
+pkg_deps=(
+  core/coreutils
+  core/node
+)
+pkg_bin_dirs=(bin)
+pkg_description="TAP to xUnit XML converter"
+pkg_upstream_url=https://github.com/aghassemi/tap-xunit
+
+do_build() {
+  return 0
+}
+
+do_install() {
+	cp -r ./* "${pkg_prefix}/"
+  pushd "${pkg_prefix}" > /dev/null
+  npm install
+  fix_interpreter "${pkg_prefix}/bin/*" core/coreutils bin/env
+  popd > /dev/null
+}


### PR DESCRIPTION
Adding a new plan for tap-xunit, a nodejs command line tool that converts TAP testing output into xUnit format, for consumption by test analytics systems.

Currently testing is manual.

### Testing

```
hab studio enter
build tap-xunit
source results/last_build.env
hab pkg install --binlink results/${pkg_artifact}

echo "1..4
ok 1 - Input file opened
not ok 2 - First line of the input valid
ok 3 - Read the rest of the file
not ok 4 - Summarized correctly # TODO Not written yet" | tap-xunit
```

### Sample output

```
<?xml version="1.0"?>
<testsuites>
  <testsuite tests="4" skipped="1" failures="1" errors="0" name="Default">
    <testcase name="#1 Input file opened"/>
    <testcase name="#2 First line of the input valid">
      <failure/>
    </testcase>
    <testcase name="#3 Read the rest of the file"/>
    <testcase name="#4 Summarized correctly">
      <skipped/>
    </testcase>
  </testsuite>
</testsuites>

```