### PR TITLE
[artifactory-pro] update to artifactory-pro-6.11.0

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.10.4
+pkg_version=6.11.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=307053165f2e96d74182e1a75105b46f57ed49b625e53b43c84da6f6baabccbf
+pkg_shasum=c615d2bf465ea65d172c8fd84375d4ff212e27c4111462275e0895c0c176f969
 pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

[Release Notes](https://www.jfrog.com/confluence/display/RTF/Release+Notes#ReleaseNotes-Artifactory6.11)

## Testing

```
hab pkg build artifactory-pro
source ./results/last_build.env
hab studio run "./artifactory-pro/tests/test.sh ${pkg_ident}"
```