### PR TITLE
[artifactory] [artifactory-pro] Add API funtionality test

### DIFF
--- a/artifactory-pro/tests/helpers.bash
+++ b/artifactory-pro/tests/helpers.bash
@@ -11,14 +11,3 @@ test_listen() {
   nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
   return $?
 }
-
-wait_listen() {
-  local proto="-z"
-  if [ "${1}" == "udp" ]; then
-    proto="-u"
-  fi
-  local wait=${3:-1}
-  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
-    sleep 1
-  done
-}

--- a/artifactory-pro/tests/test.bats
+++ b/artifactory-pro/tests/test.bats
@@ -1,7 +1,13 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 load helpers
 
 @test "Port Listen TCP/8081" {
   test_listen tcp 8081
   [ "$?" -eq 0 ]
+}
+
+@test "API is functional" {
+  local addr="$(netstat -lnp | grep 8081 | head -1 | awk '{print $4}')"
+  result="$(curl -s http://${addr}/artifactory/api/repositories | jq -r '.[].key')"
+  [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory-pro/tests/test.bats
+++ b/artifactory-pro/tests/test.bats
@@ -7,7 +7,6 @@ load helpers
 }
 
 @test "API is functional" {
-  local addr="$(netstat -lnp | grep 8081 | head -1 | awk '{print $4}')"
-  result="$(curl -s http://${addr}/artifactory/api/repositories | jq -r '.[].key')"
+  result="$(curl -s http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
   [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory-pro/tests/test.sh
+++ b/artifactory-pro/tests/test.sh
@@ -19,20 +19,14 @@ export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static nc
-hab pkg binlink core/busybox-static netstat
 hab pkg install core/curl --binlink
 hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
-
-hab sup term
 hab sup run &
+sleep 5
 echo "Waiting for supervisor to start"
-wait_listen tcp 9632 30
-
 hab svc load "${TEST_PKG_IDENT}"
-
 echo "Waiting for Artifactory to start"
-wait_listen tcp 8081 90
 sleep 60
 
 bats "${TESTDIR}/test.bats"

--- a/artifactory-pro/tests/test.sh
+++ b/artifactory-pro/tests/test.sh
@@ -19,6 +19,9 @@ export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg install core/curl --binlink
+hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
 hab sup term
@@ -28,9 +31,9 @@ wait_listen tcp 9632 30
 
 hab svc load "${TEST_PKG_IDENT}"
 
-# Wait for 30 seconds on first check, to ensure service is up.
 echo "Waiting for Artifactory to start"
 wait_listen tcp 8081 90
+sleep 60
 
 bats "${TESTDIR}/test.bats"
 

--- a/artifactory/tests/helpers.bash
+++ b/artifactory/tests/helpers.bash
@@ -11,14 +11,3 @@ test_listen() {
   nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"
   return $?
 }
-
-wait_listen() {
-  local proto="-z"
-  if [ "${1}" == "udp" ]; then
-    proto="-u"
-  fi
-  local wait=${3:-1}
-  while ! nc "${proto}" -w"${wait}" 127.0.0.1 "${2}"; do
-    sleep 1
-  done
-}

--- a/artifactory/tests/test.bats
+++ b/artifactory/tests/test.bats
@@ -1,7 +1,13 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 load helpers
 
 @test "Port Listen TCP/8081" {
   test_listen tcp 8081
   [ "$?" -eq 0 ]
+}
+
+@test "API is functional" {
+  local addr="$(netstat -lnp | grep 8081 | head -1 | awk '{print $4}')"
+  result="$(curl -s http://${addr}/artifactory/api/repositories | jq -r '.[].key')"
+  [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory/tests/test.bats
+++ b/artifactory/tests/test.bats
@@ -7,7 +7,6 @@ load helpers
 }
 
 @test "API is functional" {
-  local addr="$(netstat -lnp | grep 8081 | head -1 | awk '{print $4}')"
-  result="$(curl -s http://${addr}/artifactory/api/repositories | jq -r '.[].key')"
+  result="$(curl -s http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
   [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory/tests/test.sh
+++ b/artifactory/tests/test.sh
@@ -8,7 +8,7 @@ set -eou pipefail
 
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
-	exit 1
+  exit 1
 fi
 
 TESTDIR="$(dirname "${0}")"
@@ -19,6 +19,9 @@ export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg install core/curl --binlink
+hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
 hab sup term
@@ -28,9 +31,9 @@ wait_listen tcp 9632 30
 
 hab svc load "${TEST_PKG_IDENT}"
 
-# Wait for 30 seconds on first check, to ensure service is up.
 echo "Waiting for Artifactory to start"
 wait_listen tcp 8081 90
+sleep 60
 
 bats "${TESTDIR}/test.bats"
 

--- a/artifactory/tests/test.sh
+++ b/artifactory/tests/test.sh
@@ -23,17 +23,12 @@ hab pkg binlink core/busybox-static netstat
 hab pkg install core/curl --binlink
 hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
-
-hab sup term
 hab sup run &
+sleep 5
 echo "Waiting for supervisor to start"
-wait_listen tcp 9632 30
-
 hab svc load "${TEST_PKG_IDENT}"
-
 echo "Waiting for Artifactory to start"
-wait_listen tcp 8081 90
-sleep 60
+sleep 90
 
 bats "${TESTDIR}/test.bats"
 


### PR DESCRIPTION

![its_not_fine_op](https://user-images.githubusercontent.com/3253989/60053170-08477780-968c-11e9-90dd-03996780d400.gif)
Signed-off-by: echohack <echohack@users.noreply.github.com>

I wanted to add a test that actually hit the API. It looks like this endpoint is the only good one to really hit that is unauthenticated. Unfortunately there isn't any version information that we can compare to -- all of that is behind auth.

I will mention that while writing this, I ran into some weird errors with jq because the Artifactory service wasn't finished yet -- so I added a sleep in, which takes care of the problem.

In other words, this test *does* test something very different than just seeing if the port is available for service. I still think the port test is valuable though, because it gives a fine grain view into what exactly might be failing with the starting service.