### PR TITLE
[man-pages] Update plan metadata

### DIFF
--- a/man-pages/plan.sh
+++ b/man-pages/plan.sh
@@ -2,8 +2,10 @@ pkg_name=man-pages
 pkg_origin=core
 pkg_version=4.02
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('gplv2')
-pkg_source=https://www.kernel.org/pub/linux/docs/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
+pkg_license=('GPL-2.0-or-later')
+pkg_source=https://www.kernel.org/pub/linux/docs/"$pkg_name"/"${pkg_name}"-"${pkg_version}".tar.xz
+pkg_upstream_url="https://www.kernel.org/doc/man-pages/"
+pkg_description="The Linux man-pages project documents the Linux kernel and C library interfaces that are employed by user-space programs."
 pkg_shasum=48aacb75d522dd31978682c4fd8bc68e43c9a409bc4c7a126810e7610dff0dd3
 pkg_build_deps=(core/coreutils core/make)
 


### PR DESCRIPTION
This adds required metadata to the man-pages plan. Ref: #1306

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>