### PR TITLE
[clingo] Fix runtime core/clingo so that gringo works properly

### DIFF
--- a/clingo/README.md
+++ b/clingo/README.md
@@ -12,4 +12,7 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/clingo)

--- a/clingo/plan.sh
+++ b/clingo/plan.sh
@@ -16,6 +16,8 @@ pkg_build_deps=(
 pkg_deps=(
   core/gcc-libs
   core/glibc
+  core/python
+  core/lua
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
@@ -28,7 +30,9 @@ do_build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCLINGO_MANAGE_RPATH=YES \
-    -DCLINGO_BUILD_APPS=YES
+    -DCLINGO_BUILD_APPS=YES \
+    -DLUA_LIBRARIES="$(pkg_path_for core/lua)/lib/liblua.a" \
+    -DLUA_INCLUDE_DIR="$(pkg_path_for core/lua)/include"
   make -C build
 }
 

--- a/clingo/tests/fixtures/examples/gringo/sort/RESULT_FOR_LUA.txt
+++ b/clingo/tests/fixtures/examples/gringo/sort/RESULT_FOR_LUA.txt
@@ -1,0 +1,9 @@
+p(1).
+p(a).
+p(b).
+p(s(f)).
+gather(1).
+enumerate(1,1).
+enumerate(2,a).
+enumerate(3,b).
+enumerate(4,s(f)).

--- a/clingo/tests/fixtures/examples/gringo/sort/RESULT_FOR_PYTHON.txt
+++ b/clingo/tests/fixtures/examples/gringo/sort/RESULT_FOR_PYTHON.txt
@@ -1,0 +1,9 @@
+p(1).
+p(a).
+p(b).
+p(s(f)).
+gather(1).
+enumerate(0,1).
+enumerate(1,a).
+enumerate(2,b).
+enumerate(3,s(f)).

--- a/clingo/tests/fixtures/examples/gringo/sort/encoding.lp
+++ b/clingo/tests/fixtures/examples/gringo/sort/encoding.lp
@@ -1,0 +1,9 @@
+p(1).
+p(a).
+p(b).
+p(s(f)).
+
+gather(1).
+gather(@gather(X)) :- p(X).
+
+enumerate(X,N) :- gather(1), (X,N) = @sort().

--- a/clingo/tests/fixtures/examples/gringo/sort/sort-lua.lp
+++ b/clingo/tests/fixtures/examples/gringo/sort/sort-lua.lp
@@ -1,0 +1,21 @@
+#script (lua)
+
+clingo = require("clingo")
+
+values = {}
+
+function gather(a)
+    values[#values+1] = a
+    return 1
+end
+
+function sort()
+    table.sort(values)
+    ret = {}
+    for k, v in ipairs(values) do
+        ret[#ret+1] = clingo.Tuple({k, v})
+    end
+    return ret
+end
+
+#end.

--- a/clingo/tests/fixtures/examples/gringo/sort/sort-py.lp
+++ b/clingo/tests/fixtures/examples/gringo/sort/sort-py.lp
@@ -1,0 +1,14 @@
+#script (python)
+
+import clingo
+
+values = []
+
+def gather(a):
+    values.append(a)
+    return 1
+
+def sort():
+    return list(enumerate(sorted(values)))
+
+#end.

--- a/clingo/tests/test.bats
+++ b/clingo/tests/test.bats
@@ -1,0 +1,19 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" gringo --version | grep -E "^gringo version")"
+  diff <(echo "$actual_version") <( echo "gringo version ${TEST_PKG_VERSION}")
+}
+
+# Refer to https://github.com/potassco/clingo/tree/master/examples/gringo/sort
+@test "gringo should work as expected for python" {
+  actual=$( hab pkg exec "${TEST_PKG_IDENT}" gringo --text ${TESTDIR}/fixtures/examples/gringo/sort/sort-py.lp ${TESTDIR}/fixtures/examples/gringo/sort/encoding.lp )
+  expected=$( cat ${TESTDIR}/fixtures/examples/gringo/sort/RESULT_FOR_PYTHON.txt )
+  diff <( echo "${actual}" ) <( echo "${expected}" )
+}
+
+# Refer to https://github.com/potassco/clingo/tree/master/examples/gringo/sort
+@test "gringo should work as expected for lua" {
+  actual=$( hab pkg exec "${TEST_PKG_IDENT}" gringo --text ${TESTDIR}/fixtures/examples/gringo/sort/sort-lua.lp ${TESTDIR}/fixtures/examples/gringo/sort/encoding.lp )
+  expected=$( cat ${TESTDIR}/fixtures/examples/gringo/sort/RESULT_FOR_LUA.txt )
+  diff <( echo "${actual}" ) <( echo "${expected}" )
+}

--- a/clingo/tests/test.sh
+++ b/clingo/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+export TESTDIR
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting on approval.


### Context
This PR created to fix https://github.com/habitat-sh/core-plans/issues/2210.  Issue fixed by adding core/python and core/lua to $pkg_deps and verifying the runtime environment with bats tests

### Completed Tasks
- [x] Fixed comments
- [x] Fixed the failing buildkite tests: Replace the hardcoded 'core/clingo' with the $pkg_ident
- [x] Squash commits
- [x] Revert testing section from README
- [x] Squash commits; alert Scott