### PR TITLE
[hugo] Update hugo to 0.55.5, implement new testing style

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.55.4"
+pkg_version="0.55.5"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -1,7 +1,6 @@
 source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Version matches" {
-  echo $PATH
   result="$(hab pkg exec "${PKGIDENT}" hugo version | awk '{print $5}')"
   [ "$result" = "v${pkg_version}" ]
 }

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -1,17 +1,18 @@
 source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Version matches" {
-  result="$(hugo version | awk '{print $5}')"
+  echo $PATH
+  result="$(hab pkg exec "${PKGIDENT}" hugo version | awk '{print $5}')"
   [ "$result" = "v${pkg_version}" ]
 }
 
 @test "Help command" {
-  run hugo help
+  run hab pkg exec "${PKGIDENT}" hugo help
   [ "$status" -eq 0 ]
 }
 
 @test "Generate new site" {
-  run hugo new site testsite
+  run hab pkg exec "${PKGIDENT}" hugo new site testsite
   [ "$status" -eq 0 ]
   [ -d testsite ]
   [ -f testsite/config.toml ]

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -14,4 +14,5 @@ fi
 PKGIDENT="${1}"
 export PKGIDENT
 hab pkg install --binlink core/bats
+hab pkg install "${PKG_IDENT}"
 bats "$(dirname "${0}")/test.bats"

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -14,5 +14,5 @@ fi
 PKGIDENT="${1}"
 export PKGIDENT
 hab pkg install --binlink core/bats
-hab pkg install "${PKG_IDENT}"
+hab pkg install "${PKGIDENT}"
 bats "$(dirname "${0}")/test.bats"

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -1,21 +1,17 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+PKGIDENT="${1}"
+export PKGIDENT
+hab pkg install --binlink core/bats
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://gohugo.io/news/0.55.5-relnotes/)

This PR also includes a new approach for testing to match new proposed requirements for testing:

* Build is done separate to test
* Test takes pkg_ident as argument
* Binaries are executed with `hab pkg exec`

### Testing

```
hab studio build hugo
source results/last_build.env
hab studio run "./hugo/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```