### PR TITLE
[grub] Fix compiling of grub with freetype2

### DIFF
--- a/grub/plan.sh
+++ b/grub/plan.sh
@@ -29,7 +29,7 @@ pkg_build_deps=(
   core/texinfo
   core/patch
 )
-pkg_deps=(core/glibc core/xz core/gettext core/pcre core/gcc-libs core/devicemapper core/elfutils core/bzip2 core/libcap)
+pkg_deps=(core/glibc core/xz core/gettext core/pcre core/gcc-libs core/devicemapper core/elfutils core/bzip2 core/libcap core/zlib core/libpng)
 
 do_setup() {
   if [[ ! -d /boot ]]; then


### PR DESCRIPTION
Need to add the deps from freetype2 to compile grub. This PR is dependent on #2494 being merged, built and promoted before grub will compile.

Resolves #2329 and #2215  

Signed-off-by: Will Fisher <wfisher@chef.io>