### PR TITLE
[grub] Fix failing grub build adding core dependencies

### DIFF
--- a/grub/plan.sh
+++ b/grub/plan.sh
@@ -17,6 +17,8 @@ pkg_build_deps=(
   core/diffutils
   core/dosfstools
   core/flex
+  core/zlib
+  core/libpng
   core/freetype
   core/gcc
   core/gettext
@@ -71,6 +73,10 @@ do_check() {
 
 do_after() {
   if [[ -n "${_GRUB_CLEANUP_BOOT}" ]]; then
+    # Although this looks dangerous, it shouldn't be
+    # because this should only every run in a habitat studio environment and
+    # the /boot directory is both created and destroyed by the plan
+    # shellcheck disable=SC2114
     rm -rf /boot
     info "Cleanup /boot"
   fi

--- a/grub/tests/test.bats
+++ b/grub/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" grub-fstest --version | grep -oP '(?<=grub-fstest \(GRUB\) )([^$]*)')"
+  diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
+}

--- a/grub/tests/test.sh
+++ b/grub/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
## Outstanding Tasks:
- [ ] Waiting on Scott whether he thinks the core/freetype is ok in $pkg_build_deps.
- [ ] Approve and merge

## Context

### Adding core/zlib and core/libpng fixes the grub build

Before updating the $pkg_build_deps, the grub build is unsuccessful with something like:

```bash
...
...
Package zlib was not found in the pkg-config search path.
Perhaps you should add the directory containing `zlib.pc'
to the PKG_CONFIG_PATH environment variable
Package 'zlib', required by 'freetype2', not found
checking ft2build.h usability... no
checking ft2build.h presence... no
checking for ft2build.h... no
configure: error: grub-mkfont was explicitly requested but can't be compiled (need freetype2 headers)
   grub: Build time: 2m53s
   grub: Exiting on error
[3][default:/src/grub:1]#
```

However, the build is successful after

* adding the core/zlib and core/libpng to $pkg_build_deps
* re-running the build succeeds:

```diff
diff --git a/grub/plan.sh b/grub/plan.sh
index 8be2a5ec..f5d25116 100644
--- a/grub/plan.sh
+++ b/grub/plan.sh
@@ -17,6 +17,8 @@ pkg_build_deps=(
core/diffutils
core/dosfstools
core/flex
+  core/zlib
+  core/libpng
core/freetype
core/gcc
core/gettext
```

```bash
...
...
» Signing /hab/cache/artifacts/.bigbird-grub-2.02-20190508101932-x86_64-linux.tar.xz
☛ Signing /hab/cache/artifacts/.bigbird-grub-2.02-20190508101932-x86_64-linux.tar.xz with bigbird-20190502094947 to create /hab/cache/artifacts/bigbird-grub-2.02-20190508101932-x86_64-linux.hart
★ Signed artifact /hab/cache/artifacts/bigbird-grub-2.02-20190508101932-x86_64-linux.hart.
'/hab/cache/artifacts/bigbird-grub-2.02-20190508101932-x86_64-linux.hart' -> '/src/grub/results/bigbird-grub-2.02-20190508101932-x86_64-linux.hart'
grub: hab-plan-build cleanup
grub:
grub: Source Path: /hab/cache/src/grub-2.02
grub: Installed Path: /hab/pkgs/bigbird/grub/2.02/20190508101932
grub: Artifact: /src/grub/results/bigbird-grub-2.02-20190508101932-x86_64-linux.hart
grub: Build Report: /src/grub/results/last_build.env
grub: SHA256 Checksum: 28ff13b6c53d81274ab883482ad50cab21cef5cdd7da8e0f6f3af4dad6c315f0
grub: Blake2b Checksum: 33205ca5abbbf8c072da3419529237e9828477ecdb5429275bbcae710c553598
grub:
grub: I love it when a plan.sh comes together.
grub:
grub: Build time: 5m23s
[4][default:/src/grub:0]#
```

### Testing the freetype

Verifying the core/freetype is a bit tricky since it relies on an environment variable PKG_CONFIG_PATH which is only available during the habitat build phase and not at runtime.  As a result invoking freetype executables directly in the habitat studio will fail.  

For example ``hab pkg exec core/freetype freetype-config --prefix`` in the runtime environment fails

```bash
[10][default:/src/grub:0]# hab pkg exec core/freetype freetype-config --prefix
...
...
Package freetype2 was not found in the pkg-config search path.
Perhaps you should add the directory containing `freetype2.pc'
to the PKG_CONFIG_PATH environment variable
No package 'freetype2' found
sed: -e expression #1, char 0: no previous regular expression
sed: -e expression #1, char 0: no previous regular expression

[11][default:/src/grub:0]#
```

but succeeds in the build-time environment after

* adding a temporary an "attach" to the grub plan
* re-building the plan and wait for the debug session
* re-running ``hab pkg exec core/freetype freetype-config --prefix`` again.  Note that the $PKG_CONFIG_PATH is also populated as expected

```diff
diff --git a/grub/plan.sh b/grub/plan.sh
index 8be2a5ec..f5d25116 100644
--- a/grub/plan.sh
+++ b/grub/plan.sh
@@ -76,4 +76,6 @@ do_after() {
    rm -rf /boot
    info "Cleanup /boot"
fi
+
+  attach
}
```



```bash
### Attaching to debugging session

From: /src/grub/plan.sh @ line 80 :

    70: do_check() {
    71:   make -j "$(nproc)" check
    72: }
    73:
    74: do_after() {
    75:   if [[ -n "${_GRUB_CLEANUP_BOOT}" ]]; then
    76:     rm -rf /boot
    77:     info "Cleanup /boot"
    78:   fi
    79:
=> 80:   attach
    81: }

[1] grub(do_after)>
```

This time it works without issue

```bash
[2] grub(do_after)> echo $PKG_CONFIG_PATH
/hab/pkgs/core/xz/5.2.4/20190115013348/lib/pkgconfig:/hab/pkgs/core/pcre/8.42/20190115012526/lib/pkgconfig:/hab/pkgs/core/elfutils/0.175/20190302013808/lib/pkgconfig:/hab/pkgs/core/libcap/2.25/20190115012150/lib/pkgconfig:/hab/pkgs/core/zlib/1.2.11/20190115003728/lib/pkgconfig:/hab/pkgs/core/libpng/1.6.37/20190416161431/lib/pkgconfig:/hab/pkgs/core/freetype/2.9.1/20190502094019/lib/pkgconfig:/hab/pkgs/core/python/3.7.0/20190305212847/lib/pkgconfig
[3] grub(do_after)>
[4] grub(do_install)> hab pkg exec core/freetype freetype-config --prefix
/hab/pkgs/core/freetype/2.9.1/20190502094019
[5] grub(do_install)> exit
```

## Completed Tasks
- [x] [the duplicate PR](https://github.com/habitat-sh/core-plans/pull/2499) is closed
- [x] Fix the broken buildkite by adding shellcheck disable on SC2771
- [x] Rebuild buildkite because it failed to load properly.
- [x] Added bats tests
- [x] Squashed commits