### PR TITLE
[openresty] Update openresty to 1.15.8.1, add tests

### DIFF
--- a/openresty/plan.sh
+++ b/openresty/plan.sh
@@ -1,16 +1,35 @@
 pkg_name=openresty
 pkg_origin=core
-pkg_version=1.13.6.2
+pkg_version=1.15.8.1
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://openresty.org/download/${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942
-pkg_deps=(core/glibc core/gcc-libs core/libxml2 core/libxslt core/zlib core/bzip2 core/openssl core/pcre core/coreutils core/perl core/which)
-pkg_build_deps=(core/gcc core/make)
+pkg_shasum=89a1238ca177692d6903c0adbea5bdf2a0b82c383662a73c03ebf5ef9f570842
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/libxml2
+  core/libxslt
+  core/zlib
+  core/bzip2
+  core/openssl
+  core/pcre
+  core/coreutils
+  core/perl
+  core/which
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin nginx/sbin luajit/bin)
+pkg_bin_dirs=(
+  bin
+  nginx/sbin
+  luajit/bin
+)
 pkg_include_dirs=(include)
 pkg_svc_user="root"
 pkg_exports=(
@@ -27,7 +46,8 @@ do_prepare() {
 }
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" \
+  ./configure \
+    --prefix="${pkg_prefix}" \
     --user=hab \
     --group=hab \
     --http-log-path=/dev/stdout \

--- a/openresty/tests/test.bats
+++ b/openresty/tests/test.bats
@@ -1,0 +1,15 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} openresty -v 2>&1 | head -n 1 | awk -F'/' '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "openresty[0-9]*\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 80" {
+  result="$(netstat -peanut | grep nginx | awk '{print $4}' | awk -F':' '{print $2}')"
+  [ "${result}" -eq 80 ]
+}

--- a/openresty/tests/test.sh
+++ b/openresty/tests/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg install "${TEST_PKG_IDENT}"
+
+hab sup term
+hab sup run &
+sleep 5
+
+hab svc load "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build openresty
source results/last_build.env
hab studio run "./openresty/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
```