### PR TITLE
[7zip] Replace '[[' in test.bats

### DIFF
--- a/7zip/README.md
+++ b/7zip/README.md
@@ -27,22 +27,3 @@ On Linux you can do the same, or binlink and use the command directly:
 hab pkg install core/7zip --binlink
 7z --help
 ```
-
-# Testing
-
-For the linux plan:
-
-```bash
-hab pkg build 7zip
-source ./results/last_build.env
-hab studio run "./7zip/tests/test.sh $pkg_ident"
-```
-
-For the windows plan:
-
-```powershell
-hab pkg build 7zip
-. .\results\last_build.ps1
-hab studio run -D "hab pkg install results/$pkg_artifact"
-hab studio run -D "& 7zip/tests/test.ps1 $pkg_ident"
-```

--- a/7zip/tests/test.bats
+++ b/7zip/tests/test.bats
@@ -5,8 +5,8 @@ expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
 }
 
 @test "7z exe output mentions expected version $expected_version" {
-  run hab pkg exec $TEST_PKG_IDENT 7z
-  [[ "$output" =~ 7-Zip\ \[64\]\ $expected_version ]]
+   run hab pkg exec "${TEST_PKG_IDENT}" 7z
+   grep -Eo "7-Zip \[64\] $expected_version" <<< "${output}"
 }
 
 @test "7za exe runs" {
@@ -15,6 +15,6 @@ expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
 }
 
 @test "7za exe output mentions expected version $expected_version" {
-  run hab pkg exec $TEST_PKG_IDENT 7za
-  [[ "$output" =~ 7-Zip\ \(a\)\ \[64\]\ $expected_version ]]
+   run hab pkg exec "${TEST_PKG_IDENT}" 7za
+   grep -Eo "7-Zip \(a\) \[64\] $expected_version"  <<< "${output}"
 }


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting for approval and merge

### Context
Raising this PR against 7zip:
* to remove the double-brackets from tests.bats according to issue #2716
* to update the README with a link to testing standards document

### Completed Tasks
- [x] Replaced '[[' in tests with grep equivalent
- [x] Reverted testing section from README
- [x] Fixed according to comments; squashed commits