### PR TITLE
Update yarn to 1.16.0

### DIFF
--- a/yarn/plan.sh
+++ b/yarn/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=yarn
 pkg_origin=core
-pkg_version=1.12.1
+pkg_version=1.16.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don’t ever have to worry."
 pkg_upstream_url=https://yarnpkg.com/
 pkg_license=('BSD-2-Clause')
 pkg_source="https://yarnpkg.com/downloads/${pkg_version}/yarn-v${pkg_version}.tar.gz"
-pkg_shasum=09bea8f4ec41e9079fa03093d3b2db7ac5c5331852236d63815f8df42b3ba88d
+pkg_shasum=df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029
 pkg_bin_dirs=(bin)
 pkg_build_deps=()
 pkg_deps=(


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md)

### Testing

```
hab studio enter
./yarn/tests/test.sh
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```