### PR TITLE
[elixir] Update elixir to 1.9.0, update tests

### DIFF
--- a/elixir/plan.sh
+++ b/elixir/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=elixir
-pkg_version=1.8.0
+pkg_version=1.9.0
 pkg_description="A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain."
 pkg_upstream_url=http://elixir-lang.org
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/elixir-lang/elixir/archive/v${pkg_version}.tar.gz"
-pkg_shasum=fe896d8b2914f982d2e6fceeb585f59a8f92ad872653fc46c13df9ff86d69234
+pkg_shasum=dbf4cb66634e22d60fe4aa162946c992257f700c7db123212e7e29d1c0b0c487
 pkg_deps=(
   core/busybox
   core/cacerts

--- a/elixir/tests/test.bats
+++ b/elixir/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(elixir --version | tail -1 | awk '{print $2}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} elixir --version | tail -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Trivial Elixir code tests" {
-  run elixir -e "is_atom :ok"
+  run hab pkg exec ${TEST_PKG_IDENT} elixir -e "is_atom :ok"
   [ $status -eq 0 ]
 }

--- a/elixir/tests/test.sh
+++ b/elixir/tests/test.sh
@@ -1,23 +1,19 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-hab pkg install core/erlang --binlink
-
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/elixir-lang/elixir/blob/v1.9/CHANGELOG.md)

### Testing

```
hab pkg build elixir
source results/last_build.env
hab studio run "./elixir/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Trivial Elixir code tests

2 tests, 0 failures
```