### PR TITLE
[scaffolding-chef] automatically accept license for chef15

### DIFF
--- a/scaffolding-chef/lib/scaffolding.sh
+++ b/scaffolding-chef/lib/scaffolding.sh
@@ -57,7 +57,7 @@ do_default_build_service() {
 
 chef_client_cmd()
 {
-  chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb -j $pkg_svc_config_path/attributes.json --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}}
+  chef-client -z -l {{cfg.log_level}} -c $pkg_svc_config_path/client-config.rb -j $pkg_svc_config_path/attributes.json --once --no-fork --run-lock-timeout {{cfg.run_lock_timeout}} --chef-license "{{cfg.chef_license.acceptance}}"
 }
 
 SPLAY_DURATION=\$({{pkgPathFor "core/coreutils"}}/bin/shuf -i 0-{{cfg.splay}} -n 1)
@@ -155,6 +155,10 @@ EOF
 
   build_line "Generating Chef Habitat configuration, default.toml"
   cat << EOF >> "${pkg_prefix}/default.toml"
+
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
 interval = 1800
 splay = 1800
 splay_first_run = 0
@@ -163,6 +167,9 @@ log_level = "warn"
 chef_client_ident = "" # this is blank by default so it can be populated from the bind
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 ssl_verify_mode = ":verify_peer"
+
+[chef_license]
+acceptance = "undefined"
 
 [data_collector]
 enable = false

--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.5.0"
+pkg_version="0.6.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This is a pretty small change to keep us working on Chef 15. Also releases a new version of the scaffolding so folks who want to pin to 14 forever can use the 0.5.0 scaffolding forever.

Resolves #2563