### PR TITLE
[corretto8] Fix linker issues with Corretto8

### DIFF
--- a/corretto/plan.sh
+++ b/corretto/plan.sh
@@ -3,9 +3,9 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_name=corretto
 # NOTE: Retrieve download link from here: https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html
 pkg_version=11.0.2.9.3
-pkg_source=https://d3pxv6yz143wms.cloudfront.net/${pkg_version}/amazon-corretto-${pkg_version}-linux-x64.tar.gz
+pkg_source="https://d3pxv6yz143wms.cloudfront.net/${pkg_version}/amazon-corretto-${pkg_version}-linux-x64.tar.gz"
 pkg_shasum=be8452a78baa077e19afbfa64070b26275030267a5ea4e837dec7a30eff85c9c
-pkg_filename=corretto-${pkg_version}_linux-x64_bin.tar.gz
+pkg_filename="corretto-${pkg_version}_linux-x64_bin.tar.gz"
 pkg_dirname="amazon-corretto-${pkg_version}-linux-x64"
 pkg_license=("GPL-2.0-only")
 pkg_description=('Corretto is a build of the Open Java Development Kit (OpenJDK) with long-term support from Amazon.')
@@ -22,15 +22,18 @@ pkg_deps=(
   core/xlib
   core/zlib
 )
-pkg_build_deps=(core/patchelf core/rsync)
+pkg_build_deps=(
+  core/patchelf
+  core/rsync
+)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
-source_dir=$HAB_CACHE_SRC_PATH/${pkg_dirname}
+source_dir="${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
 
 do_setup_environment() {
- set_runtime_env JAVA_HOME "$pkg_prefix"
+ set_runtime_env JAVA_HOME "${pkg_prefix}"
 }
 
 do_build() {
@@ -44,13 +47,13 @@ do_install() {
   export LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/jli:${pkg_prefix}/lib/server:${pkg_prefix}/lib"
 
   build_line "Setting interpreter for all executables to '$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2'"
-  build_line "Setting rpath for all libraries to '$LD_RUN_PATH'"
+  build_line "Setting rpath for all libraries to '${LD_RUN_PATH}'"
 
-  find "$pkg_prefix"/bin -type f -executable \
+  find "${pkg_prefix}"/bin -type f -executable \
     -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
-  find "$pkg_prefix/lib" -type f -name "*.so" \
+  find "${pkg_prefix}/lib" -type f -name "*.so" \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
 
   popd || exit 1

--- a/corretto8/plan.sh
+++ b/corretto8/plan.sh
@@ -7,13 +7,13 @@ pkg_description=('Corretto is a build of the Open Java Development Kit (OpenJDK)
 pkg_license=("GPL-2.0-only")
 pkg_upstream_url=https://aws.amazon.com/corretto/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://d2znqt9b1bc64u.cloudfront.net/amazon-corretto-${pkg_version}-linux-x64.tar.gz
+pkg_source="https://d2znqt9b1bc64u.cloudfront.net/amazon-corretto-${pkg_version}-linux-x64.tar.gz"
 pkg_shasum=c19a928687479e1036ff1d6e023975402d2f027d9b3e4d64cfaf0c9f35bf9669
-pkg_filename=corretto-${pkg_version}_linux-x64_bin.tar.gz
+pkg_filename="corretto-${pkg_version}_linux-x64_bin.tar.gz"
 pkg_dirname="amazon-corretto-${pkg_version}-linux-x64"
 
 do_setup_environment() {
- set_runtime_env JAVA_HOME "$pkg_prefix"
+ set_runtime_env JAVA_HOME "${pkg_prefix}"
 }
 
 do_build() {
@@ -22,18 +22,26 @@ do_build() {
 
 do_install() {
   pushd "${pkg_prefix}" || exit 1
-  rsync -avz "$HAB_CACHE_SRC_PATH/${pkg_dirname}/" .
+  rsync -avz "${HAB_CACHE_SRC_PATH}/${pkg_dirname}/" .
 
-  export LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/amd64/jli:${pkg_prefix}/lib/server:${pkg_prefix}/lib/amd64"
+  LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/amd64/jli"
+  LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/server"
+  LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/amd64"
+  LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/jre/lib/amd64"
+  LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/jre/lib/amd64/server"
+  export LD_RUN_PATH
 
   build_line "Setting interpreter for all executables to '$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2'"
-  build_line "Setting rpath for all libraries to '$LD_RUN_PATH'"
+  build_line "Setting rpath for all libraries to '${LD_RUN_PATH}'"
 
-  find "$pkg_prefix"/bin -type f -executable \
+  find "${pkg_prefix}"/bin -type f -executable \
     -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
-  find "$pkg_prefix/lib" -type f -name "*.so" \
+  find "${pkg_prefix}/lib" -type f -name "*.so" \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+
+  find "${pkg_prefix}/jre/lib" -type f -name "*.so" \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
 
   popd || exit 1


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Before fix:

```
# ldd /hab/pkgs/core/corretto8/8.202.08.2/20190611004012/jre/lib/amd64/libfontmanager.so 
        linux-vdso.so.1 (0x00007ffca45f0000)
        libfreetype.so.6 => not found
        libawt.so => /hab/pkgs/core/corretto8/8.202.08.2/20190611004012/jre/lib/amd64/libawt.so (0x00007f22dc8c2000)
        libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007f22dc72f000)
        libjava.so => /hab/pkgs/core/corretto8/8.202.08.2/20190611004012/jre/lib/amd64/libjava.so (0x00007f22dc501000)
        libjvm.so => not found
        libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f22dc349000)
        /hab/pkgs/core/glibc/2.27/20190115002733/lib64/ld-linux-x86-64.so.2 (0x00007f22dce03000)
        libjvm.so => not found
        libdl.so.2 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libdl.so.2 (0x00007f22dc342000)
        libjvm.so => not found
        libverify.so => /hab/pkgs/core/corretto8/8.202.08.2/20190611004012/jre/lib/amd64/libverify.so (0x00007f22dc12f000)
        libjvm.so => not found
[14][default:/src:0]# ldd /hab/pkgs/core/corretto11/11.0.2.9.3/20190611004012/
```

After fix:

```
ldd /hab/pkgs/rakops/corretto8/8.202.08.2/20190612021235/jre/lib/amd64/libfontmanager.so 
        linux-vdso.so.1 (0x00007fffcb7cf000)
        libfreetype.so.6 => /hab/pkgs/core/freetype/2.9.1/20190502094019/lib/libfreetype.so.6 (0x00007f63a59d3000)
        libawt.so => /hab/pkgs/rakops/corretto8/8.202.08.2/20190612021235/jre/lib/amd64/libawt.so (0x00007f63a56fb000)
        libm.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libm.so.6 (0x00007f63a5568000)
        libjava.so => /hab/pkgs/rakops/corretto8/8.202.08.2/20190612021235/jre/lib/amd64/libjava.so (0x00007f63a5334000)
        libjvm.so => /hab/pkgs/rakops/corretto8/8.202.08.2/20190612021235/jre/lib/amd64/server/libjvm.so (0x00007f63a43b7000)
        libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007f63a41ff000)
        /hab/pkgs/core/glibc/2.27/20190115002733/lib64/ld-linux-x86-64.so.2 (0x00007f63a5d28000)
        libbz2.so.1.0 => /hab/pkgs/core/bzip2/1.0.6/20190115011950/lib/libbz2.so.1.0 (0x00007f63a41ec000)
        libpng16.so.16 => /hab/pkgs/core/libpng/1.6.37/20190416161431/lib/libpng16.so.16 (0x00007f63a41a8000)
        libz.so.1 => /hab/pkgs/core/zlib/1.2.11/20190115003728/lib/libz.so.1 (0x00007f63a4185000)
        libdl.so.2 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libdl.so.2 (0x00007f63a4180000)
        libverify.so => /hab/pkgs/rakops/corretto8/8.202.08.2/20190612021235/jre/lib/amd64/libverify.so (0x00007f63a3f6c000)
        libpthread.so.0 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libpthread.so.0 (0x00007f63a3f4a000)
```

