### PR TITLE
[consul] Update consul to 1.5.2, update tests

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.4.4
+pkg_version=1.5.2
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=d3bdf9817c7de9d83426d8c421eb3f37bf82c03c97860ef78fb56e148c4a9765
+pkg_shasum=d4aaf1956c39ed778d10642e301d382ce37fcddf268366700f2a45e737157ef3
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)

--- a/consul/tests/helpers.bash
+++ b/consul/tests/helpers.bash
@@ -8,11 +8,11 @@ get_ip_address() {
 }
 
 check_ip() {
-  if [ -z $1 ]
+  if [ -z "${1}" ]
   then
-    echo $(get_ip_address)
+    get_ip_address
   else
-    echo $1
+    echo "${1}"
   fi
 }
 
@@ -21,19 +21,22 @@ test_listen() {
   if [ "${1}" == "udp" ]; then
     proto="-u"
   fi
-  local ip_address=$(check_ip $4)
-  local wait=${3:-3}
+  local ip_address
+  ip_address="$(check_ip "${4}")"
+
+  local wait="${3:-3}"
   nc "${proto}" -w"${wait}" "${ip_address}" "${2}"
   return $?
 }
 
 wait_listen() {
-  echo $4
+  echo "${4}"
   local proto="-z"
   if [ "${1}" == "udp" ]; then
     proto="-u"
   fi
-  local ip_address=$(check_ip $4)
+  local ip_address
+  ip_address="$(check_ip "${4}")"
   local wait=${3:-1}
   while ! nc "${proto}" -w"${wait}" "${ip_address}" "${2}"; do
     sleep 1

--- a/consul/tests/test.bats
+++ b/consul/tests/test.bats
@@ -1,4 +1,3 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
 load helpers
 
 @test "Port Listen TCP/8300" {


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build consul
source results/last_build.env
hab studio run "./consul/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```