### PR TITLE
[sqlserver] do not apply firewall dsc in install hook

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1362,6 +1362,10 @@ plan_path = "sqitch"
 plan_path = "sqitch_pg"
 [sqlite]
 plan_path = "sqlite"
+[sqlserver]
+plan_path = "sqlserver"
+[sqlserver-ha-ag]
+plan_path = "sqlserver-ha-ag"
 [sshpass]
 plan_path = "sshpass"
 [storm]

--- a/sqlserver/hooks/install
+++ b/sqlserver/hooks/install
@@ -40,7 +40,4 @@ if($(Get-Service 'MpsSvc').Status -eq "Running") {
             Install-Module xNetworking -Force | Out-Null
         }
     }
-
-    Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
-    Start-DscCore (Join-Path {{pkg.svc_config_install_path}} firewall.ps1) NewFirewallRule
 }


### PR DESCRIPTION
It's redundant to run this in the install when it also needs to be run in `init`.

Signed-off-by: mwrock <matt@mattwrock.com>