### PR TITLE
[cyrus-sasl] add tests for cyrus-sasl

### DIFF
--- a/cyrus-sasl/tests/test.bats
+++ b/cyrus-sasl/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" saslauthd -v 2>&1 | head -n1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "saslauthd command" {
+  run hab pkg exec "${TEST_PKG_IDENT}" saslauthd -h 2>&1
+  [ $status -eq 0 ]
+}

--- a/cyrus-sasl/tests/test.sh
+++ b/cyrus-sasl/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/tlog/6/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
![tenor-132965506](https://user-images.githubusercontent.com/3253989/59793090-8bcb2800-928a-11e9-92b2-05d33146d3c5.gif)
Signed-off-by: echohack <echohack@users.noreply.github.com>

You can test with

```
hab pkg build cyrus-sasl
source results/last_build.env
hab studio run "./cyrus-sasl/tests/test.sh ${pkg_ident}"
```

Yes, for some reason cyrus-sasl outputs their helptext to stderr. It's not my fault I swear! 🗡 