### PR TITLE
[jq-static] Update to jq 1.6 and add tests

### DIFF
--- a/jq-static/plan.ps1
+++ b/jq-static/plan.ps1
@@ -6,7 +6,7 @@ $pkg_license=@("MIT")
 $pkg_upstream_url="https://stedolan.github.io/jq/"
 $pkg_description="jq is a lightweight and flexible command-line JSON processor."
 $pkg_source="https://github.com/stedolan/jq/releases/download/jq-$pkg_version/jq-win64.exe"
-$pkg_shasum="ebecd840ba47efbf66822868178cc721a151060937f7ac406e3d31bd015bde94"
+$pkg_shasum="a51d36968dcbdeabb3142c6f5cf9b401a65dc3a095f3144bd0c118d5bb192753"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack { }

--- a/jq-static/plan.ps1
+++ b/jq-static/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="jq-static"
 $pkg_origin="core"
-$pkg_version="1.5"
+$pkg_version="1.6"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("MIT")
 $pkg_upstream_url="https://stedolan.github.io/jq/"

--- a/jq-static/plan.sh
+++ b/jq-static/plan.sh
@@ -1,15 +1,18 @@
 pkg_name=jq-static
 pkg_distname=jq
 pkg_origin=core
-pkg_version=1.5
+pkg_version=1.6
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/stedolan/$pkg_distname/releases/download/${pkg_distname}-${pkg_version}/jq-linux64"
 pkg_upstream_url="https://stedolan.github.io/jq/"
 pkg_description="jq is a lightweight and flexible command-line JSON processor."
-pkg_shasum=c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+pkg_shasum=af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44
 pkg_deps=()
-pkg_build_deps=(core/coreutils core/wget)
+pkg_build_deps=(
+  core/coreutils
+  core/wget
+)
 pkg_bin_dirs=(bin)
 
 do_unpack() {

--- a/jq-static/tests/test.bats
+++ b/jq-static/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" jq --version | cut -c 4-)"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/jq-static/tests/test.pester.ps1
+++ b/jq-static/tests/test.pester.ps1
@@ -1,0 +1,14 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "jq-static bin" {
+    Context "jq-static" {
+        It "has expected version" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier jq --version
+            $output | Out-String | Should -Match "jq-${expected_version}"
+        }
+    }
+}

--- a/jq-static/tests/test.ps1
+++ b/jq-static/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/jq-static/tests/test.sh
+++ b/jq-static/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/tlog/6/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"

--- a/jq-static/tests/test.sh
+++ b/jq-static/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #/ Usage: test.sh <pkg_ident>
 #/
-#/ Example: test.sh core/tlog/6/20181108151533
+#/ Example: test.sh origin/package/1.2.3/20181108151533
 #/
 
 set -euo pipefail


### PR DESCRIPTION
![cat_computer](https://user-images.githubusercontent.com/3253989/60059803-d5f54480-96a2-11e9-93cd-a869848e582b.gif)

[Release Notes](https://github.com/stedolan/jq/releases)

## Testing

Linux
```
hab pkg build jq-static
source results/last_build.env
hab studio run "./jq-static/tests/test.sh ${pkg_ident}"
```

Windows
```
hab pkg build jq-static
. results/last_build.ps1
hab studio run "./jq-static/tests/test.ps1 ${pkg_ident}"
```