### PR TITLE
[perl] Add windows and linux tests to core/perl

### DIFF
--- a/perl/README.md
+++ b/perl/README.md
@@ -11,3 +11,7 @@ Binary package
 ## Usage
 
 *TODO: Add instructions for usage*
+
+## Testing
+
+To run tests follow the example in the latest [test standards document](https://github.com/habitat-sh/core-plans/blob/master/docs/dev/policy_documents/standards-for-tests.md).

--- a/perl/tests/test.bats
+++ b/perl/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" perl --version | grep 'This is perl' | grep -oP '(?<=\(v)([^\)]*)' )"
+  diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
+}

--- a/perl/tests/test.bats
+++ b/perl/tests/test.bats
@@ -1,5 +1,5 @@
 @test "Version matches plan" {
   TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
-  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" perl --version | grep 'This is perl' | grep -oP '(?<=\(v)([^\)]*)' )"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" perl --version | grep 'This is perl' | grep -oP '(?<=\(v)(.*?)(?=\) built for x86_64-linux-thread-multi)')"
   diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
 }

--- a/perl/tests/test.pester.ps1
+++ b/perl/tests/test.pester.ps1
@@ -1,0 +1,14 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/perl" {
+    Context "perl" {
+        $OutputVariable = (hab pkg exec $PackageIdentifier perl --version | Out-String).split(' ')
+        It "returns --version that matches the plan" {
+            "$OutputVariable" | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/perl/tests/test.pester.ps1
+++ b/perl/tests/test.pester.ps1
@@ -6,9 +6,10 @@ param (
 $PackageVersion = $PackageIdentifier.split('/')[2]
 Describe "core/perl" {
     Context "perl" {
-        $OutputVariable = (hab pkg exec $PackageIdentifier perl --version | Out-String).split(' ')
-        It "returns --version that matches the plan" {
-            "$OutputVariable" | Should -BeExactly "$PackageVersion"
+        $OutputVariable = (hab pkg exec $PackageIdentifier perl.exe --version | Out-String)
+        $OutputVariable -match "(?<=\(v)(.*?)(?=\) built for MSWin32)"
+        It "returns --version that matches the plan"  {
+            $matches[1] | Should -BeExactly "$PackageVersion"
         }
     }
 }

--- a/perl/tests/test.ps1
+++ b/perl/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/perl/tests/test.sh
+++ b/perl/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [x] Remove README addition
- [x] Squash all commits and then move back to 'blocked' column
- [x] Blocked by Mark Wrock's PR https://github.com/habitat-sh/core-plans/pull/2745 to be approved and merged
- [x] Has the above been merged?  Update this PR from 'draft' to 'ready for review'
- [x] Close this PR as duplicate of #2806 

### Context
Tests have been added for both windows and linux.  The linux ones pass.  Doing:

```bash
hab pkg build perl
source ./results/last_build.env
hab studio run "./perl/tests/test.sh $pkg_ident"
```

produces

```bash
 ✓ Version matches plan

1 test, 0 failures
```

However, the windows perl doesn't return any stdout even though the build completes without error.  See [openssl,bzip2 issue](https://github.com/habitat-sh/core-plans/issues/2739)

### Completed Tasks
- [x] Verify whether perl works on windows or not.  If not, then add to [this issue](https://github.com/habitat-sh/core-plans/issues/2739) along with bzip2 and openssl
- [x] Verify with windows tests that [Mark Wrock's plan.ps1 updates](https://github.com/habitat-sh/core-plans/pull/2745) work.