### PR TITLE
[artifactory] [artifactory-pro] update to 6.10.4

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.10.3
+pkg_version=6.10.4
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=392610eeedd13a3eea8472bb3577776bd237f6637673da1df9732a4424cb7f89
+pkg_shasum=307053165f2e96d74182e1a75105b46f57ed49b625e53b43c84da6f6baabccbf
 pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port

--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.10.3
+pkg_version=6.10.4
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum=809b8227ec854d2dca789135a8d77df1dc6feaabc40875799cafc98c368fae59
+pkg_shasum=54e050667070edebe9fa0703a9cbecb8acb49cba8fe8998abc7c3193aff15621
 pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>
[Release Notes](https://www.jfrog.com/confluence/display/RTF/Release+Notes#ReleaseNotes-Artifactory6.10.4)

## Testing

```
hab pkg build artifactory
source results/last_build.env
hab studio run "./artifactory/tests/test.sh ${pkg_ident}"

hab pkg build artifactory-pro
source results/last_build.env
hab studio run "./artifactory-pro/tests/test.sh ${pkg_ident}"
```

![CDA8EDBF-A4AD-4EF4-9B48-F1F2C0E237E6](https://user-images.githubusercontent.com/3253989/59785098-d2178b80-9278-11e9-8dcc-9a53a4e59c8b.JPG)
![DEE353FB-BE9E-4B00-9856-DDFD6F0B5EFF](https://user-images.githubusercontent.com/3253989/59785099-d2b02200-9278-11e9-98c4-6540a1111ba1.JPG)

