### PR TITLE
[postgresql/postgresql11] Remove volumes from example docker-compose

### DIFF
--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -104,27 +104,17 @@ services:
     image: habitat/postgresql
     command: --group cluster
       --topology leader
-    volumes:
-      - pg1-data:/hab/svc/postgresql/data
   pg2:
     image: habitat/postgresql
     command: --group cluster
       --topology leader
       --peer pg1
-    volumes:
-      - pg2-data:/hab/svc/postgresql/data
   pg3:
     image: habitat/postgresql
     command: --group cluster
       --topology leader
       --peer pg1
-    volumes:
-      - pg3-data:/hab/svc/postgresql/data
 
-volumes:
-  pg1-data:
-  pg2-data:
-  pg3-data:
 EOF
 
 docker-compose up

--- a/postgresql11/README.md
+++ b/postgresql11/README.md
@@ -104,27 +104,17 @@ services:
     image: habitat/postgresql11
     command: --group cluster
       --topology leader
-    volumes:
-      - pg1-data:/hab/svc/postgresql11/data
   pg2:
     image: habitat/postgresql11
     command: --group cluster
       --topology leader
       --peer pg1
-    volumes:
-      - pg2-data:/hab/svc/postgresql11/data
   pg3:
     image: habitat/postgresql11
     command: --group cluster
       --topology leader
       --peer pg1
-    volumes:
-      - pg3-data:/hab/svc/postgresql11/data
 
-volumes:
-  pg1-data:
-  pg2-data:
-  pg3-data:
 EOF
 
 docker-compose up


### PR DESCRIPTION
Fixes #2279 

Volumes will always be mounted as root, after the directories are chowned to the svc_user resulting in the postgresql service in the docker-compose example unable to start.  Some additional context in https://github.com/habitat-sh/core-plans/pull/1921

This fixes the issue by removing the volumes from the example docker-compose.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>