### PR TITLE
[ansible] Update ansible to 2.8.1

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version="2.7.11"
+pkg_version="2.8.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="1112f0d1295cd121b7f997141402e3a4506ffd6bbc8eb4b2ba5de1eb0aa5e536"
+pkg_shasum="0f06a784e138244491c74409240b4a0ee495e2f349cdda67398837c5915bb556"
 pkg_deps=(
   core/libffi
   core/python2


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build ansible
source results/last_build.env
hab studio run "./ansible/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
```