### PR TITLE
[haproxy] Add Haproxy 2.0.0, Fix tests

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -513,15 +513,23 @@ paths = [
 [haproxy17]
 plan_path = "haproxy17"
 paths = [
-  "haproxy/*"
+  "haproxy/*",
+  "haproxy16/*"
 ]
 [haproxy18]
 plan_path = "haproxy18"
 paths = [
-  "haproxy/*"
+  "haproxy/*",
+  "haproxy16/*"
 ]
 [haproxy19]
 plan_path = "haproxy19"
+paths = [
+  "haproxy/*",
+  "haproxy16/*"
+]
+[haproxy20]
+plan_path = "haproxy20"
 paths = [
   "haproxy/*"
 ]

--- a/.bldr.toml
+++ b/.bldr.toml
@@ -508,25 +508,25 @@ plan_path = "haproxy"
 [haproxy16]
 plan_path = "haproxy16"
 paths = [
-  "haproxy/*"
+  "haproxy/*",
+  "haproxy19/*"
 ]
 [haproxy17]
 plan_path = "haproxy17"
 paths = [
   "haproxy/*",
-  "haproxy16/*"
+  "haproxy19/*"
 ]
 [haproxy18]
 plan_path = "haproxy18"
 paths = [
   "haproxy/*",
-  "haproxy16/*"
+  "haproxy19/*"
 ]
 [haproxy19]
 plan_path = "haproxy19"
 paths = [
-  "haproxy/*",
-  "haproxy16/*"
+  "haproxy/*"
 ]
 [haproxy20]
 plan_path = "haproxy20"

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=haproxy
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=1.9.8
+pkg_version=2.0.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
-pkg_source="https://www.haproxy.org/download/1.9/src/haproxy-${pkg_version}.tar.gz"
+pkg_source="https://www.haproxy.org/download/2.0/src/haproxy-${pkg_version}.tar.gz"
 pkg_upstream_url="https://www.haproxy.org/"
-pkg_shasum=2d9a3300dbd871bc35b743a83caaf50fecfbf06290610231ca2d334fd04c2aee
+pkg_shasum=fe0a0d69e1091066a91b8d39199c19af8748e0e872961c6fc43c91ec7a28ff20
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
 pkg_svc_user=root
 pkg_svc_group=root
@@ -38,7 +38,7 @@ do_build() {
   make \
     USE_PCRE=1 \
     USE_PCRE_JIT=1 \
-    TARGET=linux2628 \
+    TARGET=linux-glibc \
     USE_OPENSSL=1 \
     USE_ZLIB=1 \
     USE_GETADDRINFO=1 \

--- a/haproxy/tests/test.bats
+++ b/haproxy/tests/test.bats
@@ -8,7 +8,7 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Service is running" {
   echo -e "$(hab svc status)"
-  [ "$(hab svc status | grep "haproxy\.default" | awk '{print $4}' | grep up)" ]
+  [ "$(hab svc status | grep "haproxy[0-9]*\.default" | awk '{print $4}' | grep up)" ]
 }
 
 @test "Listening on port 80" {

--- a/haproxy16/plan.sh
+++ b/haproxy16/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy19/plan.sh"
 
 pkg_name=haproxy16
 pkg_origin=core
@@ -19,15 +19,3 @@ pkg_build_deps=(
   core/openssl
   core/zlib
 )
-
-do_build() {
-  make \
-    USE_PCRE=1 \
-    USE_PCRE_JIT=1 \
-    TARGET=linux2628 \
-    USE_OPENSSL=1 \
-    USE_ZLIB=1 \
-    USE_GETADDRINFO=1 \
-    ADDINC="${CFLAGS}" \
-    ADDLIB="${LDFLAGS}"
-}

--- a/haproxy17/plan.sh
+++ b/haproxy17/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy19/plan.sh"
 
 pkg_name=haproxy17
 pkg_origin=core

--- a/haproxy17/plan.sh
+++ b/haproxy17/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
 
 pkg_name=haproxy17
 pkg_origin=core
@@ -7,7 +7,7 @@ pkg_distname=haproxy
 pkg_version=1.7.11
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
-pkg_source=https://www.haproxy.org/download/1.7/src/${pkg_distname}-${pkg_version}.tar.gz
+pkg_source="https://www.haproxy.org/download/1.7/src/${pkg_distname}-${pkg_version}.tar.gz"
 pkg_shasum=d564b8e9429d1e8e13cb648bf4694926b472e36da1079df946bb732927b232ea
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_upstream_url="https://www.haproxy.org/"

--- a/haproxy18/plan.sh
+++ b/haproxy18/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
 
 pkg_name=haproxy18
 pkg_origin=core
@@ -7,7 +7,7 @@ pkg_distname=haproxy
 pkg_version=1.8.14
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
-pkg_source=https://www.haproxy.org/download/1.8/src/${pkg_distname}-${pkg_version}.tar.gz
+pkg_source="https://www.haproxy.org/download/1.8/src/${pkg_distname}-${pkg_version}.tar.gz"
 pkg_shasum=b17e402578be85e58af7a3eac99b1f675953bea9f67af2e964cf8bdbd1bd3fdf
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_upstream_url="https://www.haproxy.org/"

--- a/haproxy18/plan.sh
+++ b/haproxy18/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy19/plan.sh"
 
 pkg_name=haproxy18
 pkg_origin=core

--- a/haproxy19/plan.sh
+++ b/haproxy19/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
 
 pkg_name=haproxy19
 pkg_origin=core

--- a/haproxy19/plan.sh
+++ b/haproxy19/plan.sh
@@ -1,4 +1,4 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../haproxy16/plan.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
 
 pkg_name=haproxy19
 pkg_origin=core
@@ -20,3 +20,15 @@ pkg_build_deps=(
   core/zlib
   core/diffutils
 )
+
+do_build() {
+  make \
+    USE_PCRE=1 \
+    USE_PCRE_JIT=1 \
+    TARGET=linux2628 \
+    USE_OPENSSL=1 \
+    USE_ZLIB=1 \
+    USE_GETADDRINFO=1 \
+    ADDINC="${CFLAGS}" \
+    ADDLIB="${LDFLAGS}"
+}

--- a/haproxy20/README.md
+++ b/haproxy20/README.md
@@ -1,0 +1,71 @@
+# haproxy
+
+HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. It is particularly suited for very high traffic web sites and powers quite a number of the world's most visited ones.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+This is a service package that will be run by the Habitat supervisor.
+
+## Usage
+
+You can start the service with:
+
+```
+$ hab start core/haproxy19
+```
+
+And bind another Habitat service to it - see "Binding" below for more details.
+
+## Bindings
+
+Consuming services can bind to HAProxy via:
+
+```
+hab svc load core/haproxy19 --bind port:haproxy.default
+```
+
+## Topologies
+
+This plan currently only supports the standalone topology.
+
+### Standalone
+
+To run a standalone haproxy instance, run
+
+```
+hab sup run --topology standalone
+hab svc load core/haproxy19
+```
+
+The standalone topology is used by default by the habitat supervisor if none is specified.
+For more details on the standalone topology, see [the Habitat docs on standalone](https://www.habitat.sh/docs/using-habitat/#standalone).
+
+### Leader-Follower
+
+This plan does not make use of the leader/follower topology.
+
+Check out [the Habitat docs on Leader-Follower](https://www.habitat.sh/docs/using-habitat/#leader-follower-topology) for more details on what the leader-follower topology is and what it does.
+
+## Update Strategies
+
+The authors do not provide any recommendations for how to use update strategies with this package.
+
+Check out [the update strategy documentation](https://www.habitat.sh/docs/using-habitat/#update-strategy) for information on the strategies Habitat supports.
+
+### Configuration Updates
+
+Check out the [configuration update](https://www.habitat.sh/docs/using-habitat/#configuration-updates) documentation for more information on what configuration updates are and how they are executed.
+
+Take a look at the [default.toml](default.toml) for this package to see the configuration settings you can override.
+
+## Scaling
+
+This package does not currently support high availability on its own.
+
+## Monitoring
+
+This service can be monitored by making TCP connections to the configured port (default is 80)

--- a/haproxy20/config/haproxy.conf
+++ b/haproxy20/config/haproxy.conf
@@ -1,0 +1,34 @@
+global
+    maxconn {{cfg.maxconn}}
+
+defaults
+    mode {{cfg.front-end.mode}}
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend http-in
+    bind {{cfg.front-end.listen}}:{{cfg.front-end.port}}
+    default_backend default
+
+backend default
+{{#if cfg.httpchk}}
+    option httpchk {{cfg.httpchk}}
+{{~/if}}
+{{~#eachAlive bind.backend.members as |member|}}
+    server {{member.sys.ip}} {{member.sys.ip}}:{{member.cfg.port}}
+{{~/eachAlive}}
+
+{{#if cfg.status.enabled}}
+listen  stats
+    bind {{cfg.status.listen}}:{{cfg.status.port}}
+    mode            http
+    log             global
+    maxconn 10
+    stats enable
+    stats hide-version
+    stats refresh 30s
+    stats show-node
+    stats auth {{cfg.status.user}}:{{cfg.status.password}}
+    stats uri  {{cfg.status.uri}}
+{{~/if}}

--- a/haproxy20/default.toml
+++ b/haproxy20/default.toml
@@ -1,0 +1,15 @@
+maxconn = 32
+httpchk = "GET /"
+
+[front-end]
+listen = "*"
+port = 80
+mode = "http"
+
+[status]
+enabled = false
+listen = "*"
+port = 9000
+user = "admin"
+password = "password"
+uri = "/haproxy-stats"

--- a/haproxy20/plan.sh
+++ b/haproxy20/plan.sh
@@ -1,14 +1,14 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../haproxy/plan.sh"
 
-pkg_name=haproxy16
+pkg_name=haproxy20
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
 pkg_distname=haproxy
-pkg_version=1.6.14
+pkg_version=2.0.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
-pkg_source="https://www.haproxy.org/download/1.6/src/${pkg_distname}-${pkg_version}.tar.gz"
-pkg_shasum=bac949838a3a497221d1a9e937d60cba32156783a216146a524ce40675b6b828
+pkg_source="https://www.haproxy.org/download/2.0/src/${pkg_distname}-${pkg_version}.tar.gz"
+pkg_shasum=fe0a0d69e1091066a91b8d39199c19af8748e0e872961c6fc43c91ec7a28ff20
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_upstream_url="https://www.haproxy.org/"
 pkg_build_deps=(
@@ -18,16 +18,5 @@ pkg_build_deps=(
   core/make
   core/openssl
   core/zlib
+  core/diffutils
 )
-
-do_build() {
-  make \
-    USE_PCRE=1 \
-    USE_PCRE_JIT=1 \
-    TARGET=linux2628 \
-    USE_OPENSSL=1 \
-    USE_ZLIB=1 \
-    USE_GETADDRINFO=1 \
-    ADDINC="${CFLAGS}" \
-    ADDLIB="${LDFLAGS}"
-}

--- a/haproxy20/tests/test.sh
+++ b/haproxy20/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+TESTDIR="$(dirname "${0}")"
+"${TESTDIR}/../../haproxy/tests/test.sh" "$@"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Major version upgrade for Haproxy. Major difference in compilation is the target:

```
Target 'linux2628' was removed from HAProxy 2.0 due to being irrelevant and
often wrong. Please use 'linux-glibc' instead or define your custom target
by checking available options using 'make help TARGET=<your-target>'.
```

* Added haproxy20
* Update haproxy to 2.0.0
* Made haproxy1x source haproxy19 (for `TARGET=linux2628`)
* Updates to tests for any service/version number

### Testing

```
hab pkg build haproxy
source results/last_build.env
haproxy_pkg_ident="${pkg_ident}"
hab pkg build haproxy20
source results/last_build.env
haproxy20_pkg_ident="${pkg_ident}"
hab pkg build haproxy19
source results/last_build.env
haproxy19_pkg_ident="${pkg_ident}"
hab pkg build haproxy18
source results/last_build.env
haproxy18_pkg_ident="${pkg_ident}"
hab pkg build haproxy17
source results/last_build.env
haproxy17_pkg_ident="${pkg_ident}"
hab pkg build haproxy16
source results/last_build.env
haproxy16_pkg_ident="${pkg_ident}"

hab studio run "./haproxy/tests/test.sh ${haproxy_pkg_ident}"
hab studio run "./haproxy20/tests/test.sh ${haproxy20_pkg_ident}"
hab studio run "./haproxy19/tests/test.sh ${haproxy19_pkg_ident}"
hab studio run "./haproxy18/tests/test.sh ${haproxy18_pkg_ident}"
hab studio run "./haproxy17/tests/test.sh ${haproxy17_pkg_ident}"
hab studio run "./haproxy16/tests/test.sh ${haproxy16_pkg_ident}"
```

### Sample output

Full output:  https://gist.github.com/predominant/2d04f3bbc435d4d1ea67545d37eee884

Result only output:

```
 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy/2.0.0/20190617004043

---

 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy20/2.0.0/20190617004215

---

 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy19/1.9.8/20190617004338

---

 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy18/1.8.14/20190617004458

---

 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy17/1.7.11/20190617004603

---

 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
hab-sup(AG): Unloading rakops/haproxy16/1.6.14/20190617004655
```