### PR TITLE
[kubectl] Upgrade to k8s 1.14.3

### DIFF
--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -4,9 +4,9 @@ pkg_description="kubectl CLI tool"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
+pkg_version=1.14.3
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=073b77321812f26df6513c0ad0aef3a8b0c17f6281a186d515f5855ae009ea17
+pkg_shasum=3896f5beb1f381cd022ca3dcac2ff4ec4660f7471a1f50cca91a4916ddf54eaa
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This PR updates the standalone kubectl client package to the latest stable release