### PR TITLE
[hugo] Update hugo to 0.55.2

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.55.0"
+pkg_version="0.55.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://gohugo.io/news/0.55.2-relnotes/)

### Testing

```
hab studio enter
./hugo/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```