### PR TITLE
[ffmpeg3][ffmpeg4] Update pkg_name 

### DIFF
--- a/ffmpeg3/plan.sh
+++ b/ffmpeg3/plan.sh
@@ -1,6 +1,6 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../ffmpeg/plan.sh"
 
-pkg_name=ffmpeg
+pkg_name=ffmpeg3
 pkg_origin=core
 pkg_version=3.4.6
 pkg_source=https://ffmpeg.org/releases/${pkg_name}-${pkg_version}.tar.gz

--- a/ffmpeg4/plan.sh
+++ b/ffmpeg4/plan.sh
@@ -1,6 +1,6 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../ffmpeg/plan.sh"
 
-pkg_name=ffmpeg
+pkg_name=ffmpeg4
 pkg_origin=core
 pkg_version=4.1.3
 pkg_source=https://ffmpeg.org/releases/${pkg_name}-${pkg_version}.tar.gz


### PR DESCRIPTION
This updates the pkg_name for ffmpeg3 and ffmpeg4 to reflect that they are different packages than ffmpeg.  

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>