### PR TITLE
[ant] Update ant to 1.10.6, and update tests

### DIFF
--- a/ant/plan.sh
+++ b/ant/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=ant
-pkg_version=1.10.5
-pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
-pkg_license=('Apache-2.0')
+pkg_version=1.10.6
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
 pkg_description="Ant is a Java based build tool."
-pkg_upstream_url="https://ant.apache.org/"
-pkg_source=https://github.com/apache/ant/archive/rel/$pkg_version.tar.gz
-pkg_shasum=372174125cf845d7ce73606187f7a8d35df8237f75af0fdbe846339853807bda
+pkg_upstream_url=https://ant.apache.org/
+pkg_source="https://github.com/apache/ant/archive/rel/${pkg_version}.tar.gz"
+pkg_shasum=7e5f8386cd41c4c1d7dd9fc5ed001248ee6e8de326155d3bb901a41b2ccf216e
 pkg_build_deps=(
   core/python2
 )
@@ -14,26 +14,25 @@ pkg_deps=(
   core/coreutils
   core/jdk8
   core/sed
-  )
+)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 
 do_prepare() {
-  JAVA_HOME=$(pkg_path_for core/jdk8)
+  JAVA_HOME="$(pkg_path_for core/jdk8)"
   export JAVA_HOME
-  cd "$HAB_CACHE_SRC_PATH/${pkg_name}-rel-${pkg_version}"
+  cd "${HAB_CACHE_SRC_PATH}/${pkg_name}-rel-${pkg_version}"
   sed -i 's|/usr/bin/python|/usr/bin/python2|' src/script/runant.py
 }
 
 do_build() {
-  cd "$HAB_CACHE_SRC_PATH/${pkg_name}-rel-${pkg_version}"
-
+  cd "${HAB_CACHE_SRC_PATH}/${pkg_name}-rel-${pkg_version}"
   ./bootstrap.sh
   bootstrap/bin/ant -Ddest=optional -f fetch.xml
   bootstrap/bin/ant dist
 }
 
 do_install() {
-  mv "$HAB_CACHE_SRC_PATH/${pkg_name}-rel-${pkg_version}/apache-${pkg_name}-${pkg_version}/bin/"* "$pkg_prefix/bin/"
-  mv "$HAB_CACHE_SRC_PATH/${pkg_name}-rel-${pkg_version}/apache-${pkg_name}-${pkg_version}/lib/"* "$pkg_prefix/lib/"
+  mv "${HAB_CACHE_SRC_PATH}/${pkg_name}-rel-${pkg_version}/apache-${pkg_name}-${pkg_version}/bin/"* "${pkg_prefix}/bin/"
+  mv "${HAB_CACHE_SRC_PATH}/${pkg_name}-rel-${pkg_version}/apache-${pkg_name}-${pkg_version}/lib/"* "${pkg_prefix}/lib/"
 }

--- a/ant/tests/test.bats
+++ b/ant/tests/test.bats
@@ -1,6 +1,6 @@
 source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Version matches" {
-  result="$(ant -version | awk '{print $4}')"
+  result="$(hab pkg exec "${PKGIDENT}" ant -version | awk '{print $4}')"
   [ "$result" = "${pkg_version}" ]
 }

--- a/ant/tests/test.bats
+++ b/ant/tests/test.bats
@@ -1,6 +1,5 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
 @test "Version matches" {
+  version="$(echo ${PKGIDENT} | cut -d/ -f3)"
   result="$(hab pkg exec "${PKGIDENT}" ant -version | awk '{print $4}')"
-  [ "$result" = "${pkg_version}" ]
+  [ "$result" = "${version}" ]
 }

--- a/ant/tests/test.sh
+++ b/ant/tests/test.sh
@@ -1,24 +1,19 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-JAVA_HOME="$(hab pkg path core/jdk8)"
-export JAVA_HOME
-
-bats "${TESTDIR}/test.bats"
+PKGIDENT="${1}"
+export PKGIDENT
+hab pkg install --binlink core/bats
+hab pkg install core/jdk8
+hab pkg install "${PKGIDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
* [Changelog](https://archive.apache.org/dist/ant/RELEASE-NOTES-1.10.6.html)

### Testing

```
hab studio build ant
source results/last_build.env
hab studio run "./ant/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```