### PR TITLE
[handlebars-cmd] Update install process

### DIFF
--- a/handlebars-cmd/plan.sh
+++ b/handlebars-cmd/plan.sh
@@ -3,7 +3,6 @@ pkg_origin=core
 pkg_version="0.1.4"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
-pkg_source=nosuchfile.tar.gz
 pkg_deps=(
   core/coreutils
   core/node
@@ -15,29 +14,12 @@ pkg_description="handlebars command-line tool."
 pkg_upstream_url="https://github.com/DavidBabel/handlebars-cmd"
 pkg_bin_dirs=(bin)
 
-do_prepare() {
-  npm config set progress false
-  npm config set prefix "$pkg_prefix"
-}
-
-do_download() {
-  return 0
-}
-
-do_verify() {
-  return 0
-}
-
-do_unpack() {
-  return 0
-}
-
 do_build() {
   return 0
 }
 
 do_install() {
   # Use handlebars-cmd branch with a recent version of handlebars.
-  npm install -g "DavidBabel/$pkg_name#bc510fc"
+  npm install -g "DavidBabel/$pkg_name#bc510fc" --prefix="$pkg_prefix" --progress=false
   fix_interpreter "$pkg_prefix/bin/handlebars" core/coreutils bin/env
 }

--- a/handlebars-cmd/tests/bats/test.bats
+++ b/handlebars-cmd/tests/bats/test.bats
@@ -1,0 +1,5 @@
+@test "Handlebars parses minimal example" {
+  result="$(echo "Hello {{name}}" | /bin/hab pkg exec $pkg_ident handlebars --name "Test")"
+
+  [ "$result" == "Hello Test" ]
+}

--- a/handlebars-cmd/tests/test.sh
+++ b/handlebars-cmd/tests/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+	echo "Usage: handlebars-cmd/tests/test.sh FULLY_QUALIFIED_PACKAGE_IDENTIFIER"
+	exit 1
+fi
+
+pkg_ident="$1"
+
+hab pkg install core/bats
+
+tests_path="$(dirname "$0")"
+
+export pkg_ident
+hab pkg exec core/bats bats "$tests_path"/bats/test.bats


### PR DESCRIPTION
Closes #1566

This updates the install process for handlebars to pass options to `npm install`, rather than use `npm config` which writes configuration to a global location.

It also adds a simple test to validate behavior. 