### PR TITLE
Adjust codeownership for self

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@ scaffolding-* @habitat-sh/scaffolding-maintainers
 
 libarchive @reset @fnichol @raskchanky @nellshamrell
 libsodium @reset @fnichol @raskchanky @nellshamrell
-nginx @reset @fnichol @raskchanky @nellshamrell
+nginx @reset @fnichol @raskchanky @nellshamrell @predominant
 postgresql @reset @fnichol @irvingpop @raskchanky @nellshamrell
 protobuf @reset @fnichol @raskchanky @nellshamrell
 protobuf-rust @reset @fnichol @raskchanky @nellshamrell
@@ -121,7 +121,7 @@ cerebro @predominant
 clojure @johnjelinek
 concourse @echohack
 concourse-fly @echohack
-consul @defilan
+consul @defilan @predominant
 corretto @johnjelinek
 corretto8 @johnjelinek
 corretto11 @johnjelinek
@@ -155,14 +155,14 @@ happy @wduncanfraser
 harfbuzz @rsertelon
 hugo @tduffield @cnunciato @predominant
 innounp @mwrock
-jdk7 @predominant @rsertelon
-jdk8 @predominant @rsertelon
-jdk9 @predominant @rsertelon
+jdk7 @rsertelon
+jdk8 @rsertelon
+jdk9 @rsertelon
 jenkins @predominant
 journalbeat @thomascate @echohack
-jre7 @predominant @rsertelon
-jre8 @predominant @rsertelon
-jre9 @predominant @rsertelon
+jre7 @rsertelon
+jre8 @rsertelon
+jre9 @rsertelon
 kibana @joshbrand @predominant
 logstash @joshbrand @predominant
 libimagequant @predominant
@@ -185,7 +185,6 @@ postgresql11 @irvingpop
 postgresql11-client @irvingpop
 prometheus-cpp @bdangit
 protobuf-cpp @afiune
-rabbitmqadmin @predominant
 redis @irvingpop
 shared-mime-info @rsertelon
 shellcheck @wduncanfraser
@@ -193,7 +192,7 @@ sqitch @irvingpop
 sqitch_pg @irvingpop
 sqlserver @mwrock
 sqlserver-ha-ag @mwrock
-terraform @defilan @echohack
-vault @defilan
+terraform @defilan @echohack @predominant
+vault @defilan @predominant
 visual-build-tools-2017 @mwrock
 wrk @afiune


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Update a number of code ownership lines to help relieve blockers on plan review.

![tenor-45033446](https://user-images.githubusercontent.com/24568/59314530-a6ccf380-8cf0-11e9-8ad8-ef4ebfbc3d49.gif)
