### PR TITLE
[ghc] Updated GHC to 8.6.5

### DIFF
--- a/ghc/plan.ps1
+++ b/ghc/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="ghc"
 $pkg_origin="core"
-$pkg_version="8.6.3"
+$pkg_version="8.6.5"
 $pkg_license=@("BSD-3-Clause")
 $pkg_upstream_url="https://www.haskell.org/ghc/"
 $pkg_description="The Glasgow Haskell Compiler"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-x86_64-unknown-mingw32.tar.xz"
-$pkg_shasum="2fec383904e5fa79413e9afd328faf9bc700006c8c3d4bcdd8d4f2ccf0f7fa2a"
+$pkg_shasum="457024c6ea43bdce340af428d86319931f267089398b859b00efdfe2fd4ce93f"
 
 $pkg_bin_dirs=@("bin")
 $pkg_lib_dirs=@("lib")

--- a/ghc/plan.sh
+++ b/ghc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ghc
 pkg_origin=core
-pkg_version=8.6.3
+pkg_version=8.6.5
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-src.tar.xz"
-pkg_shasum="9f9e37b7971935d88ba80426c36af14b1e0b3ec1d9c860f44a4391771bc07f23"
+pkg_shasum="4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)

--- a/ghc/plan.sh
+++ b/ghc/plan.sh
@@ -10,7 +10,7 @@ pkg_shasum="4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
-pkg_include_dirs=(lib/ghc-${pkg_version}/include)
+pkg_include_dirs=("lib/ghc-${pkg_version}/include")
 pkg_interpreters=(bin/runhaskell bin/runghc)
 
 pkg_build_deps=(

--- a/ghc86/plan.sh
+++ b/ghc86/plan.sh
@@ -11,4 +11,4 @@ pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-
 pkg_shasum="4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
 pkg_dirname="ghc-${pkg_version}"
 
-pkg_include_dirs=(lib/ghc-${pkg_version}/include)
+pkg_include_dirs=("lib/ghc-${pkg_version}/include")

--- a/ghc86/plan.sh
+++ b/ghc86/plan.sh
@@ -2,13 +2,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../ghc/plan.sh"
 
 pkg_name=ghc86
 pkg_origin=core
-pkg_version=8.6.3
+pkg_version=8.6.5
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-src.tar.xz"
-pkg_shasum="9f9e37b7971935d88ba80426c36af14b1e0b3ec1d9c860f44a4391771bc07f23"
+pkg_shasum="4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
 pkg_dirname="ghc-${pkg_version}"
 
 pkg_include_dirs=(lib/ghc-${pkg_version}/include)


### PR DESCRIPTION
Updated GHC to 8.6.5

Tested by building cabal-install and shellcheck on Linux and Windows.