### PR TITLE
[memcached] Update memcached to 1.5.14

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.13
+pkg_version=1.5.14
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=61e1a774949735a9eb6e40992bb04083d8427f3d0ce1a52a15c0116db39c4d63
+pkg_shasum=9c5bdf29a780fb6c6f7c9eaaeeda0583efdf663193758c3e316c969a510af2a9
 pkg_deps=(
   core/glibc
   core/cyrus-sasl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/memcached/memcached/wiki/ReleaseNotes1514)

### Testing

```
hab studio enter
./memcached/tests/test.sh
```

### Sample output

```
 ✓ Command is on path
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

6 tests, 0 failures
```