### PR TITLE
[openssl] Add windows and linux tests to core/openssl

### DIFF
--- a/openssl/tests/test.bats
+++ b/openssl/tests/test.bats
@@ -1,0 +1,10 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" openssl version | awk '{print $1,$2}')"
+  diff <( echo "$actual_version" ) <( echo "OpenSSL ${TEST_PKG_VERSION}-fips" )
+}
+
+@test "Encodes successfully" {
+  actual="$(echo "a_byte_character" | hab pkg exec "${TEST_PKG_IDENT}" openssl enc -base64)"
+  diff <( echo "$actual" ) <( echo "YV9ieXRlX2NoYXJhY3Rlcgo=" )
+}

--- a/openssl/tests/test.pester.ps1
+++ b/openssl/tests/test.pester.ps1
@@ -1,0 +1,20 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/openssl" {
+    Context "openssl" {
+        $OutputVariable = (hab pkg exec $PackageIdentifier openssl version | Out-String).Trim()
+        $OutputVariable -match "(?<=^OpenSSL )([^ ]*)"
+        It "returns version that matches the plan" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+
+        $OutputVariable = ("a_byte_character" | hab pkg exec $PackageIdentifier openssl enc -base64| Out-String).Trim()
+        It "returns correct encoded string" {
+            "$OutputVariable" | Should -BeExactly "YV9ieXRlX2NoYXJhY3Rlcg0K"
+        }
+    }
+}

--- a/openssl/tests/test.ps1
+++ b/openssl/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/openssl/tests/test.sh
+++ b/openssl/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [x] Close this PR and open a new one #2917 based off the refresh/2019q3 branch.

### Context
Tests have been added for both windows and linux.  The linux ones pass.  Doing:

```bash
hab pkg build openssl
source ./results/last_build.env
hab studio run "./openssl/tests/test.sh $pkg_ident"
```

produces

```bash
1..2
ok 1 Version matches plan
ok 2 Encodes successfully
```

However, the windows openssl doesn't return any stdout even though the build completes without error.  See [issue for core/openssl on windows](https://github.com/habitat-sh/core-plans/issues/2739)

The windows tests have been added in this PR and, in theory, could be used to validate the openssl build.

### Completed Tasks
- [x] Verify with windows tests that [Mark Wrock's plan.ps1 updates](https://github.com/habitat-sh/core-plans/pull/2745) work.
- [x] Remove README test section addition
- [x] Wait for blocker by Mark Wrock's PR https://github.com/habitat-sh/core-plans/pull/2745 to be approved and merged
- [x] Rebuild and verify powershell tests
- [x] Squash commits