### PR TITLE
[dotnet-471-dev-pack] VERSION 2: Add Pester tests to habitat installation of dotnet-471-dev-pack

### DIFF
--- a/dotnet-471-dev-pack/README.md
+++ b/dotnet-471-dev-pack/README.md
@@ -1,0 +1,81 @@
+# Habitat package: dotnet471
+
+## Description
+
+This package is for the .NET 4.7.1 framework developer pack from microsoft. It provides 4.7.1 reference assemblies as well as the SDK needed to support building .NET 4.7.1 applications
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+Binary
+
+## Usage
+
+Add core/dotnet471 to pkg_build_deps then leverage nuget and msbuild to build and deploy your application. For an example see mwrock's asp full framework MVC blog post: https://www.habitat.sh/blog/2017/08/Habitat-plans-for-net-full-iis-apps/
+
+# Testing dotnet-471-dev-pack on Windows
+
+**Note**: before proceeding, [Pester](https://github.com/pester/Pester/wiki/Installation-and-Update) must be installed on the testing system
+
+## Build and Install the dotnet-471-dev-pack core plan
+
+### Build and Install
+
+Open a powershell terminal at the root directory of the core-plans repo, build and install the package:
+
+```powershell
+hab studio run -D "hab pkg build dotnet-471-dev-pack"
+. .\results\last_build.ps1
+hab studio run -D "hab pkg install results/$pkg_artifact"
+```
+
+### Test
+
+In a different terminal, test the package:
+
+```powershell
+. .\results\last_build.ps1
+hab studio run -D "& dotnet-471-dev-pack/tests/test.ps1 $pkg_ident"
+```
+
+Sample output:
+
+```powershell
+PS C:\Users\azureuser\Documents\habitat\core-plans> hab studio run -D "& dotnet-471-dev-pack/tests/test.ps1 $pkg_ident"
+   hab-studio: Creating Studio at C:\
+» Importing origin key from standard input
+★ Imported public origin key core-20190508125251.
+» Importing origin key from standard input
+★ Imported secret origin key core-20190508125251.
+   hab-studio: Running '& dotnet-471-dev-pack/tests/test.ps1 core/dotnet-471-dev-pack/4.7.1/20190508130615' in Studio at
+ C:\
+» Installing core/pester
+☁ Determining latest version of core/pester in the 'stable' channel
+☛ Verifying core/pester/4.8.1/20190517153523
+✓ Installed core/pester/4.8.1/20190517153523
+★ Install of core/pester/4.8.1/20190517153523 complete with 1 new packages installed.
+» Installing core/dotnet-471-dev-pack/4.7.1/20190508130615
+☛ Verifying core/dotnet-471-dev-pack/4.7.1/20190508130615
+✓ Installed core/dotnet-471-dev-pack/4.7.1/20190508130615
+★ Install of core/dotnet-471-dev-pack/4.7.1/20190508130615 complete with 1 new packages installed.
+Executing all tests in 'C:\src\dotnet-471-dev-pack\tests/test.pester.ps1'
+
+Executing script C:\src\dotnet-471-dev-pack\tests/test.pester.ps1
+
+  Describing The NETFXSDK installation of pkg_ident [core/dotnet-471-dev-pack/4.7.1/20190508130615] when
+
+    Context is the SDK version 4.7
+      [+] has the 'Program Files/Windows Kits/NETFXSDK/4.7/Include/um' directory 65ms
+      [+] has the 'Program Files/Windows Kits/NETFXSDK/4.7/Lib/um/x64' directory 4ms
+      [+] has the 'Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.7 Tools/x64' directory 37ms
+
+    Context is the SDK version 4.7.1
+      [+] has the 'Program Files/Windows Kits/NETFXSDK/4.7.1/Include/um' directory 3ms
+      [+] has the 'Program Files/Windows Kits/NETFXSDK/4.7.1/Lib/um/x64' directory 3ms
+      [+] has the 'Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.7.1 Tools/x64' directory 3ms
+Tests completed in 803ms
+Tests Passed: 6, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
+```

--- a/dotnet-471-dev-pack/tests/test.pester.ps1
+++ b/dotnet-471-dev-pack/tests/test.pester.ps1
@@ -1,0 +1,33 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "The NETFXSDK installation of pkg_ident [$PackageIdentifier] when" {
+    Context "is the SDK version 4.7" {
+        $sdk_version="4.7"
+        It "has the 'Program Files/Windows Kits/NETFXSDK/$sdk_version/Include/um' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Windows Kits/NETFXSDK/$sdk_version/Include/um" | Should -Exist
+        }
+        It "has the 'Program Files/Windows Kits/NETFXSDK/$sdk_version/Lib/um/x64' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Windows Kits/NETFXSDK/$sdk_version/Lib/um/x64" | Should -Exist
+        }
+        It "has the 'Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX $sdk_version Tools/x64' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX $sdk_version Tools/x64" | Should -Exist
+        }
+    }
+
+    $sdk_version=Split-Path (Split-Path $PackageIdentifier -Parent) -Leaf
+    Context "is the SDK version $sdk_version" {
+
+        It "has the 'Program Files/Windows Kits/NETFXSDK/$sdk_version/Include/um' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Windows Kits/NETFXSDK/$sdk_version/Include/um" | Should -Exist
+        }
+        It "has the 'Program Files/Windows Kits/NETFXSDK/$sdk_version/Lib/um/x64' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Windows Kits/NETFXSDK/$sdk_version/Lib/um/x64" | Should -Exist
+        }
+        It "has the 'Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX $sdk_version Tools/x64' directory" {
+            "c:/hab/pkgs/$PackageIdentifier/Program Files/Microsoft SDKs/Windows/v10.0A/bin/NETFX $sdk_version Tools/x64" | Should -Exist
+        }
+    }
+}

--- a/dotnet-471-dev-pack/tests/test.ps1
+++ b/dotnet-471-dev-pack/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount


### PR DESCRIPTION
## Outstanding Tasks
- [x] Confirm that this is meeting windows standard according to [stocksy's comment](https://github.com/habitat-sh/core-plans/pull/2556#issuecomment-499834855)
- [x] Merge as approval's have already been applied

## Context
**NOTE:** Opening this PR to replace [this one](https://github.com/habitat-sh/core-plans/pull/2443) so that the PR branch is up-to-date with all master commits before merging into the main core-plans.


Note that this PR:
* adds Pester tests that verify the presence of both the 4.7 and also the 4.7.1 NETFX lib, bin and include directories in a local build of the dotnet-471-dev-pack.  Since [pester](https://github.com/Pester/Pester/wiki) tests can be run from within an isolated windows habitat studio environment and [inspec](https://www.inspec.io) tests cannot, pester was chosen for testing this windows plan.
* adds a README to meet [core-plan requirements](https://github.com/habitat-sh/core-plans/blob/master/CONTRIBUTING.md)

## Completed Tasks
- [x] Extract dotnet version from $PackageIdentifier in Pester test SO THAT same test can be dropped into other dotnet versions.  See [Stocksy's comment](https://github.com/habitat-sh/core-plans/pull/2443#discussion_r280341601)
- [x] Ruled out rebasing existing PR branch with latest master commits.  This only confused the PR with masses of changed files.
- [x] Merged ['old' PR](https://github.com/habitat-sh/core-plans/pull/2443) changes into a this one so that latest master changes are also included
- [x] Fix "test" directory to be "tests" to comply with [Stocksy's design document](https://github.com/habitat-sh/core-plans/pull/2539)
- [x] Install the same [pre-commit](https://pre-commit.com) hook utility on my local core-plans repo to replicate the Travis CI environment, which is failing.
- [x] Fix Travis CI build failure by correcting all the whitespace and newline errors in the dotnet-471 code.
- [x] Update the pester tests to use the core/pester module.