### PR TITLE
[bind] Update to 9.14.2, add tests

### DIFF
--- a/bind/README.md
+++ b/bind/README.md
@@ -15,6 +15,8 @@ Binary package
 Typically this is a run-time dependency that can be added to your
 plan.sh:
 
-    pkg_deps=(core/bind)
+```
+pkg_deps=(core/bind)
+```
 
 You'll also have to add your own configuration for named and use a command like `named -c <path to config file>` to your run hook.

--- a/bind/plan.sh
+++ b/bind/plan.sh
@@ -46,7 +46,6 @@ do_prepare() {
 }
 
 do_build() {
-  attach
   PYTHONPATH="${pkg_prefix}/pip"
   export PYTHONPATH
   ./configure \

--- a/bind/plan.sh
+++ b/bind/plan.sh
@@ -46,12 +46,14 @@ do_prepare() {
 }
 
 do_build() {
+  attach
+  PYTHONPATH="${pkg_prefix}/pip"
+  export PYTHONPATH
   ./configure \
     --prefix="${pkg_prefix}" \
     --with-libxml2="$(pkg_path_for "core/libxml2")" \
     --with-openssl="$(pkg_path_for "core/openssl")" \
-    --with-python="$(pkg_path_for core/python)/bin/python" \
-    --with-python-install-dir="${pkg_prefix}/pip"
+    --with-python="$(pkg_path_for core/python)/bin/python"
   make
 }
 

--- a/bind/plan.sh
+++ b/bind/plan.sh
@@ -1,17 +1,20 @@
 pkg_name=bind
 pkg_origin=core
-pkg_version=9.11.2
+pkg_version=9.14.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Versatile, Classic, Complete Name Server Software"
 pkg_upstream_url="https://www.isc.org/downloads/bind/"
 pkg_license=("MPL-2.0")
-pkg_source="https://ftp.isc.org/isc/bind9/9.11.2/bind-${pkg_version}.tar.gz"
-pkg_shasum="7f46ad8620f7c3b0ac375d7a5211b15677708fda84ce25d7aeb7222fe2e3c77a"
+pkg_source="https://ftp.isc.org/isc/bind9/${pkg_version}/bind-${pkg_version}.tar.gz"
+pkg_shasum="0e4027573726502ec038db3973a086c02508671723a4845e21da1769a5c27f0c"
 pkg_deps=(
   core/glibc
   core/libxml2
   core/openssl
   core/zlib
+  core/libcap
+  core/busybox-static
+  core/python
 )
 pkg_build_deps=(
   core/diffutils
@@ -27,18 +30,28 @@ pkg_bin_dirs=(
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+ply_version="3.11"
+
 do_prepare() {
   # The configure script expects `file` binaries to be in `/usr/bin`
   if [[ ! -r /usr/bin/file ]]; then
     ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
     _clean_file=true
   fi
+
+  pip install \
+    --target "${pkg_prefix}/pip" \
+    --ignore-installed \
+    "ply==${ply_version}"
 }
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" \
+  ./configure \
+    --prefix="${pkg_prefix}" \
     --with-libxml2="$(pkg_path_for "core/libxml2")" \
-    --with-openssl="$(pkg_path_for "core/openssl")"
+    --with-openssl="$(pkg_path_for "core/openssl")" \
+    --with-python="$(pkg_path_for core/python)/bin/python" \
+    --with-python-install-dir="${pkg_prefix}/pip"
   make
 }
 

--- a/bind/tests/test.bats
+++ b/bind/tests/test.bats
@@ -1,0 +1,24 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" named -v | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Dig" {
+  run hab pkg exec "${TEST_PKG_IDENT}" dig a localhost
+  [ $status -eq 0 ]
+}
+
+@test "Host" {
+  run hab pkg exec "${TEST_PKG_IDENT}" host 127.0.0.1
+  [ $status -eq 0 ]
+
+  run hab pkg exec "${TEST_PKG_IDENT}" host 127.0.0.1.x
+  [ $status -eq 1 ]
+}
+
+@test "ARPAname" {
+  run hab pkg exec "${TEST_PKG_IDENT}" arpaname 127.0.0.1
+  [ $status -eq 0 ]
+}

--- a/bind/tests/test.bats
+++ b/bind/tests/test.bats
@@ -22,3 +22,13 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
   run hab pkg exec "${TEST_PKG_IDENT}" arpaname 127.0.0.1
   [ $status -eq 0 ]
 }
+
+@test "DNSSec Keygen" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" dnssec-keygen -a RSASHA512 test)"
+  status=$?
+  [ $status -eq 0 ]
+
+  keyname="$(echo "${result}" | tail -1)"
+  [ -f "${keyname}.key" ]
+  [ -f "${keyname}.private" ]
+}

--- a/bind/tests/test.sh
+++ b/bind/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
### Testing

```
hab studio build bind
source results/last_build.env
hab studio run "./bind/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Dig
 ✓ Host
 ✓ ARPAname
 ✓ DNSSec Keygen

5 tests, 0 failures
```

### Notes

This is still a binary package.

Testing includes some basic tests to ensure the python dependencies are working at a basic level.

In the future we should improve this to a service plan with minimal/basic configuration for `named`.

This supersedes #2101 