### PR TITLE
[go] Update golang to 1.12.5, add trivial test

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,16 +1,28 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.12
+pkg_version=1.12.5
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz
-pkg_shasum=09c43d3336743866f2985f566db0520b36f4992aea2b4b2fd9f52f17049e88f2
+pkg_source="https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz"
+pkg_shasum=2aa5f088cbb332e73fc3def546800616b38d3bfe6b8713b8a6404060f22503e8
 pkg_dirname=go
-pkg_deps=(core/glibc core/iana-etc core/cacerts)
-pkg_build_deps=(core/coreutils core/inetutils core/bash core/patch core/gcc core/go17 core/perl)
+pkg_deps=(
+  core/glibc
+  core/iana-etc
+  core/cacerts
+)
+pkg_build_deps=(
+  core/coreutils
+  core/inetutils
+  core/bash
+  core/patch
+  core/gcc
+  core/go17
+  core/perl
+)
 pkg_bin_dirs=(bin)
 
 do_prepare() {

--- a/go/plan.sh
+++ b/go/plan.sh
@@ -53,13 +53,13 @@ do_prepare() {
 
   # Add `cacerts` to the SSL certificate lookup chain
   # shellcheck disable=SC2002
-  cat "$PLAN_CONTEXT/cacerts.patch" \
+  cat "${PLAN_CONTEXT}/cacerts.patch" \
     | sed -e "s,@cacerts@,$(pkg_path_for cacerts)/ssl/cert.pem,g" \
     | patch -p1
 
   # Set the dynamic linker from `glibc`
   dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
-  sed -e "s,/lib64/ld-linux-x86-64.so.2,$dynamic_linker," \
+  sed -e "s,/lib64/ld-linux-x86-64.so.2,${dynamic_linker}," \
     -i src/cmd/link/internal/amd64/obj.go
 
   # Use the services database from `iana-etc`
@@ -97,35 +97,35 @@ do_check() {
 
   # Clean up any symlinks that were added to support the build's test suite.
   for cmd in "${_clean_cmds[@]}"; do
-    rm -fv "$cmd"
+    rm -fv "${cmd}"
   done
 }
 
 do_install() {
-  cp -av bin src lib doc misc "$pkg_prefix/"
+  cp -av bin src lib doc misc "${pkg_prefix}/"
 
-  mkdir -pv "$pkg_prefix/bin" "$pkg_prefix/pkg"
-  cp -av pkg/{linux_$GOARCH,tool} "$pkg_prefix/pkg/"
+  mkdir -pv "${pkg_prefix}/bin" "${pkg_prefix}/pkg"
+  cp -av pkg/{linux_${GOARCH},tool} "${pkg_prefix}/pkg/"
   if [[ -d "pkg/linux_${GOARCH}_race" ]]; then
-    cp -av pkg/linux_${GOARCH}_race "$pkg_prefix/pkg/"
+    cp -av pkg/linux_${GOARCH}_race "${pkg_prefix}/pkg/"
   fi
 
   # For godoc
-  install -v -Dm644 favicon.ico "$pkg_prefix/favicon.ico"
+  install -v -Dm644 favicon.ico "${pkg_prefix}/favicon.ico"
 
   # Install the license
-  install -v -Dm644 LICENSE "$pkg_prefix/share/licenses/LICENSE"
+  install -v -Dm644 LICENSE "${pkg_prefix}/share/licenses/LICENSE"
 
   # Remove unneeded Windows files
-  rm -fv "$pkg_prefix/src/*.bat"
+  rm -fv "${pkg_prefix}/src/*.bat"
 
   # Move header files to the correct place
-  cp -arv "$pkg_prefix/src/runtime" "$pkg_prefix/pkg/include"
+  cp -arv "${pkg_prefix}/src/runtime" "${pkg_prefix}/pkg/include"
 }
 
 do_strip() {
   # Strip manually since `strip` will not process Go's static libraries.
-  for f in $pkg_prefix/bin/* $pkg_prefix/pkg/tool/linux_$GOARCH/*; do
-    strip -s "$f"
+  for f in "${pkg_prefix}/bin/"* "${pkg_prefix}/pkg/tool/linux_${GOARCH}/"*; do
+    strip -s "${f}"
   done
 }

--- a/go/tests/hello.go
+++ b/go/tests/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}

--- a/go/tests/test.bats
+++ b/go/tests/test.bats
@@ -1,11 +1,18 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(go version | awk '{print $3}')"
-  [ "$result" = "go${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} go version | awk '{print $3}')"
+  [ "$result" = "go${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run go help
+  run hab pkg exec ${TEST_PKG_IDENT} go help
   [ $status -eq 0 ]
+}
+
+@test "Simple compile" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} go run ${BATS_TEST_DIRNAME}/hello.go)"
+  status=$?
+  [ $status -eq 0 ]
+  [ "$result" = "Hello, 世界" ]
 }

--- a/go/tests/test.sh
+++ b/go/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Adds a simple hello world test to ensure go can run go things :)

### Testing

```
hab studio build go
source results/last_build.env
hab studio run ./go/tests/test.sh ${pkg_ident}
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Simple compile

3 tests, 0 failures
```

![tenor-19713607](https://user-images.githubusercontent.com/24568/58534714-f3133080-8226-11e9-8e1e-61b3b6d9d46c.gif)
