### PR TITLE
[CI] Change verify builds to "soft_fail" 

### DIFF
--- a/.expeditor/templates/verify_linux_pipeline.yml
+++ b/.expeditor/templates/verify_linux_pipeline.yml
@@ -19,4 +19,8 @@
       executor:
         docker:
           privileged: true
+    soft_fail:
+      - exit_status: "*"
+    retry:
+      manual:
     timeout_in_minutes: 60

--- a/bin/ci/verify-pr-build.sh
+++ b/bin/ci/verify-pr-build.sh
@@ -32,7 +32,7 @@ for bl in "${PLAN_BLACKLIST[@]}"; do
     if [[ "${CI:-}" == "true" ]]; then
       buildkite-agent annotate --style 'warning' ":bangbang: ${plan} found in build blacklist. Skipping build. "
     fi
-    exit 0;
+    exit 52;
   fi
 done
 
@@ -64,6 +64,5 @@ status=$?
 
 if [[ $status -ne 0 ]]; then
   echo "--- :rotating_light: :rotating_light: :rotating_light: BUILD FAILED :rotating_light: :rotating_light: :rotating_light:"
+  exit 52
 fi
-
-exit 0


### PR DESCRIPTION
This updates the CI pipeline to soft fail verify builds.  This will give us a better indicator that there may be something to investigate, while not hard-blocking merges because of unresolvable issues with a particular piece of software's test suite.