### PR TITLE
[opendistro-for-elasticsearch] New plan! adds new opendistro-for-elasticsearch (plan and testing)

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1026,6 +1026,8 @@ plan_path = "ocamlbuild"
 plan_path = "omniORB"
 [opa]
 plan_path = "opa"
+[opendistro-for-elasticsearch]
+plan_path = "opendistro-for-elasticsearch"
 [opam]
 plan_path = "opam"
 [openjpeg]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -175,6 +175,7 @@ mssql @mwrock
 nano @predominant
 nmap @defilan
 nuget @mwrock
+opendistro-for-elasticsearch @echohack
 openjdk11 @irvingpop
 optipng @predominant
 p4broker @dbhagen

--- a/opendistro-for-elasticsearch/README.md
+++ b/opendistro-for-elasticsearch/README.md
@@ -1,0 +1,41 @@
+# opendistro-for-elasticsearch
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+Install the package, and load the service:
+
+```bash
+hab pkg install core/opendistro-for-elasticsearch
+hab svc load core/opendistro-for-elasticsearch
+```
+
+## Bindings
+
+Services consuming opendistro-for-elasticsearch can bind via:
+
+```
+hab svc load origin/package --bind elasticsearch:opendistro-for-elasticserach.default
+```
+
+Elasticsearch's contract presents the following ports to bind to:
+
+- `http-port`
+- `transport-port`
+
+## Topologies
+
+Currently this plan supports standalone topology.
+
+## Update Strategies
+
+No update strategy or at-once update strategy works fine in a single-node installation.
+
+### Configuration Updates

--- a/opendistro-for-elasticsearch/config/certificates/MyRootCA.pem
+++ b/opendistro-for-elasticsearch/config/certificates/MyRootCA.pem
@@ -1,0 +1,3 @@
+{{#if cfg.opendistro_ssl.rootCA ~}}
+  {{cfg.opendistro_ssl.rootCA}}
+{{/if ~}}

--- a/opendistro-for-elasticsearch/config/certificates/admin.key
+++ b/opendistro-for-elasticsearch/config/certificates/admin.key
@@ -1,0 +1,3 @@
+{{#if cfg.opendistro_ssl.admin_key ~}}
+  {{cfg.opendistro_ssl.admin_key}}
+{{/if ~}}

--- a/opendistro-for-elasticsearch/config/certificates/admin.pem
+++ b/opendistro-for-elasticsearch/config/certificates/admin.pem
@@ -1,0 +1,3 @@
+{{#if cfg.opendistro_ssl.admin_cert ~}}
+  {{cfg.opendistro_ssl.admin_cert}}
+{{/if ~}}

--- a/opendistro-for-elasticsearch/config/certificates/node.key
+++ b/opendistro-for-elasticsearch/config/certificates/node.key
@@ -1,0 +1,3 @@
+{{#if cfg.opendistro_ssl.node_key ~}}
+  {{cfg.opendistro_ssl.node_key}}
+{{/if ~}}

--- a/opendistro-for-elasticsearch/config/certificates/node.pem
+++ b/opendistro-for-elasticsearch/config/certificates/node.pem
@@ -1,0 +1,3 @@
+{{#if cfg.opendistro_ssl.node_cert ~}}
+  {{cfg.opendistro_ssl.node_cert}}
+{{/if ~}}

--- a/opendistro-for-elasticsearch/config/elasticsearch.yml
+++ b/opendistro-for-elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,1 @@
+{{toYaml cfg.es_yaml}}

--- a/opendistro-for-elasticsearch/config/hook-helper.sh
+++ b/opendistro-for-elasticsearch/config/hook-helper.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# TODO: Re-evaluate when hooks can run on their own thread
+# Sleeps in hooks that are not the run hook
+# are not a good practice because all hooks run in the Supervisor's
+# main thread. In the future, this may change.
+# See also: https://github.com/habitat-sh/habitat/issues/2364
+# Wait so elasticsearch can start
+create_credentials_delay() {
+    CURL_STATUS="1"
+    BREAKER=0
+    while [ $CURL_STATUS != "0" ]; do
+    sleep 5
+    CURL_OUTPUT="$(curl -sk https://{{svc.me.sys.ip}}:{{svc.me.cfg.http-port}})"
+    CURL_STATUS=$?
+    if [[ $CURL_OUTPUT =~ .*Security\ not\ initialized.* ]]; then
+        echo "inserting default credentials"
+        set -e
+        {{pkg.path}}/plugins/opendistro_security/tools/securityadmin.sh -h {{svc.me.sys.ip}} -p {{svc.me.cfg.transport-port}} -cacert {{pkg.svc_path}}/config/certificates/MyRootCA.pem -cert {{pkg.svc_path}}/config/certificates/admin.pem -key {{pkg.svc_path}}/config/certificates/admin.key -nhnv -icl -cd {{pkg.svc_path}}/config/securityconfig
+        echo "Inserted default securityconfig"
+        exit 0
+    elif [ "$CURL_OUTPUT" == 'Unauthorized' ]; then
+        echo "Authentication appears to already be setup, giving up"
+        exit 0
+    fi
+    if [[ $BREAKER -gt 30 ]]; then
+        echo "After 2.5 minutes Elasticsearch never responded to requests to insert data, giving up"
+        exit 1
+    fi
+    BREAKER=$((BREAKER+1))
+    done
+
+    exit 0
+}

--- a/opendistro-for-elasticsearch/config/jvm.options
+++ b/opendistro-for-elasticsearch/config/jvm.options
@@ -1,0 +1,55 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+## We are setting these dynamically in the run hook based on system memory
+#-Xms{{cfg.runtime.heapsize}}
+#-Xmx{{cfg.runtime.heapsize}}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+-XX:+DisableExplicitGC
+-XX:+AlwaysPreTouch
+-server
+-Xss1m
+-Djava.awt.headless=true
+-Dfile.encoding=UTF-8
+-Djna.nosys=true
+-Djdk.io.permissionsUseCanonicalPath=true
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+-Djava.io.tmpdir={{pkg.svc_var_path}}
+-XX:+HeapDumpOnOutOfMemoryError
+{{cfg.runtime.es_java_opts}}

--- a/opendistro-for-elasticsearch/config/log4j2.properties
+++ b/opendistro-for-elasticsearch/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/opendistro-for-elasticsearch/config/securityconfig/action_groups.yml
+++ b/opendistro-for-elasticsearch/config/securityconfig/action_groups.yml
@@ -1,0 +1,4 @@
+UNLIMITED:
+  readonly: true
+  permissions:
+    - "*"

--- a/opendistro-for-elasticsearch/config/securityconfig/config.yml
+++ b/opendistro-for-elasticsearch/config/securityconfig/config.yml
@@ -1,0 +1,14 @@
+opendistro_security:
+  dynamic:
+    http:
+      anonymous_auth_enabled: false
+    authc:
+      basic_internal_auth_domain:
+        http_enabled: true
+        transport_enabled: true
+        order: 4
+        http_authenticator:
+          type: basic
+          challenge: true
+        authentication_backend:
+          type: intern

--- a/opendistro-for-elasticsearch/config/securityconfig/internal_users.yml
+++ b/opendistro-for-elasticsearch/config/securityconfig/internal_users.yml
@@ -1,0 +1,4 @@
+# This is the internal user database
+# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+{{toYaml cfg.securityconfig.internal_users}}

--- a/opendistro-for-elasticsearch/config/securityconfig/roles.yml
+++ b/opendistro-for-elasticsearch/config/securityconfig/roles.yml
@@ -1,0 +1,10 @@
+all_access:
+  readonly: true
+  cluster:
+    - UNLIMITED
+  indices:
+    '*':
+      '*':
+        - UNLIMITED
+  tenants:
+    admin_tenant: RW

--- a/opendistro-for-elasticsearch/config/securityconfig/roles_mapping.yml
+++ b/opendistro-for-elasticsearch/config/securityconfig/roles_mapping.yml
@@ -1,0 +1,4 @@
+all_access:
+  readonly: true
+  backendroles:
+    - admin

--- a/opendistro-for-elasticsearch/default.toml
+++ b/opendistro-for-elasticsearch/default.toml
@@ -1,0 +1,60 @@
+# ======================== Elasticsearch Configuration =========================
+#
+[es_yaml]
+[es_yaml.bootstrap]
+memory_lock = false
+[es_yaml.cluster]
+name = "example-cluster"
+[es_yaml.discovery.zen]
+minimum_master_nodes = 1
+[es_yaml.http]
+port = 9200
+[es_yaml.transport.tcp]
+port = 9300
+[es_yaml.network]
+host = "0.0.0.0"
+[es_yaml.node]
+max_local_storage_nodes = 1
+[es_yaml.path]
+data = "/hab/svc/opendistro-for-elasticsearch/data"
+logs = "/hab/svc/opendistro-for-elasticsearch/logs"
+[es_yaml.opendistro_security]
+allow_unsafe_democertificates = "true"
+# These are example DN generated certificates. Override if you're generating your own
+nodes_dn = [ "CN=node,O=example.com,L=example_city,ST=example_state,C=CC" ]
+[es_yaml.opendistro_security.authcz]
+admin_dn = [ "CN=admin,O=example.com,L=example_city,ST=example_state,C=CC" ]
+[es_yaml.opendistro_security.ssl]
+[es_yaml.opendistro_security.ssl.http]
+enabled = true
+pemcert_filepath = "certificates/admin.pem"
+pemkey_filepath = "certificates/admin.key"
+pemtrustedcas_filepath = "certificates/MyRootCA.pem"
+[es_yaml.opendistro_security.ssl.transport]
+enabled = true
+pemcert_filepath = "certificates/node.pem"
+pemkey_filepath = "certificates/node.key"
+pemtrustedcas_filepath = "certificates/MyRootCA.pem"
+enforce_hostname_verification = false
+
+[securityconfig]
+[securityconfig.internal_users]
+[securityconfig.internal_users.admin]
+readonly = true
+hash = "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG" #password is: admin
+roles = [ "admin" ]
+# Runtime settings for jvm.options and the systemd service
+[runtime]
+  max_open_files = ""
+  max_locked_memory = ""
+  es_startup_sleep_time = ""
+  # This config variable becomes the value of ES_JAVA_OPTS.
+  # Note: JVM values for -Xms and -Xmx are auto calculated in the run hook.
+  # Any value defined here will override the calculation in the hook.
+  es_java_opts = ""
+
+# This section contains any settings that need to applied on startup for opendistro.
+# Any values put under this hash will be rendered into yaml and applied with
+# securityadmin.sh. These should be your basic admin credentials, as long term you
+# can manage your creds outside of habitat with securityadmin.sh.
+[odconfig_yaml]

--- a/opendistro-for-elasticsearch/hooks/health-check
+++ b/opendistro-for-elasticsearch/hooks/health-check
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Elasticsearch Health Check for Habitat
+
+# For details on the elasticsearch health colors, see:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+status="$(curl -sk --cacert {{pkg.svc_path}}/config/certificates/MyRootCA.key --key {{pkg.svc_path}}/config/certificates/node.key --cert {{pkg.svc_path}}/config/certificates/node.pem https://{{svc.me.sys.ip}}:{{svc.me.cfg.http-port}}/_cat/health)"
+color="$(echo "$status" | awk '{print $4}')"
+
+case $color in
+  "green")
+    rc=0 ;;                     # OK (200)
+  "yellow")
+    rc=1 ;;                     # WARNING (200)
+  "red")
+    rc=2 ;;                     # CRITICAL (503)
+  *)
+    rc=3 ;;                     # UNKNOWN (500)
+esac
+
+exit $rc

--- a/opendistro-for-elasticsearch/hooks/init
+++ b/opendistro-for-elasticsearch/hooks/init
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+mkdir -p {{pkg.svc_path_config_path}}/tmp
+mkdir -p {{pkg.svc_data_path}}/{{cfg.es_yaml.cluster.name}}
+
+#This section makes sure that the admin key exists.
+
+#if [ ! -s {{pkg.svc_config_path}}/certificates/MyRootCA.key ]; then
+
+{{#unless cfg.opendistro_ssl.rootCA}}
+  RANDFILE={{pkg.svc_config_path}}/certificates/.rnd
+
+  mkdir -p {{pkg.svc_config_path}}
+  #First, create a private key for the CA:
+  openssl genrsa -out {{pkg.svc_config_path}}/certificates/MyRootCA.key 2048
+
+  #Create the CA and enter the Organization details:
+  openssl req -x509 -new -key {{pkg.svc_config_path}}/certificates/MyRootCA.key -sha256 -out {{pkg.svc_config_path}}/certificates/MyRootCA.pem -subj '/C=CC/ST=example_state/L=example_city/O=example.com/CN=rootca'
+
+  #the rsa keys
+  openssl genrsa -out {{pkg.svc_config_path}}/certificates/node-pkcs12.key 2048
+  openssl genrsa -out {{pkg.svc_config_path}}/certificates/admin-pkcs12.key 2048
+
+  #IMPORTANT: Convert these to PKCS#5 v1.5 to work correctly with the JDK.
+  openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "{{pkg.svc_config_path}}/certificates/node-pkcs12.key" -topk8 -out "{{pkg.svc_config_path}}/certificates/node.key" -nocrypt
+  openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "{{pkg.svc_config_path}}/certificates/admin-pkcs12.key" -topk8 -out "{{pkg.svc_config_path}}/certificates/admin.key" -nocrypt
+
+  #Create the CSR and enter the organization and server details for the node key
+  openssl req -new -key {{pkg.svc_config_path}}/certificates/node.key -out {{pkg.svc_config_path}}/certificates/node.csr -subj '/C=CC/ST=example_state/L=example_city/O=example.com/CN=node'
+
+  #Create the CSR and enter the organization and server details for the admin key
+  openssl req -new -key {{pkg.svc_config_path}}/certificates/admin.key -out {{pkg.svc_config_path}}/certificates/admin.csr -subj '/C=CC/ST=example_state/L=example_city/O=example.com/CN=admin'
+
+  #Use the CSR to generate the signed node Certificate:
+  openssl x509 -req -in {{pkg.svc_config_path}}/certificates/node.csr -CA {{pkg.svc_config_path}}/certificates/MyRootCA.pem -CAkey {{pkg.svc_config_path}}/certificates/MyRootCA.key -CAcreateserial -out {{pkg.svc_config_path}}/certificates/node.pem -sha256
+
+  #Use the CSR to generate the signed admin Certificate:
+  openssl x509 -req -in {{pkg.svc_config_path}}/certificates/admin.csr -CA {{pkg.svc_config_path}}/certificates/MyRootCA.pem -CAkey {{pkg.svc_config_path}}/certificates/MyRootCA.key -CAcreateserial -out {{pkg.svc_config_path}}/certificates/admin.pem -sha256
+{{/unless}}

--- a/opendistro-for-elasticsearch/hooks/post-run
+++ b/opendistro-for-elasticsearch/hooks/post-run
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+exec 2>&1
+
+source "{{pkg.svc_config_path}}/hook-helper.sh"
+
+create_credentials_delay

--- a/opendistro-for-elasticsearch/hooks/run
+++ b/opendistro-for-elasticsearch/hooks/run
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+exec 2>&1
+
+# Don't use the default password, ok?
+if [ "{{cfg.securityconfig.internal_users.admin.hash}}" = '$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG' ]; then
+    echo "=================================================="
+    echo "WARNING: UNSAFE DEFAULT PASSWORD FOR ADMIN USER!!!"
+    echo "WARNING: USE FOR TESTING PURPOSES ONLY!!!"
+    echo "WARNING: UNSAFE DEFAULT PASSWORD FOR ADMIN USER!!!"
+    echo "=================================================="
+fi
+
+free_mem="$(free -m | grep Mem | awk '{print $2}')"
+computed_mem="$(( $free_mem / 2 ))"
+half_mem="$(echo $computed_mem)"
+if [ $half_mem -lt 26624 ]; then
+    heapsize=$half_mem; heapsize+=m;
+else
+    heapsize=26624m;
+fi
+export ES_JAVA_HEAP="-Xms$heapsize -Xmx$heapsize"
+
+{{#if cfg.runtime.es_startup_sleep_time ~}}
+export ES_STARTUP_SLEEP_TIME={{cfg.runtime.es_startup_sleep_time}}
+{{/if ~}}
+{{#if cfg.runtime.max_locked_memory ~}}
+ulimit -l {{cfg.runtime.max_locked_memory}}
+{{/if ~}}
+{{#if cfg.runtime.max_open_files ~}}
+ulimit -n {{cfg.runtime.max_open_files}}
+{{/if ~}}
+{{#if cfg.runtime.es_java_opts ~}}
+export ES_JAVA_OPTS="{{cfg.runtime.es_java_opts}}"
+{{else ~}}
+export ES_JAVA_OPTS="${ES_JAVA_HEAP}"
+{{/if ~}}
+
+export ES_PATH_CONF="{{pkg.svc_config_path}}"
+
+# Clean up any elasticsearch temp dirs
+# this prevents the service from filling up /tmp if it's in a bootloop
+rmdir {{pkg.svc_path}}/tmp/elasticsearch.*
+# Create a temporary folder for Elastic Search ourselves.
+# Ref: https://github.com/elastic/elasticsearch/pull/27659
+export TMPDIR="{{pkg.svc_path_config_path}}/tmp"
+ES_TMPDIR=$(mktemp -d -t elasticsearch.XXXXXXXX)
+export ES_TMPDIR
+
+exec elasticsearch

--- a/opendistro-for-elasticsearch/plan.sh
+++ b/opendistro-for-elasticsearch/plan.sh
@@ -1,0 +1,95 @@
+ELASTICSEARCH_VERSION="6.5.4"
+ELASTICSEARCH_PKG_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz"
+ELASTICSEARCH_PKG_SHASUM="0943f434170567e6d780d24caca86d23710049599172a533f8140b2f659dd130"
+pkg_version=0.7.0.1
+pkg_name="opendistro-for-elasticsearch"
+pkg_description="An Apache 2.0-licensed distribution of Elasticsearch enhanced with enterprise security, alerting, SQL, and more"
+pkg_origin="core"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_upstream_url="https://github.com/opendistro-for-elasticsearch"
+pkg_build_deps=(
+  core/git
+  core/maven
+  core/zip
+)
+pkg_deps=(
+  core/busybox-static
+  core/coreutils
+  core/curl
+  core/glibc
+  core/openjdk11
+  core/openssl
+  core/procps-ng
+  core/ruby
+  core/zlib
+)
+
+pkg_bin_dirs=(bin)
+pkg_binds_optional=(
+  [elasticsearch]="http-port transport-port"
+)
+pkg_lib_dirs=(lib)
+pkg_exports=(
+  [http-port]=es_yaml.http.port
+  [transport-port]=es_yaml.transport.tcp.port
+)
+pkg_exposes=(http-port transport-port)
+
+OPENDISTRO_DEPENDENCIES=(
+  'security-parent'
+  'security-ssl'
+  'security-advanced-modules'
+  'security'
+)
+
+do_download() {
+  download_file "${ELASTICSEARCH_PKG_URL}" "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz" "${ELASTICSEARCH_PKG_SHASUM}"
+  for component in "${OPENDISTRO_DEPENDENCIES[@]}"; do
+    rm -rf "${HAB_CACHE_SRC_PATH:?}/${component}"
+    git clone \
+    --depth 1 \
+    --branch v${pkg_version} \
+    --config advice.detachedHead=false \
+    "https://github.com/opendistro-for-elasticsearch/${component}.git" "${HAB_CACHE_SRC_PATH}/${component}"
+  done
+}
+
+do_unpack() {
+  tar -xzf "${HAB_CACHE_SRC_PATH}/elasticsearch-oss-${ELASTICSEARCH_VERSION}.tar.gz" -C "${HAB_CACHE_SRC_PATH}/"
+}
+
+do_build() {
+  JAVA_HOME="$(pkg_path_for core/openjdk11)"
+  export JAVA_HOME
+
+  # Build dep packages and put them in a local maven repo
+  for component in "${OPENDISTRO_DEPENDENCIES[@]}"; do
+    pushd "${HAB_CACHE_SRC_PATH}/${component}" >/dev/null || exit 1
+    mvn compile -Dmaven.test.skip=true
+    mvn package -Dmaven.test.skip=true
+    mvn install -Dmaven.test.skip=true
+    popd || exit 1
+  done
+
+  # Build the opendistro_security plugin itself
+  pushd "${HAB_CACHE_SRC_PATH}"/security >/dev/null || exit 1
+  mvn compile -Dmaven.test.skip=true -P advanced
+  mvn package -Dmaven.test.skip=true -P advanced
+  mvn install -Dmaven.test.skip=true -P advanced
+  popd || exit 1
+}
+
+do_install() {
+  install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/README.textile" "${pkg_prefix}/README.textile"
+  install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/LICENSE.txt" "${pkg_prefix}/LICENSE.txt"
+  install -vDm644 "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/NOTICE.txt" "${pkg_prefix}/NOTICE.txt"
+
+  cp -a "${HAB_CACHE_SRC_PATH}/elasticsearch-${ELASTICSEARCH_VERSION}/"* "${pkg_prefix}/"
+
+  # Delete unused binaries to save space
+  rm "${pkg_prefix}/bin/"*.bat "${pkg_prefix}/bin/"*.exe
+
+  mkdir -p "${pkg_prefix}/plugins/opendistro_security"
+  unzip "${HAB_CACHE_SRC_PATH}/security/target/releases/opendistro_security-${pkg_version}.zip" -d "${pkg_prefix}/plugins/opendistro_security"
+}

--- a/opendistro-for-elasticsearch/tests/test.bats
+++ b/opendistro-for-elasticsearch/tests/test.bats
@@ -1,0 +1,31 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "opendistro-for-elasticsearch\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Open port 9200" {
+  result="$(netstat -peanut | grep java | grep 9200)"
+  [ $? -eq 0 ]
+}
+
+@test "Open port 9300" {
+  result="$(netstat -peanut | grep java | grep 9300)"
+  [ $? -eq 0 ]
+}
+
+@test "Correct plugin version" {
+  result="$(curl -sk https://admin:admin@0.0.0.0:9200/_cluster/stats | jq -r '.nodes.plugins[0].version')"
+  [ "${result}" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Using OSS distribution" {
+  result="$(curl -sk https://admin:admin@0.0.0.0:9200 | jq -r '.version.build_flavor')"
+  [ "${result}" = "oss" ]
+}
+
+@test "Service Healthcheck" {
+  local addr="$(netstat -lnp | grep 9200 | head -1 | awk '{print $4}')"
+  result="$(curl -sk https://admin:admin@0.0.0.0:9200/_cluster/health | jq -r '.status')"
+  [ "${result}" = "green" ]
+}

--- a/opendistro-for-elasticsearch/tests/test.sh
+++ b/opendistro-for-elasticsearch/tests/test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg install core/openjdk11
+hab pkg install core/curl --binlink
+hab pkg install core/jq-static --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+hab sup term
+sleep 5
+hab sup run &
+sleep 5
+hab svc load "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=60
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
This adds a brand new plan `opendistro-for-elasticsearch`, including a build of all of the opendistro plugins, and testing.

We've been using this plan at Chef in customer environments for running elasticsearch clusters, and it seems the right time to get it in core plans for wider usage in the community and to make it more official.

I've also spent time adding tests and docs, and bringing this up to our testing standard.

## Testing

```
hab studio build opendistro-for-elasticsearch
source results/last_build.env
hab studio run "./opendistro-for-elasticsearch/tests/test.sh ${pkg_ident}"
```

![tumblr_mmn0cwdolS1sq9klco1_500](https://user-images.githubusercontent.com/3253989/59406697-e84ab680-8d63-11e9-9f48-ce638b3dffd9.gif)
Signed-off-by: echohack <echohack@users.noreply.github.com>