### PR TITLE
Buildkite: add elasticsearch to buildkite resource blacklist

### DIFF
--- a/bin/ci/verify-pr-build.sh
+++ b/bin/ci/verify-pr-build.sh
@@ -5,6 +5,7 @@ set -u
 # Don't attempt to build the following plans. They have resource requirements
 # or build times that exceed the currently available resources on our CI
 # infrastructure.
+# See also: #2759 and #2065
 PLAN_BLACKLIST=(
  glibc
  gcc
@@ -19,6 +20,7 @@ PLAN_BLACKLIST=(
  kubernetes
  mongodb
  mysql
+ opendistro-for-elasticsearch
 )
 plan="$(basename "$1")"
 


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

When running elasticsearch builds through the new test workflow in Buildkite, we get out of resource errors:

```
opendistro-for-elasticsearch.default(O): [2019-06-17T22:25:25,746][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [unknown] uncaught exception in thread [main]
opendistro-for-elasticsearch.default(O): org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: failed to obtain node locks, tried [[/hab/svc/opendistro-for-elasticsearch/data/example-cluster]] with lock id [0]; maybe these locations are not writable or multiple nodes were started without increasing [node.max_local_storage_nodes] (was [1])?
```

We should temporarily remove these until Buildkite can handle spinning up Elasticsearch for running the full test suite.