### PR TITLE
[libedit] Update metadata

### DIFF
--- a/libedit/plan.sh
+++ b/libedit/plan.sh
@@ -1,9 +1,12 @@
 pkg_name=libedit
 pkg_origin=core
 pkg_version=3.1.20150325
-pkg_license=('bsd')
+pkg_license=('BSD-3-Clause')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://thrysoee.dk/editline/libedit-20150325-3.1.tar.gz
-pkg_dirname=${pkg_name}-20150325-3.1
+pkg_dirname="${pkg_name}-20150325-3.1"
+pkg_upstream_url="https://thrysoee.dk/editline/"
+pkg_description="This is an autotool- and libtoolized port of the NetBSD Editline library (libedit)."
 pkg_shasum=c88a5e4af83c5f40dda8455886ac98923a9c33125699742603a88a0253fcc8c5
 pkg_deps=(core/glibc core/ncurses)
 pkg_build_deps=(core/gcc core/make core/coreutils)
@@ -11,5 +14,5 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 do_build() {
-  ./configure --enable-widec --prefix=$pkg_prefix
+  ./configure --enable-widec --prefix="$pkg_prefix"
 }


### PR DESCRIPTION
This updates the libedit plan to include required metadata, partially addressing #1306. It also corrects the license string to align with SPDX 3.5. 

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>