### PR TITLE
[filebeat] Update to 7.1.1 + testing + cleanup

### DIFF
--- a/filebeat/config/filebeat.yml
+++ b/filebeat/config/filebeat.yml
@@ -1,195 +1,32 @@
-###################### Filebeat Configuration Example #########################
-
 # This file is an example configuration file highlighting only the most common
 # options. You can find the full configuration reference here:
 # https://www.elastic.co/guide/en/beats/filebeat/index.html
 
-#=========================== Filebeat prospectors =============================
-
-filebeat.prospectors:
-
-# Each - is a prospector. Most options can be set at the prospector level, so
-# you can use different prospectors for various configurations.
-# Below are the prospector specific configurations.
-
+filebeat.inputs:
 - type: log
-
-  # Change to true to enable this prospector configuration.
-  enabled: false
-
-  # Paths that should be crawled and fetched. Glob based paths.
   paths:
     - /var/log/*.log
-    #- c:\programdata\elasticsearch\logs\*
-
-  # Exclude lines. A list of regular expressions to match. It drops the lines that are
-  # matching any regular expression from the list.
-  #exclude_lines: ['^DBG']
-
-  # Include lines. A list of regular expressions to match. It exports the lines that are
-  # matching any regular expression from the list.
-  #include_lines: ['^ERR', '^WARN']
-
-  # Exclude files. A list of regular expressions to match. Filebeat drops the files that
-  # are matching any regular expression from the list. By default, no files are dropped.
-  #exclude_files: ['.gz$']
-
-  # Optional additional fields. These fields can be freely picked
-  # to add additional information to the crawled log files for filtering
-  #fields:
-  #  level: debug
-  #  review: 1
-
-  ### Multiline options
-
-  # Mutiline can be used for log messages spanning multiple lines. This is common
-  # for Java Stack Traces or C-Line Continuation
-
-  # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
-  #multiline.pattern: ^\[
-
-  # Defines if the pattern set under pattern should be negated or not. Default is false.
-  #multiline.negate: false
-
-  # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
-  # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-  # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
-  #multiline.match: after
-
-
-#============================= Filebeat modules ===============================
+  enabled: false
 
 filebeat.config.modules:
-  # Glob pattern for configuration loading
   path: ${path.config}/modules.d/*.yml
-
-  # Set to true to enable config reloading
   reload.enabled: false
-
-  # Period on which files under path should be checked for changes
-  #reload.period: 10s
-
-#==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
   index.number_of_shards: 3
-  #index.codec: best_compression
-  #_source.enabled: false
 
-#================================ General =====================================
-
-# The name of the shipper that publishes the network data. It can be used to group
-# all the transactions sent by a single shipper in the web interface.
-#name:
-
-# The tags of the shipper are included in their own field with each
-# transaction published.
-#tags: ["service-X", "web-tier"]
-
-# Optional fields that you can specify to add additional information to the
-# output.
-#fields:
-#  env: staging
-
-
-#============================== Dashboards =====================================
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards is disabled by default and can be enabled either by setting the
-# options here, or by using the `-setup` CLI flag or the `setup` command.
-#setup.dashboards.enabled: false
-
-# The URL from where to download the dashboards archive. By default this URL
-# has a value which is computed based on the Beat name and version. For released
-# versions, this URL points to the dashboard archive on the artifacts.elastic.co
-# website.
-#setup.dashboards.url:
-
-#============================== Kibana =====================================
-
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
-# This requires a Kibana endpoint configuration.
+{{#if cfg.kibana.enabled ~}}
 setup.kibana:
-
-  # Kibana Host
-  # Scheme and port can be left out and will be set to the default (http and 5601)
-  # In case you specify and additional path, the scheme is required: http://localhost:5601/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
   {{#if bind.kibana ~}}
   host: "{{bind.kibana.first.sys.ip}}:{{bind.kibana.first.cfg.port}}"
   {{else ~}}
-  {{#if cfg.kibana.enabled ~}}
   host: "{{cfg.kibana.host}}"
   {{/if ~}}
-  {{/if ~}}
+{{/if ~}}
 
-#============================= Elastic Cloud ==================================
-
-# These settings simplify using filebeat with the Elastic Cloud (https://cloud.elastic.co/).
-
-# The cloud.id setting overwrites the `output.elasticsearch.hosts` and
-# `setup.kibana.host` options.
-# You can find the `cloud.id` in the Elastic Cloud web UI.
-#cloud.id:
-
-# The cloud.auth setting overwrites the `output.elasticsearch.username` and
-# `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
-#cloud.auth:
-
-#================================ Outputs =====================================
-
-# Configure what output to use when sending the data collected by the beat.
-
-#-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:
-  # Array of hosts to connect to.
   {{#if bind.elasticsearch ~}}
   hosts: [{{#each bind.elasticsearch.members ~}} "{{sys.ip}}"{{~#unless @last}},{{/unless}} {{/each ~}}]
   {{else}}
   hosts: [{{#each cfg.elasticsearch.members as |member| ~}} "{{member.host}}:{{member.port}}"{{~#unless @last}},{{/unless}} {{/each ~}}]
   {{/if}}
-
-  # Optional protocol and basic auth credentials.
-  #protocol: "https"
-  #username: "elastic"
-  #password: "changeme"
-
-#----------------------------- Logstash output --------------------------------
-#output.logstash:
-  # The Logstash hosts
-  #hosts: ["localhost:5044"]
-
-  # Optional SSL. By default is off.
-  # List of root certificates for HTTPS server verifications
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
-
-  # Certificate for SSL client authentication
-  #ssl.certificate: "/etc/pki/client/cert.pem"
-
-  # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
-
-#================================ Logging =====================================
-
-# Sets log level. The default log level is info.
-# Available log levels are: error, warning, info, debug
-#logging.level: debug
-
-# At debug level, you can selectively enable logging only for some components.
-# To enable all selectors use ["*"]. Examples of other selectors are "beat",
-# "publish", "service".
-#logging.selectors: ["*"]
-
-#============================== Xpack Monitoring ===============================
-# filebeat can export internal metrics to a central Elasticsearch monitoring
-# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
-# reporting is disabled by default.
-
-# Set to true to enable the monitoring reporter.
-#xpack.monitoring.enabled: false
-
-# Uncomment to send the metrics to Elasticsearch. Most settings from the
-# Elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the Elasticsearch output configuration, so if you
-# have the Elasticsearch output configured, you can simply uncomment the
-# following line.
-#xpack.monitoring.elasticsearch:

--- a/filebeat/plan.sh
+++ b/filebeat/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=filebeat
 pkg_origin=core
-pkg_version=6.7.1
+pkg_version=7.1.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/go
   core/git
-  core/make
+  core/mage
   core/gcc
 )
 pkg_bin_dirs=(bin)
@@ -34,7 +34,7 @@ do_unpack() {
 
 do_build() {
   pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/filebeat" > /dev/null
-  make
+  mage build
   popd > /dev/null
 }
 

--- a/filebeat/tests/test.bats
+++ b/filebeat/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v filebeat)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(filebeat version | awk '{print $3}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" filebeat version | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run filebeat --help
+  run hab pkg exec "${TEST_PKG_IDENT}" filebeat --help
   [ $status -eq 0 ]
 }
 

--- a/filebeat/tests/test.sh
+++ b/filebeat/tests/test.sh
@@ -1,32 +1,34 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
 
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static wc
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
+hab sup term
+hab sup run &
+sleep 5
+hab svc load "${TEST_PKG_IDENT}"
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
+bats "$(dirname "${0}")/test.bats"
 
-  # Give some time for the service to start up
-  sleep 5
-fi
-
-bats "${TESTDIR}/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Changelogs are various. Major ones are posted on the [7.0 release notes](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-7.0.0.html). All are listed [here](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes.html).

### Testing

```
hab studio build filebeat
source results/last_build.env
hab studio run "./filebeat/tests/test.sh ${pkg_ident}"
```

### Sample output

```
The rakops/filebeat/7.1.1/20190529044102 service was successfully loaded
Waiting 10 seconds for service to start...
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

4 tests, 0 failures
Unloading rakops/filebeat/7.1.1/20190529044102
```

### Notes

This now does the following:

* Build and test in separate studios
* Test loads the service and waits 10 seconds
* On successful testing, the service is unloaded

In a situation where tests are failing, we can run the tests in an interactive studio, and be left with the service running for closer inspection.