### PR TITLE
[maven] update maven to 3.6.1

### DIFF
--- a/maven/plan.sh
+++ b/maven/plan.sh
@@ -1,19 +1,19 @@
 pkg_origin=core
 pkg_name=maven
-pkg_version=3.3.9
+pkg_version=3.6.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A software project management and comprehension tool"
 pkg_upstream_url="https://maven.apache.org/"
 pkg_license=("Apache-2.0")
 pkg_source=http://apache.cs.utah.edu/maven/maven-3/${pkg_version}/source/apache-maven-${pkg_version}-src.tar.gz
-pkg_shasum=9150475f509b23518e67a220a9d3a821648ab27550f4ece4d07b92b1fc5611bc
+pkg_shasum=025921fff6ba827a25413ffc08fb1933565eb1f07ee2d3f228911913ee4f3c3f
 pkg_dirname="apache-$pkg_name-$pkg_version"
 pkg_deps=(
   core/coreutils
   core/jdk8
   core/which
 )
-pkg_build_deps=(core/ant)
+pkg_build_deps=(core/maven/3.3.9)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 
@@ -24,7 +24,7 @@ do_prepare() {
 }
 
 do_build() {
-  ant -Dmaven.home="$pkg_prefix"
+  mvn -DdistributionTargetDir="$pkg_prefix" install
 }
 
 do_install() {

--- a/maven/plan.sh
+++ b/maven/plan.sh
@@ -13,7 +13,7 @@ pkg_deps=(
   core/jdk8
   core/which
 )
-pkg_build_deps=(core/maven/3.3.9)
+pkg_build_deps=(core/maven)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 

--- a/maven/tests/test.bats
+++ b/maven/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" mvn --version | head -n1 | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "mvn command" {
+  run hab pkg exec "${TEST_PKG_IDENT}" mvn --help
+  [ $status -eq 0 ]
+}

--- a/maven/tests/test.sh
+++ b/maven/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/tlog/6/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

![code_corgi](https://user-images.githubusercontent.com/3253989/59629810-84741500-90f8-11e9-9747-8fb5ef9cc13e.gif)

Until Maven 3.3, Maven core build could be boostrapped with an Ant build. This bootstrap has been removed in Maven 3.5: you need a pre-built Maven to build Maven from source.

Habitat makes this quite easy: We can just dep on a previous core/maven package.

[Release Notes](https://maven.apache.org/docs/3.6.1/release-notes.html)
[Release History](https://maven.apache.org/docs/history.html)

