### PR TITLE
[man-db] Fix missing runtime dependency

### DIFF
--- a/man-db/plan.sh
+++ b/man-db/plan.sh
@@ -13,6 +13,7 @@ pkg_deps=(
   core/groff
   core/gzip
   core/libiconv
+  core/libpipeline
 )
 pkg_build_deps=(
   core/coreutils

--- a/man-db/tests/test.bats
+++ b/man-db/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" man --version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec "${TEST_PKG_IDENT}" man --help
+  [ $status -eq 0 ]
+}

--- a/man-db/tests/test.sh
+++ b/man-db/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/man-db/2.7.5/20190430093433
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
## Description

This fixes an error due to a missing runtime dependency.

## Problem

```
[23][default:/hab/pkgs/core/man-db/2.7.5/20190115180532/bin:0]# ./man --help
man: error while loading shared libraries: libpipeline.so.1: cannot open shared object file: No such file or directory
[24][default:/hab/pkgs/core/man-db/2.7.5/20190115180532/bin:127]# ldd ./man
	linux-vdso.so.1 (0x00007ffcd6259000)
	libmandb-2.7.5.so => /hab/pkgs/core/man-db/2.7.5/20190115180532/lib/man-db/libmandb-2.7.5.so (0x00007fda041dc000)
	libman-2.7.5.so => /hab/pkgs/core/man-db/2.7.5/20190115180532/lib/man-db/libman-2.7.5.so (0x00007fda041b2000)
	libgdbm.so.6 => /hab/pkgs/core/gdbm/1.17/20190115012826/lib/libgdbm.so.6 (0x00007fda0419d000)
	libpipeline.so.1 => not found
	libiconv.so.2 => /hab/pkgs/core/libiconv/1.14/20190115155025/lib/libiconv.so.2 (0x00007fda040aa000)
	libc.so.6 => /hab/pkgs/core/glibc/2.27/20190115002733/lib/libc.so.6 (0x00007fda03ef0000)
	/hab/pkgs/core/glibc/2.27/20190115002733/lib/ld-linux-x86-64.so.2 => /hab/pkgs/core/glibc/2.27/20190115002733/lib64/ld-linux-x86-64.so.2 (0x00007fda041e6000)
```