### PR TITLE
[e2fsprogs] Update to 1.45.2 and add modern tests

### DIFF
--- a/e2fsprogs/plan.sh
+++ b/e2fsprogs/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=e2fsprogs
 pkg_origin=core
-pkg_version="1.44.1"
+pkg_version="1.45.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Ext2/3/4 filesystem userspace utilities"
 pkg_license=('GPL-2.0')
 pkg_upstream_url="http://e2fsprogs.sourceforge.net/"
 pkg_source="https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-${pkg_version}.tar.gz"
-pkg_shasum="1531c91198520d6868d1106b6b508c5fc780533952f63c2dfd2afec282aa7097"
+pkg_shasum=2060c7b5f07d62b9efc64b344ea5dbe6bd8f852dc4c28f671cf6373522f16c97
 pkg_deps=(
   core/glibc
 )
@@ -16,4 +16,7 @@ pkg_build_deps=(
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-pkg_bin_dirs=(bin sbin)
+pkg_bin_dirs=(
+  bin
+  sbin
+)

--- a/e2fsprogs/tests/test.bats
+++ b/e2fsprogs/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
+
+@test "uuidgen works" {
+  run hab pkg exec "${TEST_PKG_IDENT}" uuidgen -t
+  [ "$status" -eq 0 ]
+}

--- a/e2fsprogs/tests/test.sh
+++ b/e2fsprogs/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This PR supersedes #2256 and adds modern testing to avoid the issue discussed there.

* [Changelog](http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.45.2)

### Testing

```
hab studio build e2fsprogs
source results/last_build.env
hab studio run "./e2fsprogs/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ uuidgen works

1 test, 0 failures
```