### PR TITLE
[zlib] Add tests to zlib (base plan refresh)

### DIFF
--- a/zlib/tests/test.bats
+++ b/zlib/tests/test.bats
@@ -1,0 +1,3 @@
+@test "libz.so exists" {
+  [ -f "/hab/pkgs/$TEST_PKG_IDENT/lib/libz.so" ]
+}

--- a/zlib/tests/test.sh
+++ b/zlib/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install --binlink core/bats
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
There is no new version of zlib available. So for the purposes of the base plan refresh; I have just added tests for the existing plan.