### PR TITLE
[haproxy] add ability to pick a user for HAProxy to switch to after startup

### DIFF
--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -9,7 +9,7 @@ defaults
     timeout server 50000ms
 
 frontend http-in
-    bind {{cfg.front-end.listen}}:{{cfg.front-end.port}}
+    bind {{cfg.front-end.listen}}:{{cfg.front-end.port}} {{#if cfg.tls}}ssl crt {{pkg.svc_config_path}}/haproxy.pem{{~/if}}
     default_backend default
 
 backend default

--- a/haproxy/config/haproxy.conf
+++ b/haproxy/config/haproxy.conf
@@ -1,5 +1,6 @@
 global
     maxconn {{cfg.maxconn}}
+    user {{cfg.user}}
 
 defaults
     mode {{cfg.front-end.mode}}

--- a/haproxy/config/haproxy.pem
+++ b/haproxy/config/haproxy.pem
@@ -1,0 +1,2 @@
+{{~#each bind.tls_certificates.members as |member|}}{{#if @first ~}}{{member.cfg.fullchain}}{{/if ~}}{{~/each}}
+{{~#each bind.tls_certificates.members as |member|}}{{#if @first ~}}{{member.cfg.privkey}}{{/if ~}}{{~/each}}

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -1,5 +1,6 @@
-maxconn = 32
 httpchk = "GET /"
+maxconn = 32
+user = "hab"
 
 [front-end]
 listen = "*"

--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -1,5 +1,6 @@
 httpchk = "GET /"
 maxconn = 32
+tls = false  # if set to 'true', ensure you bind to a `tls_certificates` export
 user = "hab"
 
 [front-end]

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -17,6 +17,7 @@ pkg_exports=(
 pkg_exposes=(port status-port)
 pkg_binds_optional=(
   [backend]="port"
+  [tls_certificates]="domain fullchain privkey"
 )
 pkg_deps=(core/zlib core/pcre core/openssl)
 pkg_build_deps=(

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=haproxy
-pkg_origin=core
+pkg_origin=smartb
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
 pkg_version=1.9.6
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
@@ -15,7 +15,7 @@ pkg_exports=(
   [status-port]=status.port
 )
 pkg_exposes=(port status-port)
-pkg_binds=(
+pkg_binds_optional=(
   [backend]="port"
 )
 pkg_deps=(core/zlib core/pcre core/openssl)

--- a/haproxy/tests/test.bats
+++ b/haproxy/tests/test.bats
@@ -19,3 +19,8 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   result="$(netstat -peanut | grep haproxy | awk '{print $4}' | awk -F':' '{print $2}')"
   [ "${result}" -eq 80 ]
 }
+
+@test "Process user has successfully switched to 'hab'" {
+  result="$(ps | grep [h]aproxy | awk '{print $2}')"
+  [ "$result" = "hab" ]
+}

--- a/haproxy/tests/test.sh
+++ b/haproxy/tests/test.sh
@@ -5,6 +5,7 @@ SKIPBUILD=${SKIPBUILD:-0}
 
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
 
 hab pkg install --binlink core/bats
 source "${PLANDIR}/plan.sh"


### PR DESCRIPTION
Because `pkg_svc_user` remains `root` we can still bind to ports like 
`80` or `443`.

Signed-off-by: Blake Irvin <blakeirvin@me.com>