### PR TITLE
[sassc] Fix version info in build, add tests

### DIFF
--- a/sassc/plan.sh
+++ b/sassc/plan.sh
@@ -4,6 +4,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_version=3.6.0
 pkg_source="https://github.com/sass/${pkg_name}/archive/${pkg_version}.tar.gz"
 pkg_shasum=dac8d83339c3c8fc6b9599e2ff1e0a0ae833ab0e65d4370b9c69bde18f8ec676
+libsass_shasum=b4b962a30bcd99adf0162a8eac7e1be94612b1c19912237f53d9a2c11d375169
 pkg_license=('MIT')
 pkg_description='libsass command line driver'
 pkg_upstream_url=https://github.com/sass/sassc
@@ -24,10 +25,10 @@ do_download() {
   download_file \
     "https://github.com/sass/libsass/archive/${pkg_version}.tar.gz" \
     "libsass.tar.gz" \
-    "b4b962a30bcd99adf0162a8eac7e1be94612b1c19912237f53d9a2c11d375169"
+    "${libsass_shasum}"
   verify_file \
     "libsass.tar.gz" \
-    "b4b962a30bcd99adf0162a8eac7e1be94612b1c19912237f53d9a2c11d375169"
+    "${libsass_shasum}"
 }
 
 do_unpack() {
@@ -37,6 +38,8 @@ do_unpack() {
 
 do_build() {
   export SASS_LIBSASS_PATH="${HAB_CACHE_SRC_PATH}/libsass-${pkg_version}"
+  echo "${pkg_version}" > "${HAB_CACHE_SRC_PATH}/sassc-${pkg_version}/VERSION"
+  echo "${pkg_version}" > "${HAB_CACHE_SRC_PATH}/libsass-${pkg_version}/VERSION"
   make
 }
 

--- a/sassc/tests/test.bats
+++ b/sassc/tests/test.bats
@@ -1,0 +1,14 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Package and library Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" sassc --version | grep 'sassc:' | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" sassc --version | grep 'libsass:' | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec "${TEST_PKG_IDENT}" sassc --help
+  [ "$status" -eq 0 ]
+}

--- a/sassc/tests/test.sh
+++ b/sassc/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Adds version information to the build, and tests.

Fixes #2589 

### Testing

```
hab studio build sassc
source results/last_build.env
hab studio run "sassc/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Package and library Version matches
 ✓ Help command

2 tests, 0 failures
```