### PR TITLE
[nginx] Remove deprecated --with-ipv6 configure flag

### DIFF
--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -46,7 +46,6 @@ do_build() {
     --http-fastcgi-temp-path="${pkg_svc_var_path}/fastcgi" \
     --http-scgi-temp-path="${pkg_svc_var_path}/scgi" \
     --http-uwsgi-temp-path="${pkg_svc_var_path}/uwsgi" \
-    --with-ipv6 \
     --with-pcre \
     --with-pcre-jit \
     --with-file-aio \


### PR DESCRIPTION
Reference: http://hg.nginx.org/nginx/rev/a6d116645c51