### PR TITLE
[ripgrep] Update ripgrep to 11.0.1, add tests

### DIFF
--- a/ripgrep/plan.sh
+++ b/ripgrep/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=ripgrep
 pkg_origin=core
-pkg_version="0.5.2"
+pkg_version="11.0.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT' 'Unlicense')
-pkg_source="https://github.com/BurntSushi/$pkg_name/releases/download/$pkg_version/$pkg_name-$pkg_version-x86_64-unknown-linux-musl.tar.gz"
-pkg_dirname="$pkg_name-$pkg_version-x86_64-unknown-linux-musl"
-pkg_shasum="ecb53ed7e9f3a1ebea76a4e517af42ffe1e778eab3b413200a3e543d033f68f5"
+pkg_source="https://github.com/BurntSushi/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}-x86_64-unknown-linux-musl.tar.gz"
+pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-musl"
+pkg_shasum="ce74cabac9b39b1ad55837ec01e2c670fa7e965772ac2647b209e31ead19008c"
 pkg_bin_dirs=(bin)
 pkg_description="ripgrep combines the usability of The Silver Searcher with the raw speed of grep."
 pkg_upstream_url="https://github.com/BurntSushi/ripgrep"
@@ -15,7 +15,7 @@ do_build() {
 }
 
 do_install() {
-  install -v -m 0755 "$CACHE_PATH/rg" "$pkg_prefix/bin/rg"
+  install -v -m 0755 "${CACHE_PATH}/rg" "${pkg_prefix}/bin/rg"
 }
 
 do_strip() {

--- a/ripgrep/tests/test.bats
+++ b/ripgrep/tests/test.bats
@@ -1,0 +1,23 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(rg --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${pkg_version}" ]
+}
+
+@test "Help command" {
+  run rg --help
+  [ $status -eq 0 ]
+}
+
+@test "Usage test no params" {
+  run rg
+  [ $status -eq 2 ]
+}
+
+@test "Usage test with params" {
+  result=$(rg "ripgrep" | rg "raw speed")
+  [ $? -eq 0 ]
+  lines=$(echo "${result}" | wc -l)
+  [ $lines -eq 3 ]
+}

--- a/ripgrep/tests/test.sh
+++ b/ripgrep/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/BurntSushi/ripgrep/blob/master/CHANGELOG.md)

### Testing

```
hab studio enter
./ripgrep/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Usage test no params
 ✓ Usage test with params

4 tests, 0 failures
```