### PR TITLE
Add missing freetype-config script to the package

### DIFF
--- a/freetype/plan.sh
+++ b/freetype/plan.sh
@@ -9,20 +9,22 @@ pkg_source=http://download.savannah.gnu.org/releases/freetype/${pkg_name}-${pkg_
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d
 pkg_build_deps=(
-  core/coreutils
   core/diffutils
   core/gcc
   core/make
-  core/pkg-config
 )
 pkg_deps=(
+  core/coreutils
   core/bzip2
   core/glibc
   core/libpng
   core/zlib
   core/bash
+  core/sed
+  core/pkg-config
 )
 pkg_include_dirs=(include)
+pkg_pconfig_dirs=(lib/pkgconfig)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)
 
@@ -30,7 +32,7 @@ do_install() {
   do_default_install
 
   build_line "Remove space from freetype-config interperter"
-  sed -i 's@ /bin/sh@/bin/sh@' "$CACHE_PATH/builds/unix/freetype-config"
+  sed -i 's@#! /bin/sh@#!/bin/sh@' "$CACHE_PATH/builds/unix/freetype-config"
 
   build_line "Copy freetype-config to bin"
   install "$CACHE_PATH/builds/unix/freetype-config" "$pkg_prefix/bin/"

--- a/freetype/plan.sh
+++ b/freetype/plan.sh
@@ -28,9 +28,9 @@ pkg_bin_dirs=(bin)
 
 do_install() {
   do_default_install
- 
+
   build_line "Remove space from freetype-config interperter"
-  sed -i 's@ /bin/sh@/bin/sh@'  $CACHE_PATH/builds/unix/freetype-config
+  sed -i 's@ /bin/sh@/bin/sh@' "$CACHE_PATH/builds/unix/freetype-config"
 
   build_line "Copy freetype-config to bin"
   install "$CACHE_PATH/builds/unix/freetype-config" "$pkg_prefix/bin/"

--- a/freetype/plan.sh
+++ b/freetype/plan.sh
@@ -20,6 +20,20 @@ pkg_deps=(
   core/glibc
   core/libpng
   core/zlib
+  core/bash
 )
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_install() {
+  do_default_install
+ 
+  build_line "Remove space from freetype-config interperter"
+  sed -i 's@ /bin/sh@/bin/sh@'  $CACHE_PATH/builds/unix/freetype-config
+
+  build_line "Copy freetype-config to bin"
+  install "$CACHE_PATH/builds/unix/freetype-config" "$pkg_prefix/bin/"
+
+  fix_interpreter "$pkg_prefix/bin/freetype-config" "core/bash" "bin/sh"
+}


### PR DESCRIPTION
The `freetype` package was missing the `freetype-config` script, which is needed by other packages like `grub` in order to compile with freetype2 support.

See #2329 and #2215 for examples of where it's failing.

This is similar to what LFS does when [installing Freetype](http://www.linuxfromscratch.org/blfs/view/8.3/general/freetype2.html)

Signed-off-by: Will Fisher <wfisher@chef.io>