### PR TITLE
[libgpg-error] Update metadata

### DIFF
--- a/libgpg-error/plan.sh
+++ b/libgpg-error/plan.sh
@@ -1,19 +1,40 @@
 pkg_name=libgpg-error
 pkg_origin=core
 pkg_version=1.20
-pkg_license=('lgplv2+')
+pkg_license=('GPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=ftp://ftp.gnupg.org/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2
+pkg_upstream_url="https://www.gnupg.org/software/libgpg-error/index.html"
+pkg_description="Libgpg-error is a small library that originally defined common error values for all GnuPG components."
 pkg_shasum=3266895ce3419a7fb093e63e95e2ee3056c481a9bc0d6df694cfd26f74e72522
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/gcc core/coreutils core/sed core/bison core/flex core/grep core/bash core/gawk core/libtool core/diffutils core/findutils core/xz core/gettext core/gzip core/make core/patch core/texinfo core/util-linux)
+pkg_build_deps=(
+  core/gcc
+  core/coreutils
+  core/sed
+  core/bison
+  core/flex
+  core/grep
+  core/bash
+  core/gawk
+  core/libtool
+  core/diffutils
+  core/findutils
+  core/xz
+  core/gettext
+  core/gzip
+  core/make
+  core/patch
+  core/texinfo
+  core/util-linux
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
 do_build() {
   ./configure \
-    --prefix=${pkg_prefix} \
+    --prefix="${pkg_prefix}" \
     --enable-static \
     --enable-shared
   make


### PR DESCRIPTION
This adds required metadata to the libgpg-error plan.  It also corrects the license from LGPL to GPL (https://github.com/gpg/libgpg-error/blob/libgpg-error-1.20/COPYING) and updates the string to match SPDX. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>