### PR TITLE
[prometheus] Update prometheus to 2.9.0

### DIFF
--- a/prometheus/plan.sh
+++ b/prometheus/plan.sh
@@ -2,13 +2,13 @@ pkg_name=prometheus
 pkg_description="Prometheus monitoring"
 pkg_upstream_url=http://prometheus.io
 pkg_origin=core
-pkg_version=2.7.1
+pkg_version=2.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_source="https://github.com/prometheus/prometheus/archive/v${pkg_version}.tar.gz"
-pkg_shasum=fe239e23379ce6d50c5577f515d7f576f1c6f9396ea47fd87c08fbf8b5e163fb
-prom_pkg_dir="$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}"
+pkg_shasum=d42656f45cd1b6399b2983223ef718bfc475cc518de11081acce9bea22db623c
+prom_pkg_dir="${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}"
 prom_build_dir="${prom_pkg_dir}/src/${pkg_source}"
 pkg_build_deps=(
   core/go
@@ -25,24 +25,24 @@ pkg_binds_optional=(
 )
 
 do_setup_environment() {
-  export GOPATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  export GOPATH="${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
 }
 
 do_unpack() {
-  mkdir -p "$prom_pkg_dir/src/github.com/prometheus/prometheus"
-  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
-  tar xf "$HAB_CACHE_SRC_PATH/$pkg_filename" --strip 1 --no-same-owner
+  mkdir -p "${prom_pkg_dir}/src/github.com/prometheus/prometheus"
+  pushd "${prom_pkg_dir}/src/github.com/prometheus/prometheus" || exit 1
+  tar xf "${HAB_CACHE_SRC_PATH}/${pkg_filename}" --strip 1 --no-same-owner
   popd || exit 1
 }
 
 do_build() {
-  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
-  USER="root" PREFIX="$pkg_prefix/bin" make build
+  pushd "${prom_pkg_dir}/src/github.com/prometheus/prometheus" || exit 1
+  USER="root" PREFIX="${pkg_prefix}/bin" make build
   popd || exit 1
 }
 
 do_check() {
-  pushd "$prom_pkg_dir/src/github.com/prometheus/prometheus" || exit 1
+  pushd "${prom_pkg_dir}/src/github.com/prometheus/prometheus" || exit 1
   make test
   popd || exit 1
 }

--- a/prometheus2/plan.sh
+++ b/prometheus2/plan.sh
@@ -2,11 +2,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../prometheus/plan.sh"
 
 pkg_name=prometheus2
 pkg_origin=core
-pkg_version=2.7.1
+pkg_version=2.9.0
 pkg_description="Prometheus monitoring"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/prometheus/prometheus/archive/v${pkg_version}.tar.gz"
-pkg_shasum=fe239e23379ce6d50c5577f515d7f576f1c6f9396ea47fd87c08fbf8b5e163fb
-prom_pkg_dir="$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}"
+pkg_shasum=d42656f45cd1b6399b2983223ef718bfc475cc518de11081acce9bea22db623c
+prom_pkg_dir="${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}"
 prom_build_dir="${prom_pkg_dir}/src/${pkg_source}"

--- a/prometheus2/plan.sh
+++ b/prometheus2/plan.sh
@@ -3,6 +3,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../prometheus/plan.sh"
 pkg_name=prometheus2
 pkg_origin=core
 pkg_version=2.9.0
+pkg_upstream_url=http://prometheus.io
 pkg_description="Prometheus monitoring"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md)

### Testing

```
hab studio enter
DO_CHECK=1 build prometheus
exit
```

```
hab studio enter
./prometheus/tests/test.sh
```

### Sample output

```
ok      github.com/prometheus/prometheus/cmd/prometheus 382.556s
ok      github.com/prometheus/prometheus/cmd/promtool   1.129s
ok      github.com/prometheus/prometheus/config 1.251s
ok      github.com/prometheus/prometheus/discovery      4.132s
ok      github.com/prometheus/prometheus/discovery/azure        1.105s
?       github.com/prometheus/prometheus/discovery/config       [no test files]
ok      github.com/prometheus/prometheus/discovery/consul       1.091s
ok      github.com/prometheus/prometheus/discovery/dns  1.037s
?       github.com/prometheus/prometheus/discovery/ec2  [no test files]
ok      github.com/prometheus/prometheus/discovery/file 33.192s
?       github.com/prometheus/prometheus/discovery/gce  [no test files]
ok      github.com/prometheus/prometheus/discovery/kubernetes   11.915s
ok      github.com/prometheus/prometheus/discovery/marathon     1.056s
ok      github.com/prometheus/prometheus/discovery/openstack    1.140s
ok      github.com/prometheus/prometheus/discovery/refresh      1.027s
ok      github.com/prometheus/prometheus/discovery/targetgroup  1.023s
ok      github.com/prometheus/prometheus/discovery/triton       1.079s
ok      github.com/prometheus/prometheus/discovery/zookeeper    1.051s
ok      github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter       1.100s
?       github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter-usage [no test files]
?       github.com/prometheus/prometheus/documentation/examples/remote_storage/example_write_adapter    [no test files]
?       github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter   [no test files]
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/graphite  1.017s
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/influxdb  1.037s
ok      github.com/prometheus/prometheus/documentation/examples/remote_storage/remote_storage_adapter/opentsdb  1.021s
ok      github.com/prometheus/prometheus/notifier       1.272s
?       github.com/prometheus/prometheus/pkg/gate       [no test files]
ok      github.com/prometheus/prometheus/pkg/labels     1.016s
ok      github.com/prometheus/prometheus/pkg/logging    1.230s
?       github.com/prometheus/prometheus/pkg/modtimevfs [no test files]
?       github.com/prometheus/prometheus/pkg/pool       [no test files]
ok      github.com/prometheus/prometheus/pkg/relabel    1.042s
ok      github.com/prometheus/prometheus/pkg/rulefmt    1.070s
?       github.com/prometheus/prometheus/pkg/runtime    [no test files]
ok      github.com/prometheus/prometheus/pkg/textparse  1.036s
?       github.com/prometheus/prometheus/pkg/timestamp  [no test files]
?       github.com/prometheus/prometheus/pkg/value      [no test files]
?       github.com/prometheus/prometheus/prompb [no test files]
ok      github.com/prometheus/prometheus/promql 7.156s
ok      github.com/prometheus/prometheus/rules  1.669s
ok      github.com/prometheus/prometheus/scrape 6.418s
ok      github.com/prometheus/prometheus/storage        1.037s
ok      github.com/prometheus/prometheus/storage/remote 9.935s
ok      github.com/prometheus/prometheus/storage/tsdb   1.115s
ok      github.com/prometheus/prometheus/template       1.070s
ok      github.com/prometheus/prometheus/util/httputil  1.065s
ok      github.com/prometheus/prometheus/util/promlint  1.043s
ok      github.com/prometheus/prometheus/util/stats     1.073s
ok      github.com/prometheus/prometheus/util/strutil   1.027s
?       github.com/prometheus/prometheus/util/testutil  [no test files]
?       github.com/prometheus/prometheus/util/treecache [no test files]
ok      github.com/prometheus/prometheus/web    6.811s
ok      github.com/prometheus/prometheus/web/api/v1     2.050s
?       github.com/prometheus/prometheus/web/api/v2     [no test files]
?       github.com/prometheus/prometheus/web/ui [no test files]
```

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 9090

5 tests, 0 failures
```