### PR TITLE
[metricbeat] Update metricbeat to 7.2.0

### DIFF
--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=metricbeat
 pkg_origin=core
-pkg_version=7.1.1
+pkg_version=7.2.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build metricbeat
source results/last_build.env
hab studio run "./metricbeat/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process

4 tests, 0 failures
```