### PR TITLE
[minio] Update minio to 2019-04-09T01-22-30Z, fix tests for IPv6

### DIFF
--- a/minio/plan.sh
+++ b/minio/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=minio
 pkg_origin=core
-pkg_version="2018-11-30T03-56-59Z"
+pkg_version="2019-04-09T01-22-30Z"
 pkg_description="Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure."
 pkg_upstream_url="https://minio.io"
 pkg_source="https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.${pkg_version}"
-pkg_shasum="cbb86818efa9f281195334e37cebc8aa014a41cd20173216617c2267b0d71ec3"
+pkg_shasum="88b56053d46175a60ed11ffac5335f42e48d395de9217839bc288f5554bb2476"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_bin_dirs=(bin)

--- a/minio/tests/test.bats
+++ b/minio/tests/test.bats
@@ -21,5 +21,5 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 }
 
 @test "Listening on port 9000" {
-  [ "$(netstat -peanut | grep minio | awk '{print $4}' | awk -F':' '{print $2}' | grep 9000)" ]
+  [ "$(netstat -peanut | grep minio | awk '{print $4}' | awk -F':' '{print $NF}' | grep 9000)" ]
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/minio/minio/releases)

Changes are various. Primarily bug fixes, but includes import TLS/Certificate configuration options.

### Testing

```
hab studio enter
./minio/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches, via help output
 ✓ Service is running
 ✓ A single process
 ✓ Listening on port 9000

5 tests, 0 failures
```

