### PR TITLE
[nginx] Update nginx to 1.17.1, update linux based tests

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.15.12"
+$pkg_version="1.17.1"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="adfec885ad35d02482e839e60a6a95948070de904de17ceb605bc03b0849c63e"
+$pkg_shasum="ef537959fbe10a1f138246e0a7c4e82ce97195ef058e851335d350f3d9562673"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.16.0
+pkg_version=1.17.1
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=4fd376bad78797e7f18094a00f0f1088259326436b537eb5af69b01be2ca1345
+pkg_shasum=6f1825b4514e601579986035783769c456b888d3facbab78881ed9b58467e73e
 pkg_deps=(
   core/glibc
   core/libedit
@@ -32,7 +32,8 @@ pkg_exports=(
 pkg_exposes=(port)
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" \
+  ./configure \
+    --prefix="${pkg_prefix}" \
     --conf-path="${pkg_svc_config_path}/nginx.conf" \
     --sbin-path="${pkg_prefix}/bin/nginx" \
     --pid-path="${pkg_svc_var_path}/nginx.pid" \

--- a/nginx/tests/test.bats
+++ b/nginx/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v nginx)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(nginx -v 2>&1 | awk -F'/' '{print $2}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} nginx -v 2>&1 | awk -F'/' '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run nginx -h
+  run hab pkg exec ${TEST_PKG_IDENT} nginx -h
   [ $status -eq 0 ]
 }
 

--- a/nginx/tests/test.sh
+++ b/nginx/tests/test.sh
@@ -1,33 +1,35 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
-hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static wc
-hab pkg binlink core/busybox-static uniq
-
-source "${PLANDIR}/plan.sh"
-# Unload the service if its already loaded.
-hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 5
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+hab sup term
+hab sup run &
+sleep 5
+
+hab svc load "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build nginx
source results/last_build.env
hab studio run "./nginx/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

6 tests, 0 failures
```