### PR TITLE
[terraform] Update terraform to 0.12.3

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.12.2
+pkg_version=0.12.3
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
 pkg_filename="${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=d9a96b646420d7f0a80aa5d51bb7b2a125acead537ab13c635f76668de9b8e32
+pkg_shasum=75e4323b8514074f8c2118ea382fc677c8b1d1730eda323ada222e0fac57f7db
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)
@@ -15,7 +15,7 @@ pkg_bin_dirs=(bin)
 # The pkg_filename does not extract into a folder. We need to force it.
 do_unpack() {
   cd "${HAB_CACHE_SRC_PATH}" || exit
-  unzip "${pkg_filename}" -d "${pkg_name}-${pkg_version}"
+  unzip "${pkg_filename}" -d "${pkg_dirname}"
 }
 
 do_build() {


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build terraform
source results/last_build.env
hab studio run "./terraform/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```