### PR TITLE
[metricbeat] Update to 7.1.1, update testing

### DIFF
--- a/metricbeat/default.toml
+++ b/metricbeat/default.toml
@@ -48,7 +48,6 @@ metricsets = ["uptime"]
 hosts = ["localhost:9200"]
 
 #================================ Logging ======================================
-
 [logging]
 to_files = true
 [logging.files]

--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=metricbeat
 pkg_origin=core
-pkg_version=6.7.1
+pkg_version=7.1.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/go
   core/git
-  core/make
+  core/mage
   core/gcc
 )
 pkg_bin_dirs=(bin)
@@ -25,13 +25,9 @@ do_download() {
   popd > /dev/null || exit 1
 }
 
-do_unpack() {
-  return 0
-}
-
 do_build() {
   pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat" > /dev/null || exit 1
-  make
+  mage build
   popd > /dev/null || exit 1
 }
 

--- a/metricbeat/tests/test.bats
+++ b/metricbeat/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v metricbeat)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(metricbeat version | awk '{print $3}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} metricbeat version | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run metricbeat --help
+  run hab pkg exec ${TEST_PKG_IDENT} metricbeat --help
   [ $status -eq 0 ]
 }
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio build metricbeat
source results/last_build.env
hab studio run "./metricbeat/tests/test.sh ${pkg_ident}"
```

### Sample output

```
The rakops/metricbeat/7.1.1/20190529054138 service was successfully loaded
Waiting 10 seconds for service to start...
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

4 tests, 0 failures
Unloading rakops/metricbeat/7.1.1/20190529054138
```