### PR TITLE
[hugo] Update hugo to 0.55.6

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version="0.55.5"
+pkg_version=0.55.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -13,6 +13,6 @@ fi
 
 PKGIDENT="${1}"
 export PKGIDENT
-hab pkg install --binlink core/bats
+hab pkg install core/bats --binlink
 hab pkg install "${PKGIDENT}"
 bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://gohugo.io/news/0.55.6-relnotes/)

### Testing

```
hab studio build hugo
source results/last_build.env
hab studio run "./hugo/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```