### PR TITLE
[zstd] Bump to 1.4.0, add dependencies, add tests

### DIFF
--- a/zstd/plan.sh
+++ b/zstd/plan.sh
@@ -1,15 +1,23 @@
 pkg_origin=core
 pkg_name=zstd
-pkg_version=1.3.8
+pkg_version=1.4.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_description="Zstandard is a real-time compression algorithm, providing high compression ratios. "\
 "It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder"
 pkg_upstream_url=http://facebook.github.io/zstd/
 pkg_source="https://github.com/facebook/zstd/archive/v${pkg_version}.tar.gz"
-pkg_shasum=90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3
-pkg_deps=(core/glibc)
-pkg_build_deps=(core/gcc core/make core/diffutils)
+pkg_shasum='63be339137d2b683c6d19a9e34f4fb684790e864fee13c7dd40e197a64c705c1'
+pkg_deps=(
+  core/glibc
+  core/grep
+  core/less
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/diffutils
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)

--- a/zstd/tests/test.bats
+++ b/zstd/tests/test.bats
@@ -1,0 +1,39 @@
+@test "zstd exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT zstd
+  [ $status -eq 0 ]
+}
+
+expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
+@test "zstd exe output mentions expected version $expected_version" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" zstd -h | head -1 | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')"
+  [ "$actual_version" = "$expected_version" ]
+}
+
+@test "zstdcat exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT zstdcat --help
+  [ $status -eq 0 ]
+}
+
+function basic_grep {
+  echo 'cat' | hab pkg exec $TEST_PKG_IDENT  zstdgrep 'cat'
+}
+@test "zstdgrep exe runs" {
+  run basic_grep
+  [ $status -eq 0 ]
+  [ "$output" = 'cat' ]
+}
+
+@test "zstdless exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT zstdless --help
+  [ $status -eq 0 ]
+}
+
+@test "zstdmt exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT zstdmt --help
+  [ $status -eq 0 ]
+}
+
+@test "unzstd exe runs" {
+  run hab pkg exec $TEST_PKG_IDENT unzstd --help
+  [ $status -eq 0 ]
+}

--- a/zstd/tests/test.sh
+++ b/zstd/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
[CHANGELOG](https://github.com/facebook/zstd/blob/dev/CHANGELOG)

zstdless and zstdgrep need less and grep, respectively.