### PR TITLE
[artifactory] [artifactory-pro] update to artifactory 6.10.3

### DIFF
--- a/artifactory-pro/README.md
+++ b/artifactory-pro/README.md
@@ -39,5 +39,5 @@ Build the package and run tests like so:
 ```bash
 hab studio build artifactory-pro
 source results/last_build.env
-hab studio run "./artifactory-pro/tests/test.sh $pkg_ident"
+hab studio run "./artifactory-pro/tests/test.sh ${pkg_ident}"
 ```

--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,14 +1,14 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.9.1
+pkg_version=6.10.3
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=2f052b9c0540ce1154e3ff6383238d6637f168e6dc6a29fddcd10dae6685accb
-pkg_deps=(core/bash core/jre8)
+pkg_shasum=392610eeedd13a3eea8472bb3577776bd237f6637673da1df9732a4424cb7f89
+pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port
 )

--- a/artifactory-pro/tests/test.sh
+++ b/artifactory-pro/tests/test.sh
@@ -1,39 +1,37 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
 set -eou pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
 
 TESTDIR="$(dirname "${0}")"
 source "${TESTDIR}/helpers.bash"
 
-if [ -z "${1:-}" ]; then
-  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
-  exit 1
-fi
-
-TEST_PKG_IDENT="$1"
-
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static nc
+hab pkg install "${TEST_PKG_IDENT}"
 
-# Wait for supervisor to start
 hab sup term
 hab sup run &
 echo "Waiting for supervisor to start"
 wait_listen tcp 9632 30
 
-
-# Unload the service if its already loaded.
-hab svc unload "${TEST_PKG_IDENT}"
 hab svc load "${TEST_PKG_IDENT}"
 
 # Wait for 30 seconds on first check, to ensure service is up.
 echo "Waiting for Artifactory to start"
 wait_listen tcp 8081 90
 
-export TEST_PKG_IDENT
 bats "${TESTDIR}/test.bats"
 
-hab svc unload "${TEST_PKG_IDENT}"
-hab sup term
+hab svc unload "${TEST_PKG_IDENT}" || true

--- a/artifactory/README.md
+++ b/artifactory/README.md
@@ -35,5 +35,5 @@ Build the package and run tests like so:
 ```bash
 hab studio build artifactory
 source results/last_build.env
-hab studio run "./artifactory/tests/test.sh $pkg_ident"
+hab studio run "./artifactory/tests/test.sh ${pkg_ident}"
 ```

--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,14 +1,14 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.9.1
+pkg_version=6.10.3
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum=83e99303990a444aadbda36ce5279640f17f99672917200cb1a62b13e5ecae82
-pkg_deps=(core/bash core/jre8)
+pkg_shasum=809b8227ec854d2dca789135a8d77df1dc6feaabc40875799cafc98c368fae59
+pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port
 )

--- a/artifactory/tests/test.sh
+++ b/artifactory/tests/test.sh
@@ -1,39 +1,37 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
 set -eou pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
 
 TESTDIR="$(dirname "${0}")"
 source "${TESTDIR}/helpers.bash"
 
-if [ -z "${1:-}" ]; then
-  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
-  exit 1
-fi
-
-TEST_PKG_IDENT="$1"
-
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static nc
+hab pkg install "${TEST_PKG_IDENT}"
 
-# Wait for supervisor to start
 hab sup term
 hab sup run &
 echo "Waiting for supervisor to start"
 wait_listen tcp 9632 30
 
-
-# Unload the service if its already loaded.
-hab svc unload "${TEST_PKG_IDENT}"
 hab svc load "${TEST_PKG_IDENT}"
 
 # Wait for 30 seconds on first check, to ensure service is up.
 echo "Waiting for Artifactory to start"
 wait_listen tcp 8081 90
 
-export TEST_PKG_IDENT
 bats "${TESTDIR}/test.bats"
 
-hab svc unload "${TEST_PKG_IDENT}"
-hab sup term
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
![active_time_remaining](https://user-images.githubusercontent.com/3253989/59370929-7b4e0700-8cf8-11e9-9f8a-99c9747ca35f.gif)

Signed-off-by: echohack <echohack@users.noreply.github.com>

[Artifactory Pro Release Notes](https://bintray.com/jfrog/artifactory-pro/jfrog-artifactory-pro-zip)
[Artifactory OSS Release Notes](https://bintray.com/jfrog/artifactory/jfrog-artifactory-oss-zip)

Artifactory 6.10.3 allows you to use JDK11, and [fully supports OpenJDK](https://www.jfrog.com/confluence/display/RTF/System+Requirements
). Since this lands us in a much nicer, more easily buildable and licensable situation, this PR changes over to OpenJDK11.

I also tweaked some of the tests a bit to be more up to standards.

## Testing

Build the package and run tests like so:

```bash
hab studio build artifactory
source results/last_build.env
hab studio run "./artifactory/tests/test.sh ${pkg_ident}"
```

```bash
hab studio build artifactory-pro
source results/last_build.env
hab studio run "./artifactory/tests/test.sh ${pkg_ident}"
```