### PR TITLE
Resolve build error with ocaml >= 4.0.6

### DIFF
--- a/opam/plan.sh
+++ b/opam/plan.sh
@@ -29,7 +29,7 @@ pkg_bin_dirs=(bin)
 
 do_build() {
   ./configure --prefix "${pkg_prefix}"
-  make lib-ext
+  OCAMLPARAM="safe-string=0,_" make lib-ext
   make
 }
 

--- a/opam/plan.sh
+++ b/opam/plan.sh
@@ -29,6 +29,8 @@ pkg_bin_dirs=(bin)
 
 do_build() {
   ./configure --prefix "${pkg_prefix}"
+  # This is a copy/paste from https://opam.ocaml.org/doc/Install.html#From-Sources
+  # to fix builds with ocaml >= 4.06.0
   OCAMLPARAM="safe-string=0,_" make lib-ext
   make
 }


### PR DESCRIPTION
From https://opam.ocaml.org/doc/Install.html

> Note that opam1.2.2 doesn't build from source with OCaml 4.06.0. Use this command to compile lib_ext
> OCAMLPARAM="safe-string=0,_" make lib-ext

This updates the opam plan.sh so that it is able to build again. 

Note: There is a new major version out, and it appears that they support both the new major and this version.  I'd like to split that task into a later PR and let this fix the builds of the existing version of opam first.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>