### PR TITLE
[memcached] Update memcached to 1.5.13, add do_check

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.12
+pkg_version=1.5.13
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=c02f97d5685617b209fbe25f3464317b234d765b427d254c2413410a5c095b29
+pkg_shasum=61e1a774949735a9eb6e40992bb04083d8427f3d0ce1a52a15c0116db39c4d63
 pkg_deps=(
   core/glibc
   core/cyrus-sasl
@@ -31,4 +31,8 @@ do_build() {
     --prefix="${pkg_prefix}" \
     --enable-sasl
   make
+}
+
+do_check() {
+  make test
 }

--- a/memcached/tests/test.sh
+++ b/memcached/tests/test.sh
@@ -13,10 +13,11 @@ hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
 
 source "${PLANDIR}/plan.sh"
-# Unload the service if its already loaded.
-hab svc unload "${HAB_ORIGIN}/${pkg_name}"
 
 if [ "${SKIPBUILD}" -eq 0 ]; then
+  # Unload the service if its already loaded.
+  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+
   set -e
   pushd "${PLANDIR}" > /dev/null
   build

--- a/memcached/tests/test.sh
+++ b/memcached/tests/test.sh
@@ -27,7 +27,7 @@ if [ "${SKIPBUILD}" -eq 0 ]; then
   set +e
 
   # Give some time for the service to start up
-  sleep 3
+  sleep 10
 fi
 
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/memcached/memcached/wiki/ReleaseNotes1513)

### Testing

```
hab studio enter
DO_CHECK=1 build memcached
exit
```

```
hab studio enter
./memcached/tests/test.sh
```

### Sample output

```
All tests successful.
Files=73, Tests=25874, 211 wallclock secs ( 4.14 usr  0.40 sys + 10.79 cusr  8.71 csys = 24.04 CPU)
Result: PASS
```

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

6 tests, 0 failures
```