### PR TITLE
[7zip] Update windows tests to use new core/pester core plan

### DIFF
--- a/7zip/README.md
+++ b/7zip/README.md
@@ -28,80 +28,21 @@ hab pkg install core/7zip --binlink
 7z --help
 ```
 
-## Tests
+# Testing
 
-### Linux
-
-To run tests of an already built package in a new studio instance:
+For the linux plan:
 
 ```bash
-source results/last_build.env
+hab pkg build 7zip
+source ./results/last_build.env
 hab studio run "./7zip/tests/test.sh $pkg_ident"
 ```
 
-Sample output:
-
-```bash
-➜  core-plans git:(7zip) ✗ hab studio run "./7zip/tests/test.sh $pkg_ident"
-   hab-studio: Importing 'core' secret origin key
-» Importing origin key from standard input
-★ Imported secret origin key core-20190311142149.
-   hab-studio: Importing 'core' public origin key
-» Importing origin key from standard input
-★ Imported public origin key core-20190311142149.
-   hab-studio: Exported: HAB_ORIGIN=core
-» Installing core/bats
-☁ Determining latest version of core/bats in the 'stable' channel
-☛ Verifying core/bats/0.4.0/20190115015448
-...
-✓ Installed core/bats/0.4.0/20190115015448
-★ Install of core/bats/0.4.0/20190115015448 complete with 1 new packages installed.
-» Binlinking bats from core/bats/0.4.0/20190115015448 into /bin
-★ Binlinked bats from core/bats/0.4.0/20190115015448 to /bin/bats
-» Installing core/7zip/16.02/20190513161338
-☛ Verifying core/7zip/16.02/20190513161338
-...
-✓ Installed core/7zip/16.02/20190513161338
-★ Install of core/7zip/16.02/20190513161338 complete with 1 new packages installed.
-1..5
-ok 1 package directory for package ident core/7zip/16.02/20190513161338 exists
-ok 2 7z exe runs
-ok 3 7z exe output mentions expected version 16.02
-ok 4 7za exe runs
-ok 5 7za exe output mentions expected version 16.02
-```
-
-### Windows
-
-To run tests of an already built package in a new studio instance:
+For the windows plan:
 
 ```powershell
+hab pkg build 7zip
 . .\results\last_build.ps1
-hab studio run "& ./7zip/tests/test.ps1 $pkg_ident"
-```
-
-Sample output:
-
-```powershell
-PS C:\projects\core-plans> hab studio run "& ./7zip/tests/test.ps1 $pkg_ident"
-
-Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
---     ----            -------------   -----         -----------     --------             -------
-1      Job1            BackgroundJob   Running       True            localhost            Microsoft.PowerShell.M...
-core/7zip/16.04/20190513101258
-» Installing core/7zip/16.04/20190513101258
-→ Using core/7zip/16.04/20190513101258
-≡ Install of core/7zip/16.04/20190513101258 complete with 0 new packages installed.
-Executing all tests in 'C:\projects\core-plans\7zip\tests/test.pester.ps1'
-
-Executing script C:\projects\core-plans\7zip\tests/test.pester.ps1
-
-  Describing The 7z bin
-
-    Context 7z invoked without options
-      [+] Runs and exits successfully 278ms
-      [+] Mentions the expected version number on stdout 207ms
-Tests completed in 1.03s
-Tests Passed: 2, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
-
+hab studio run -D "hab pkg install results/$pkg_artifact"
+hab studio run -D "& 7zip/tests/test.ps1 $pkg_ident"
 ```

--- a/7zip/tests/test.bats
+++ b/7zip/tests/test.bats
@@ -1,7 +1,3 @@
-@test "package directory for package ident ${TEST_PKG_IDENT} exists" {
-  [ -d "/hab/pkgs/${TEST_PKG_IDENT}" ]
-}
-
 expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
 @test "7z exe runs" {
   run hab pkg exec $TEST_PKG_IDENT 7z

--- a/7zip/tests/test.pester.ps1
+++ b/7zip/tests/test.pester.ps1
@@ -1,6 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)]
-    [string]$PackageIdentifier = ""
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
 )
 
 Describe "The 7z bin" {

--- a/7zip/tests/test.ps1
+++ b/7zip/tests/test.ps1
@@ -6,7 +6,8 @@ param (
 
 # Ensure Pester is installed
 if (-Not (Get-Module -ListAvailable -Name Pester)) {
-    Install-Module -Name Pester -Force
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
 }
 
 # Install the package
@@ -14,7 +15,8 @@ hab pkg install $PackageIdentifier
 
 # Test the package
 $__dir=(Get-Item $PSScriptRoot)
-Invoke-Pester -EnableExit -Script @{
+$test_result = Invoke-Pester -PassThru -Script @{
     Path = "$__dir/test.pester.ps1";
     Parameters = @{PackageIdentifier=$PackageIdentifier}
 }
+Exit $test_result.FailedCount

--- a/7zip/tests/test.sh
+++ b/7zip/tests/test.sh
@@ -2,17 +2,22 @@
 
 set -euo pipefail
 
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
 TESTDIR="$(dirname "${0}")"
 
-if [ -z "${1:-}" ]; then
-  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
   exit 1
 fi
 
 TEST_PKG_IDENT="$1"
 
-hab pkg install --binlink core/bats
-hab pkg install "$TEST_PKG_IDENT"
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
 
 export TEST_PKG_IDENT
 bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
## Outstanding Tasks
- [x] Raise issue [local windows studios do not link /hab/cache/artifacts](https://github.com/habitat-sh/habitat/issues/6681)
- [x] Respond to Matt Wrock's comment with proof of why 'install' is needed; 
- [x] Squash commits
- [x] Waiting final approval from @mwrock before merge.

## Context
This PR:
* updates the test.ps1 to use core/pester instead of downloading the module
* fixes Invoke-Pester to use -PassThru instead of -EnableExit, which aborts the powershell whether tests pass or fail
* updates the [testing standard document](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md) with the new pester testing instructions

## Completed
- [x] Raised [7zip PR](https://github.com/habitat-sh/core-plans/pull/2630) to add core/pester and update the  [test standards document](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md)
- [x] Changed instructions in 7zip and test design to ensure build and test are done not on windows host but in docker container.
- [x] Split out the design document change into its [own PR](https://github.com/habitat-sh/core-plans/pull/2634)--removed from this one.
- [x] Clarified with Scott approach for windows to build, install, and test on windows docker studio ``hab studio run -D``
- [x] Setup and verified the [VirtualBox Windows docker habitat studio](https://forums.habitat.sh/t/entering-a-windows-studio-from-a-mac/1120).  This works a treat and allows anyone to test windows plans on their Mac.
- [x] Fixed an incorrect update to the 7zip and dotnet-471 PRs which occured while testing the VirtualBox windows studio testing.
- [x] Reviewed with Stocksy the package install differences on mac and windows
- [x] Amend according to issue #2676