### PR TITLE
[envconsul] Update envconsul to 0.8.0, add trivial tests

### DIFF
--- a/envconsul/plan.sh
+++ b/envconsul/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=envconsul
 pkg_origin=core
-pkg_version=0.7.3
-pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_version=0.8.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MPL-2.0")
 pkg_description="Launch a subprocess with environment variables using data from @HashiCorp Consul and Vault."
 pkg_upstream_url=https://github.com/hashicorp/envconsul
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="67ed44cb254da24ca5156ada6d04e3cfeba248ca0c50a5ddd42282cbafde80bc"
+pkg_shasum="d8b07773407e45480ce1b4e440d87c0d776afa49099a5f43a88510ef0c20c523"
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)

--- a/envconsul/tests/test.bats
+++ b/envconsul/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} envconsul -version 2>&1 | head -1 | awk '{print $2}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} envconsul -help
+  [ $status -eq 0 ]
+}

--- a/envconsul/tests/test.sh
+++ b/envconsul/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build envconsul
source results/last_build.env
hab studio run "/envconsul/tests/test.sh
```

### Sample output
```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```