### PR TITLE
[docs] Add 'Testing' section to README template

### DIFF
--- a/README_TEMPLATE_FOR_PLANS.md
+++ b/README_TEMPLATE_FOR_PLANS.md
@@ -18,6 +18,10 @@ A binary package is something that packages up a standalone binary, something th
 
 How would a user use this package?  i.e. can a user simply call the package as a dependency of their application?  Or is there more they need to do?
 
+## Testing
+
+To run tests follow the example in the latest [test standards document](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md).
+
 ## Bindings
 
 *(This is only required for service packages, not [binary wrapper packages](https://www.habitat.sh/docs/best-practices/#binary-wrapper-packages)))*

--- a/docs/dev/policy_documents/standards-for-tests.md
+++ b/docs/dev/policy_documents/standards-for-tests.md
@@ -75,7 +75,12 @@ There should be no negative downstream impacts. Builder will continue to build n
 
 ### Example - 7Zip
 
-7Zip is used as an example because it has both Linux and Windows tests. Note that the plan builds different executables for Linux and Windows and therefore the tests differ.
+7Zip is used as an example because it has both Linux and Windows tests.
+
+Note that:
+
+* the plan builds different executables for Linux and Windows and therefore the tests differ.
+* the 7Zip README contains a "Testing" section according to the [readme template here](https://github.com/habitat-sh/core-plans/blob/master/README_TEMPLATE_FOR_PLANS.md).
 
 #### Windows/Pester tests
 


### PR DESCRIPTION
### Outstanding Tasks:
- [ ] Waiting on comments and or approval

### Context

Given the [testing standard](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md) has been defined for unit testing the linux and windows core-plans

This [issue](https://github.com/habitat-sh/core-plans/issues/2678) raised concern about duplicating the test instructions in each README and proposed that each README reference a single common document.  This PR is an attempt to standardize this approach.