### PR TITLE
Corrects build deps in attr, acl, coreutils, diffutils, gcc, gmp, lib…

### DIFF
--- a/acl/plan.sh
+++ b/acl/plan.sh
@@ -12,13 +12,11 @@ pkg_deps=(
   core/attr
 )
 pkg_build_deps=(
-  core/coreutils
   core/diffutils
   core/patch
   core/make
   core/file
   core/gcc
-  core/gettext
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)

--- a/attr/plan.sh
+++ b/attr/plan.sh
@@ -11,7 +11,6 @@ pkg_deps=(
   core/glibc
 )
 pkg_build_deps=(
-  core/coreutils
   core/diffutils
   core/make
   core/gcc

--- a/coreutils/plan.sh
+++ b/coreutils/plan.sh
@@ -20,14 +20,11 @@ pkg_deps=(
   core/libcap
 )
 pkg_build_deps=(
-  core/coreutils
-  core/diffutils
   core/patch
   core/make
   core/gcc
   core/m4
   core/perl
-  core/inetutils
 )
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/env)

--- a/diffutils/plan.sh
+++ b/diffutils/plan.sh
@@ -15,7 +15,6 @@ pkg_deps=(
 )
 pkg_build_deps=(
   core/coreutils
-  core/patch
   core/make
   core/gcc
   core/sed

--- a/gcc/plan.sh
+++ b/gcc/plan.sh
@@ -22,7 +22,6 @@ pkg_deps=(
   core/binutils
 )
 pkg_build_deps=(
-  core/coreutils
   core/diffutils
   core/patch
   core/file

--- a/gmp/plan.sh
+++ b/gmp/plan.sh
@@ -14,7 +14,6 @@ pkg_deps=(
   core/glibc
 )
 pkg_build_deps=(
-  core/coreutils
   core/diffutils
   core/patch
   core/make

--- a/libcap/plan.sh
+++ b/libcap/plan.sh
@@ -1,19 +1,17 @@
 pkg_name=libcap
 pkg_origin=core
-pkg_version=2.25
+pkg_version=2.27
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="POSIX 1003.1e capabilities."
 pkg_upstream_url="http://sites.google.com/site/fullycapable/"
 pkg_license=('gplv2')
 pkg_source="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="693c8ac51e983ee678205571ef272439d83afe62dd8e424ea14ad9790bc35162"
+pkg_shasum="dac1792d0118bee6aae6ba7fb93ff1602c6a9bda812fd63916eee1435b9c486a"
 pkg_deps=(
   core/glibc
   core/attr
 )
 pkg_build_deps=(
-  core/coreutils
-  core/diffutils
   core/patch
   core/make
   core/gcc

--- a/libmpc/plan.sh
+++ b/libmpc/plan.sh
@@ -18,8 +18,6 @@ pkg_deps=(
   core/mpfr
 )
 pkg_build_deps=(
-  core/coreutils
-  core/diffutils
   core/patch
   core/make
   core/gcc

--- a/linux-headers/plan.sh
+++ b/linux-headers/plan.sh
@@ -10,8 +10,6 @@ pkg_shasum="c098e2e4dcb64f8e3fb5cec35e872ff383edefa18532744ddf35bbba829cb5a3"
 pkg_dirname="linux-$pkg_version"
 pkg_deps=()
 pkg_build_deps=(
-  core/coreutils
-  core/diffutils
   core/patch
   core/make
   core/gcc

--- a/m4/plan.sh
+++ b/m4/plan.sh
@@ -16,8 +16,6 @@ pkg_deps=(
   core/glibc
 )
 pkg_build_deps=(
-  core/coreutils
-  core/diffutils
   core/patch
   core/make
   core/gcc


### PR DESCRIPTION
…cap, libmpc, linux-headers

this is the first batch of removing errant deps. In discussion with @smacfarlane, since there are going to be a lot of these we're batching them together to validate while the refresh work is occurring. 

For anyone curious about why these changes are necessary I'll explain:
Historically the "correctness" of the habitat build order has only existed because of tooling external to builder to validate our build order. This has been fine so far but as our package count increases the amount of effort to generate the graph hasn't been an issue (especially during the @eeyun/@smacfarlane human build-system days) but it's really not sustainable.

In builder, we are generating a graph as well. However builder has never taken build-deps or build-tdeps into account when generating the package graph. This hasn't been a problem either because we've supplemented builder with human effort that we have historically called a "core plans refresh".  

In the past month or so we've added support to builder for consuming and utilizing those build-deps and build-tdeps and our graph generation is now "correct". However, it brings with it some new concerns. First, there are around 100 cycles in the graph today that are inter-dependencies between probably 20-40 packages. SOME of these cycles are user error, others are cycles that _must_ exist. These PRs are focused on removing the cycles that only exist because of errant `pkg_build_deps` entries for packages that are unnecessary for various builds. We want to whittle down the number of cycles we have before we dive into the algorithmic work that is our graphing strategy. Thus why this PR now exists!

Signed-off-by: Ian Henry <ihenry@chef.io>