### PR TITLE
[strace] Update to 5.1, update tests

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,23 +1,23 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=5.0
+pkg_version=5.1
 pkg_license=("LGPL-2.1-or-later")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=3b7ad77eb2b81dc6078046a9cc56eed5242b67b63748e7fc28f7c2daf4e647da
+pkg_shasum=f5a341b97d7da88ee3760626872a4899bf23cf8dee56901f114be5b1837a9a8b
 pkg_deps=(
   core/glibc
   core/libunwind
 )
-pkg_bin_dirs=(bin)
 pkg_build_deps=(
   core/coreutils
   core/make
   core/gcc
   core/diffutils
 )
+pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 

--- a/strace/tests/test.bats
+++ b/strace/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(strace -V | head -1 | awk '{print $4}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" strace -V | head -1 | awk '{print $4}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Can strace" {
-  run strace strace -h
+  run hab pkg exec "${TEST_PKG_IDENT}" strace strace -h
   [ $status -eq 0 ]
 }

--- a/strace/tests/test.sh
+++ b/strace/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/strace/strace/releases/tag/v5.1)

### Testing

```
hab studio build strace
source results/last_build.env
hab studio run "./strace/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```