### PR TITLE
[apr] Addition of tests and README to  plan

### DIFF
--- a/apr/README.md
+++ b/apr/README.md
@@ -12,4 +12,28 @@ Binary package
 
 ## Usage
 
-*TODO: Add instructions for usage*
+More details - https://apr.apache.org
+
+On Linux binlink and use the command directly:
+
+```
+hab pkg install core/apr --binlink
+apr-1-config --version
+
+```
+
+## Testing
+
+```
+hab studio build go
+source results/last_build.env
+hab studio run ./apr/tests/test.sh ${pkg_ident}
+```
+## Sample Output
+
+```
+1..3
+ok 1 package directory for package ident bernagh/apr/1.6.5/20190529124535 exists
+ok 2 apr-1-config exe runs
+ok 3 apr-1-config exe output mentions expected version 1.6.5
+```

--- a/apr/tests/test.bats
+++ b/apr/tests/test.bats
@@ -1,0 +1,14 @@
+@test "package directory for package ident ${TEST_PKG_IDENT} exists" {
+  [ -d "/hab/pkgs/${TEST_PKG_IDENT}" ]
+}
+
+expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
+@test "apr-1-config exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT apr-1-config --bindir
+  [ $status -eq 0 ]
+}
+
+@test "apr-1-config exe output mentions expected version $expected_version" {
+  run hab pkg exec $TEST_PKG_IDENT apr-1-config --version
+  [[ "$output" =~ $expected_version ]]
+}

--- a/apr/tests/test.sh
+++ b/apr/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Signed-off-by: Davy McAleer dmcaleer@chef.io

Addition of simple bats tests and update of README

**Testing**

```
hab studio build apr
source results/last_build.env
hab studio run ./apr/tests/test.sh ${pkg_ident}
```

**Sample Output**

```
1..3
ok 1 package directory for package ident bernagh/apr/1.6.5/20190529124535 exists
ok 2 apr-1-config exe runs
ok 3 apr-1-config exe output mentions expected version 1.6.5
```
