### PR TITLE
[scaffolding-ruby] Replace dependency on PG server with PG client

### DIFF
--- a/scaffolding-ruby/CHANGELOG.md
+++ b/scaffolding-ruby/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full history](https://github.com/habitat-sh/core-plans/commits/master/scaffolding-ruby)
 
+# 0.8.11 (05-29-2019)
+
+- Replace dependency on `core/postgresql` with `core/postgresql-client`. [\#2595](https://github.com/habitat-sh/core-plans/issues/2595)
+
 # 0.8.10 (09-20-2018)
 
 - Fix parsing of `bundler --version` output to ensure ${_bundler_version}

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -624,9 +624,9 @@ _update_bin_dirs() {
   # dirs so they will be on `PATH.  We do this after the existing values so
   # that the Plan author's `${pkg_bin_dir[@]}` will always win.
   pkg_bin_dirs=(
-    ${pkg_bin_dir[@]}
+    "${pkg_bin_dir[@]}"
     bin
-    $app_prefix/binstubs
+    "$app_prefix/binstubs"
   )
 }
 
@@ -642,20 +642,20 @@ _update_svc_run() {
 
 _add_busybox() {
   build_line "Adding Busybox package to run dependencies"
-  pkg_deps=(core/busybox-static ${pkg_deps[@]})
+  pkg_deps=(core/busybox-static "${pkg_deps[@]}")
   debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
 }
 
 _add_git() {
   build_line "Adding git to build dependencies"
-  pkg_build_deps=(core/git ${pkg_build_deps[@]})
+  pkg_build_deps=(core/git "${pkg_build_deps[@]}")
   debug "Updating pkg_build_deps=(${pkg_build_deps[*]}) from Scaffolding detection"
 }
 
 _detect_execjs() {
   if _has_gem execjs; then
     build_line "Detected 'execjs' gem in Gemfile.lock, adding node packages"
-    pkg_deps=(core/node ${pkg_deps[@]})
+    pkg_deps=(core/node "${pkg_deps[@]}")
     debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
   fi
 }
@@ -672,7 +672,7 @@ _detect_nokogiri() {
   if _has_gem nokogiri; then
     build_line "Detected 'nokogiri' gem in Gemfile.lock, adding libxml2 & libxslt packages"
     export BUNDLE_BUILD__NOKOGIRI="--use-system-libraries"
-    pkg_deps=(core/libxml2 core/libxslt ${pkg_deps[@]})
+    pkg_deps=(core/libxml2 core/libxslt "${pkg_deps[@]}")
     debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
   fi
 }
@@ -681,7 +681,7 @@ _detect_pg() {
   for gem in "${_pg_gems[@]}"; do
     if _has_gem "$gem"; then
       build_line "Detected '$gem' gem in Gemfile.lock, adding postgresql package"
-      pkg_deps=(core/postgresql-client ${pkg_deps[@]})
+      pkg_deps=(core/postgresql-client "${pkg_deps[@]}")
       debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
       _uses_pg=true
       return 0
@@ -803,14 +803,14 @@ _detect_ruby() {
       build_line "No Ruby version detected in Plan or Gemfile.lock, using default '$_ruby_pkg'"
     fi
   fi
-  pkg_deps=($_ruby_pkg ${pkg_deps[@]})
+  pkg_deps=("$_ruby_pkg" "${pkg_deps[@]}")
   debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
 }
 
 _detect_sqlite3() {
   if _has_gem sqlite3; then
     build_line "Detected 'sqlite3' gem in Gemfile.lock, adding sqlite packages"
-    pkg_deps=(core/sqlite ${pkg_deps[@]})
+    pkg_deps=(core/sqlite "${pkg_deps[@]}")
     debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
   fi
 }
@@ -818,7 +818,7 @@ _detect_sqlite3() {
 _detect_webpacker() {
   if _has_gem webpacker; then
     build_line "Detected 'webpacker' gem in Gemfile.lock, adding yarn packages"
-    pkg_deps=(core/yarn ${pkg_deps[@]})
+    pkg_deps=(core/yarn "${pkg_deps[@]}")
     debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
   fi
 }
@@ -977,8 +977,8 @@ _set_if_unset() {
   key="$2"
   val="$3"
 
-  if [[ ! -v "$hash[$key]" ]]; then
-    eval "$hash[$key]='$val'"
+  if [[ ! -v "${hash}[${key}]" ]]; then
+    eval "${hash}[${key}]='${val}'"
   fi
 }
 

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -681,7 +681,7 @@ _detect_pg() {
   for gem in "${_pg_gems[@]}"; do
     if _has_gem "$gem"; then
       build_line "Detected '$gem' gem in Gemfile.lock, adding postgresql package"
-      pkg_deps=(core/postgresql ${pkg_deps[@]})
+      pkg_deps=(core/postgresql-client ${pkg_deps[@]})
       debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
       _uses_pg=true
       return 0

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=scaffolding-ruby
 pkg_origin=core
-pkg_version="0.8.10"
+pkg_version="0.8.11"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"


### PR DESCRIPTION
Ruby applications that connect to PostgreSQL databases only need to
depend on the postgres client tools. When the scaffolding assembles the
list of `pkg_deps` for a ruby project, it was adding `core/postgresql`
to the list if it detected the `pg` gem, which adds the entire server to
the installation footprint on disk (or your docker images).

This change replaces the dependency with `core/postgresql-client`, which
is smaller in size by > 100MB and ensures we only depend on exactly what
we need.

Closes #2595

Signed-off-by: Keith Walters <keith.walters@cattywamp.us>