### PR TITLE
[scaffolding-chef] ensure defaults for run hook are always set if undefined

### DIFF
--- a/scaffolding-chef/plan.sh
+++ b/scaffolding-chef/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=scaffolding-chef
 pkg_description="Scaffolding for Chef Policyfiles"
 pkg_origin=core
-pkg_version="0.6.0"
+pkg_version="0.7.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nope


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This ensures that if defaults are not set in a default/user.toml that the run hook is still able to operate. Variables set in the default.toml or user.toml will always override these defaults.

I tested by building a package with the scaffolding and running chef-client on a node. I was able to observe it run correctly and render out the run hook as intended.

![ALL OF IT](https://user-images.githubusercontent.com/3253989/58711348-35e21f00-8373-11e9-8244-2b427feacee3.gif)
