### PR TITLE
[telegraf] Update telegraf to 1.10.3

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version="1.10.2"
+pkg_version="1.10.3"
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum="e97c17f79a9f4562b8379ec8d51e4e9085a71889306b49200aaf9903554eb63e"
+pkg_shasum="fe5552e24a26e1de698207ff9c89e4a716cd3f65904bef6bcb60bd34743d9c83"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_svc_run="telegraf --config $pkg_svc_config_path/telegraf.conf"
+pkg_svc_run="telegraf --config ${pkg_svc_config_path}/telegraf.conf"
 pkg_build_deps=(
   core/wget
   core/tar


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md)

### Testing

```
hab studio enter
./telegraf/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running

2 tests, 0 failures
```