### PR TITLE
[Artifactory] Updating to 6.9.1

### DIFF
--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.9.0
+pkg_version=6.9.1
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum="10a1a5caa24b3a8d76b34b9696cf6577ef48c36c806b41802b0b12586b70a6c3"
+pkg_shasum=83e99303990a444aadbda36ce5279640f17f99672917200cb1a62b13e5ecae82
 pkg_deps=(core/bash core/jre8)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Hello, 

This PR updates Artifactory to v.6.9.1. To test this build, enter the Hab Studio ```hab studio enter``` and run the following command: ```./tests/test.sh```

The output should be:
```
Waiting for Artifactory to start
 ✓ Port Listen TCP/8081

1 test, 0 failures
```

