### PR TITLE
[test document] Update the order of --binlink according to new habitat format

### DIFF
--- a/docs/dev/policy_documents/standards-for-tests.md
+++ b/docs/dev/policy_documents/standards-for-tests.md
@@ -174,7 +174,7 @@ fi
 
 TEST_PKG_IDENT="$1"
 
-hab pkg install --binlink core/bats
+hab pkg install core/bats --binlink
 hab pkg install "$TEST_PKG_IDENT"
 
 export TEST_PKG_IDENT


### PR DESCRIPTION
Changing the order of the --binlink example in the document to satisfy new requirements in habitat.  See comment from @predominant [here](https://github.com/habitat-sh/core-plans/pull/2584#discussion_r285796038) and [clingo issue](https://github.com/habitat-sh/core-plans/issues/2210)