### PR TITLE
[tmux] Update tmux to 2.9a, update tests

### DIFF
--- a/tmux/plan.sh
+++ b/tmux/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=tmux
 pkg_origin=core
-pkg_version=2.8
+pkg_version=2.9a
 pkg_description="A terminal multiplexer"
 pkg_upstream_url=https://tmux.github.io/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/tmux/tmux/releases/download/${pkg_version}/tmux-${pkg_version}.tar.gz"
-pkg_shasum=7f6bf335634fafecff878d78de389562ea7f73a7367f268b66d37ea13617a2ba
+pkg_shasum=839d167a4517a6bffa6b6074e89a9a8630547b2dea2086f1fad15af12ab23b25
 pkg_deps=(
   core/glibc
   core/libevent

--- a/tmux/tests/test.bats
+++ b/tmux/tests/test.bats
@@ -1,6 +1,6 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(tmux -V | head -1 | awk '{print $2}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} tmux -V | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }

--- a/tmux/tests/test.sh
+++ b/tmux/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/tmux/tmux/blob/master/CHANGES)

### Testing

```
hab studio build tmux
source results/last_build.env
hab studio run "./tmux/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```