### PR TITLE
clean up unnecessary path

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1274,9 +1274,6 @@ plan_path = "rngd"
 plan_path = "rpm"
 [rpm2cpio]
 plan_path = "rpm2cpio"
-paths = [
-  "rpm2cpio/*"
-]
 [rq]
 plan_path = "rq"
 [rsync]


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This cleans up an unnecessary path from the .bldr.toml, just to make sure this common mistake doesn't get replicated.
![tenor-155293948](https://user-images.githubusercontent.com/3253989/59872994-e2e70080-934f-11e9-8205-367c63108f8a.gif)
