### PR TITLE
[galera] Update dependencies

### DIFF
--- a/galera/patches/000-add-ld_run_path-to-scons-env.patch
+++ b/galera/patches/000-add-ld_run_path-to-scons-env.patch
@@ -1,0 +1,15 @@
+--- SConstruct.orig	2016-11-08 13:17:10.000000000 +0000
++++ SConstruct	2019-04-25 17:13:47.215423000 +0000
+@@ -143,7 +143,11 @@
+ # Set up and export default build environment
+ #
+ 
+-env = Environment(ENV = {'PATH' : os.environ['PATH'], 'HOME' : os.environ['HOME']})
++env = Environment(ENV = { 
++  'PATH' : os.environ['PATH'], 
++  'HOME' : os.environ['HOME'], 
++  'LD_RUN_PATH' : os.environ['LD_RUN_PATH']
++})
+ 
+ # Set up environment for ccache and distcc
+ #env['ENV']['HOME']          = os.environ['HOME']

--- a/galera/plan.sh
+++ b/galera/plan.sh
@@ -6,10 +6,27 @@ pkg_upstream_url=https://github.com/codership/galera
 pkg_shasum=068b074ca5a5c2a5a3f799422650e7c5e5c9012ddfa1c18c30feab7f9aa9611d
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Galera WSREP plugin"
-pkg_license=('GPL-2.0')
+pkg_license=('GPL-2.0-only')
 pkg_lib_dirs=(lib)
-pkg_build_deps=(core/scons core/python2 core/gcc core/boost core/check core/openssl)
+pkg_deps=(
+  core/gcc-libs
+  core/openssl
+  core/glibc
+)
+pkg_build_deps=(
+  core/scons
+  core/python2
+  core/gcc
+  core/boost
+  core/check
+  core/patch
+)
 pkg_dirname="galera-release_${pkg_version}"
+
+do_prepare() {
+  # Patch the build script to include LD_RUN_PATH in its environment
+  patch -p0 < "$PLAN_CONTEXT"/patches/000-add-ld_run_path-to-scons-env.patch
+}
 
 do_build() {
   scons strict_build_flags=0 tests=0


### PR DESCRIPTION
Closes #2213 

This adds the missing dependencies to the `pkg_deps`.

It also patches the build script so that it includes LD_RUN_PATH in environment variables it copies into its internal build environment.  Without the patch, the LD_RUN_PATH is unset during the build and the resulting library is unable to find its dependencies.

```
ldd /hab/pkgs/foo/galera/25.3.19/20190425171738/lib/libgalera_smm.so
	linux-vdso.so.1 (0x00007fff04ddc000)
	libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007f9a11d47000)
	librt.so.1 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/librt.so.1 (0x00007f9a11d3d000)
	libssl.so.1.0.0 => /hab/pkgs/core/openssl/1.0.2r/20190305210149/lib/libssl.so.1.0.0 (0x00007f9a11cc9000)
	libcrypto.so.1.0.0 => /hab/pkgs/core/openssl/1.0.2r/20190305210149/lib/libcrypto.so.1.0.0 (0x00007f9a119f7000)
	libstdc++.so.6 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libstdc++.so.6 (0x00007f9a117ef000)
	libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007f9a1165c000)
	libgcc_s.so.1 => /hab/pkgs/core/gcc-libs/8.2.0/20190115011926/lib/libgcc_s.so.1 (0x00007f9a11640000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f9a11488000)
	/hab/pkgs/core/glibc/2.27/20190115002733/lib64/ld-linux-x86-64.so.2 (0x00007f9a12024000)
	libdl.so.2 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libdl.so.2 (0x00007f9a11483000)
```
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>