### PR TITLE
[bzip2] Add windows and linux tests to core/bzip2

### DIFF
--- a/bzip2/tests/test.bats
+++ b/bzip2/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" bzip2 --help 2>&1 | grep -oP '(?<=Version )([^,]*)')"
+  diff <( echo "${actual_version}" ) <( echo "${TEST_PKG_VERSION}" )
+}

--- a/bzip2/tests/test.pester.ps1
+++ b/bzip2/tests/test.pester.ps1
@@ -1,0 +1,15 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/bzip2" {
+    Context "bzip2" {
+        $OutputVariable = (hab pkg exec $pkg_ident bzip2 --help *>&1 | Out-String)
+        $OutputVariable -match "(?<=Version )([^,]*)"
+        It "returns --version that matches the plan" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/bzip2/tests/test.ps1
+++ b/bzip2/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/bzip2/tests/test.sh
+++ b/bzip2/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Close this PR and open a new one off the refresh/2019q3 branch.
- [ ] Cherry pick into the new refresh PR Matt Wrock's fix, which in master but not yet the refresh brach, ``git cherry-pick ec3db147a058669b40f944a15db4afcb528511b5``.  Otherwise the windows build/test will fail.
- [ ] Ensure get correct source (see chef omnibus software repo) for this (current one was an alternate because main DNS was down)
- [ ] Check for latest version
- [ ] Waiting for approval and merge

### Context
Tests have been added for both windows and linux.  The linux ones pass.  Doing:

```bash
hab pkg build bzip2
source ./results/last_build.env
hab studio run "./bzip2/tests/test.sh $pkg_ident"
```

produces

```bash
 ✓ Version matches plan

1 test, 0 failures
```

However, the windows bzip2 doesn't return any stdout even though the build completes without error.  See [openssl,bzip2 issue](https://github.com/habitat-sh/core-plans/issues/2739)

### Completed Tasks
- [x] Replace the hard-coded version check in the test with a regex.
  - [x] Successfully populated a variable with ``bzip2 --help`` output by re-directing all output streams ``*>&1`` rather than only the "Error" one ``2>&1``.  See [here](https://github.com/habitat-sh/core-plans/pull/2745#issuecomment-507433390) for discussing with Matt Wrock.
- [x] Verified core/bzip2 output in pester tests.
- [x] Remove README addition
- [x] Squash all commits and then move back to 'blocked' column
- [x] Verified [Mark Wrock's PR](https://github.com/habitat-sh/core-plans/pull/2745).
- [x] Update this PR from 'draft' to 'ready for review'.