### PR TITLE
[dsc-core] do not fail on config without resources and add tests

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -265,6 +265,8 @@ plan_path = "dri2proto"
 plan_path = "drupal"
 [drush]
 plan_path = "drush"
+[dsc-core]
+plan_path = "dsc-core"
 [e2fsprogs]
 plan_path = "e2fsprogs"
 [ed]

--- a/dsc-core/README.md
+++ b/dsc-core/README.md
@@ -81,3 +81,11 @@ You can work around this by explicitly importing the module before using the com
 Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
 Start-DscCore (Join-Path {{pkg.svc_config_path}} firewall.ps1) NewFirewallRule
 ```
+
+# Testing
+
+```
+hab pkg build dsc-core
+. .\results\last_build.ps1
+hab studio run -D "hab pkg install results/$pkg_artifact;& dsc-core/tests/test.ps1 $pkg_ident"
+```

--- a/dsc-core/tests/test.pester.ps1
+++ b/dsc-core/tests/test.pester.ps1
@@ -1,0 +1,21 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "dsc-core" {
+    Import-Module "$(hab pkg path $PackageIdentifier)\Modules\DscCore"
+    Context "Apply Configuration with file resource" {
+        It "creates the directory" {
+            Start-DscCore (Join-Path $PSScriptRoot test_config.ps1) test_with_resource
+            "c:\test_directory" | Should exist
+            $? | Should be $true
+        }
+    }
+    Context "Apply Configuration without resource" {
+        It "runs without error" {
+            Start-DscCore (Join-Path $PSScriptRoot test_config.ps1) test_without_resource
+            $? | Should be $true
+        }
+    }
+}

--- a/dsc-core/tests/test.ps1
+++ b/dsc-core/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/dsc-core/tests/test_config.ps1
+++ b/dsc-core/tests/test_config.ps1
@@ -1,0 +1,20 @@
+Configuration test_with_resource
+{
+    Node 'localhost'
+    {
+        File test_directory
+        {
+            Type = 'Directory'
+            DestinationPath = 'C:\test_directory'
+            Ensure = 'Present'
+        }
+    }
+}
+
+Configuration test_without_resource
+{
+    Node 'localhost'
+    {
+
+    }
+}


### PR DESCRIPTION
Someone mentioned that they have powershell conditionals in their dsc configuration that could possibly remove a configuration:

```
Configuration dummy_directory
{
  $something = $false

  if ($something -eq $true){
    Node 'localhost'
    {
      File dummy_directory
      {
        Type = 'Directory'
        DestinationPath = 'C:\temp\a_dummy_test_path'
        Ensure = 'Absent'
      }
    }
  }
}
```

This fails with a horrific error:
```
2019-06-26 11:56:50,066 - myapp.default(O): Compiling DSC mof for dummy_directory ...
2019-06-26 11:56:50,770 - myapp.default(E): Invoke-Command : Cannot bind argument to parameter 'Path' because it is null.
2019-06-26 11:56:50,770 - myapp.default(E): At C:\hab\pkgs\core\dsc-core\0.2.1\20180919112142\Modules\DscCore\DSCCore.psm1:104 char:9
2019-06-26 11:56:50,770 - myapp.default(E): +         Invoke-Command -ScriptBlock $block
2019-06-26 11:56:50,770 - myapp.default(E): +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2019-06-26 11:56:50,770 - myapp.default(E): + CategoryInfo          : InvalidData: (:) [Invoke-Command], ParameterBindingValidationException
2019-06-26 11:56:50,770 - myapp.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.InvokeCommandCommand
```

The fact is that compiling a configuration with no resources produces no MOF which in not handled in the module gets the above error.

This causes such a configuration to emit a warning but no error.

This PR also adds a couple sanity tests inspired by recent work in 7zip - LOVE THIS!

Signed-off-by: mwrock <matt@mattwrock.com>