### PR TITLE
[artifactory] minor version up to 6.11.1

### DIFF
--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.11.0
+pkg_version=6.11.1
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum=b0dde75c77d363a517d0aff8df028c39ae390814038fed84bf622caae5b6d2e9
+pkg_shasum=d976235c1b82a3061a28369e168161f185787c80e816c6e073ec97563a18fcce
 pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

[Release Notes](https://www.jfrog.com/confluence/display/RTF/Release+Notes#ReleaseNotes-Artifactory6.11.1)
🔢 

## Testing

```
hab pkg build artifactory
source results/last_build.env
hab studio run ./artifactory/tests/test.sh ${pkg_ident}
```