### PR TITLE
[rebar3] Update rebar3 to 3.11.0

### DIFF
--- a/rebar3/plan.sh
+++ b/rebar3/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=rebar3
-pkg_version=3.10.0
+pkg_version=3.11.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/erlang/${pkg_name}/archive/${pkg_version}.tar.gz"
 pkg_description="rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases."
 pkg_upstream_url="https://github.com/rebar/rebar3"
-pkg_shasum=656b4a0bd75f340173e67a33c92e4d422b5ccf054f93ba35a9d780b545ee827e
+pkg_shasum=d0f567bf5cfd60e16650b151a7caa24bf8164fb1c31359ce8b0452a683209421
 pkg_deps=(
   core/erlang
   core/busybox-static

--- a/rebar3/tests/test.bats
+++ b/rebar3/tests/test.bats
@@ -1,12 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(rebar3 version | head -1 | awk '{print $2}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} rebar3 version | head -1 | awk '{print $2}')"
   [ $? -eq 0 ]
-  [ "$result" = "${pkg_version}" ]
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run rebar3 help
+  run hab pkg exec ${TEST_PKG_IDENT} rebar3 help
   [ $status -eq 0 ]
 }

--- a/rebar3/tests/test.sh
+++ b/rebar3/tests/test.sh
@@ -1,22 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install --binlink core/bats
-hab pkg install --binlink core/erlang
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install --binlink --force "results/${pkg_artifact}"
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio build rebar3
source results/last_build.env
hab studio run "./rebar3/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```