### PR TITLE
[kafka] Update download location

### DIFF
--- a/kafka/plan.sh
+++ b/kafka/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=kafka
 pkg_origin=core
 pkg_version=0.10.2.2
-pkg_source="http://mirrors.gigenet.com/apache/${pkg_name}/${pkg_version}/${pkg_name}_2.11-${pkg_version}.tgz"
+pkg_source="http://archive.apache.org/dist/${pkg_name}/${pkg_version}/${pkg_name}_2.11-${pkg_version}.tgz"
 pkg_shasum="60f587ed8d1ee6e8e8057f13da6eee472f95c8d2ea691f6aab74edb842dc9950"
 pkg_dirname="${pkg_name}_2.11-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
The version of Kafka we ship has been moved to archive.apache.org, this PR corrects the download URL.  

I've also opened #2606 to investigate shipping a more recent version of Kafka.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>