### PR TITLE
[tomcat-native] Add core/gcc-libs as runtime dep, add tests

### DIFF
--- a/tomcat-native/README.md
+++ b/tomcat-native/README.md
@@ -13,3 +13,27 @@ Binary package
 ## Usage
 
 *TODO: Add instructions for usage*
+
+## Testing
+
+Run the tests/test.sh script withthe package built and installed and with `PACKAGE_IDENT` set:
+
+```
+hab studio enter
+build tomcat-native
+package_ident=$(cat results/last_build.env | grep pkg_ident | cut -d\= -f2)
+./tomcat-native/tests/test.sh $package_ident
+```
+
+```
+» Installing core/bats
+☁ Determining latest version of core/bats in the 'stable' channel
+→ Using core/bats/0.4.0/20190115015448
+★ Install of core/bats/0.4.0/20190115015448 complete with 0 new packages installed.
+» Binlinking bats from core/bats/0.4.0/20190115015448 into /bin
+★ Binlinked bats from core/bats/0.4.0/20190115015448 to /bin/bats
+ ✓ package directory for package ident core/tomcat-native/1.2.8/20190424103322 exists
+ ✓ 'ldd /hab/pkgs/core/tomcat-native/1.2.8/20190424103322/lib/*.so*' indicates no dynamic linking issues
+
+2 tests, 0 failures
+```

--- a/tomcat-native/plan.sh
+++ b/tomcat-native/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('Apache 2.0')
 pkg_source="http://archive.apache.org/dist/tomcat/tomcat-connectors/native/$pkg_version/source/$pkg_name-$pkg_version-src.tar.gz"
 pkg_shasum=408ece0b027c8967b3aa85533c5fca642827e235b1857d28df918a4eab861d30
-pkg_deps=(core/apr)
+pkg_deps=(core/apr core/gcc-libs)
 pkg_build_deps=(core/gcc core/make core/openssl core/jdk8)
 pkg_lib_dirs=(lib)
 

--- a/tomcat-native/tests/test.bats
+++ b/tomcat-native/tests/test.bats
@@ -1,0 +1,8 @@
+@test "package directory for package ident ${PACKAGE_IDENT} exists" {
+  [ -d "/hab/pkgs/${PACKAGE_IDENT}" ]
+}
+
+@test "'ldd /hab/pkgs/${PACKAGE_IDENT}/lib/*.so*' indicates no dynamic linking issues" {
+  run ldd /hab/pkgs/${PACKAGE_IDENT}/lib/*.so*
+  [ $status -eq 0 ]
+}

--- a/tomcat-native/tests/test.sh
+++ b/tomcat-native/tests/test.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: tomcat-native/tests/test.sh FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+PKG_IDENT="$1"
+
+hab pkg install core/bats
+
+export PKG_IDENT
+hab pkg exec core/bats bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Fixes #2229

Signed-off-by: James Stocks <jstocks@chef.io>