### PR TITLE
[gcc][gcc-libs] Update to 9.1

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -9,6 +9,7 @@ set -eou pipefail
 PLAN_BLACKLIST=(
  glibc
  gcc
+ gcc-libs
  ghc
  ghc710
  ghc710-bootstrap

--- a/bin/ci/verify-pr-build.sh
+++ b/bin/ci/verify-pr-build.sh
@@ -9,6 +9,7 @@ set -u
 PLAN_BLACKLIST=(
  glibc
  gcc
+ gcc-libs
  ghc
  ghc710
  ghc710-bootstrap

--- a/gcc-libs/plan.sh
+++ b/gcc-libs/plan.sh
@@ -1,19 +1,21 @@
 source ../gcc/plan.sh
 
 pkg_name=gcc-libs
+pkg_version=9.1.0
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Runtime libraries shipped by GCC."
 pkg_upstream_url="https://gcc.gnu.org/"
-pkg_license=('GPL-2.0')
+pkg_license=('GPL-3.0-or-later' 'GCC Runtime Library Exception')
 
 # The shared libraries only depend on core/glibc
 pkg_deps=(
   core/glibc
+  core/zlib
 )
 # Add the same version of the full gcc package as a build dep
 pkg_build_deps=(
-  core/gcc/$pkg_version
+  core/gcc/"$pkg_version"
   core/patchelf
 )
 
@@ -55,7 +57,7 @@ do_install() {
   find "$pkg_prefix/lib" \
     -type f \
     -name '*.so.*' \
-    -exec patchelf --set-rpath "$(pkg_path_for glibc)/lib:$pkg_prefix/lib" {} \;
+    -exec patchelf --set-rpath "$(pkg_path_for glibc)/lib:$(pkg_path_for zlib)/lib:$pkg_prefix/lib" {} \;
   find "$pkg_prefix/lib" \
     -type f \
     -name '*.so.*' \

--- a/gcc/cc-wrapper.sh
+++ b/gcc/cc-wrapper.sh
@@ -1,4 +1,5 @@
 #!@shell@
+# shellcheck disable=SC2206,2068
 #
 # # Usage
 #

--- a/gcc/plan.sh
+++ b/gcc/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=gcc
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=8.2.0
+pkg_version=9.1.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 The GNU Compiler Collection (GCC) is a compiler system produced by the GNU \
@@ -10,9 +10,9 @@ the GNU toolchain and the standard compiler for most Unix-like operating \
 systems.\
 "
 pkg_upstream_url="https://gcc.gnu.org/"
-pkg_license=('GPL-2.0')
+pkg_license=('GPL-3.0-or-later' 'GCC Runtime Library Exception')
 pkg_source="http://ftp.gnu.org/gnu/$_distname/${_distname}-${pkg_version}/${_distname}-${pkg_version}.tar.xz"
-pkg_shasum="196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080"
+pkg_shasum="79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0"
 pkg_deps=(
   core/glibc
   core/zlib
@@ -176,6 +176,7 @@ do_build() {
       --disable-werror \
       --disable-multilib \
       --with-system-zlib \
+      --enable-cet \
       --disable-libstdcxx-pch
 
     # Don't store the configure flags in the resulting executables.

--- a/gcc/tests/bats/test.bats
+++ b/gcc/tests/bats/test.bats
@@ -1,0 +1,52 @@
+setup() {
+  TEST_PKG_PATH="/hab/pkgs/$TEST_PKG_IDENT"
+  BINUTILS_DEP=$(grep binutils /hab/pkgs/$TEST_PKG_IDENT/DEPS)
+  GLIBC_DEP=$(grep glibc /hab/pkgs/$TEST_PKG_IDENT/DEPS)
+}
+
+# gcc,g++ and cpp are wrapped with shell scripts to allow us to carefully set the 
+# environment and flags passed to the underlying command. Testing core/gcc is best
+# tested by building additional software with the resulting package. The following
+# asserts that we didn't have an unexpected failure or accidental change in our 
+# build process by asserting:
+#
+# That the commmand are shell scripts
+# That the `.real` command exists and is executable
+# That the final line in the script is an exec to become the real command
+
+@test "gcc is wrapped" {
+  [ "$(file -bi "$TEST_PKG_PATH"/bin/gcc)" == "text/x-shellscript; charset=us-ascii" ]
+  [ -x "$TEST_PKG_PATH"/bin/gcc.real ]
+
+  [ "$(tail -n1 "$TEST_PKG_PATH"/bin/gcc | cut -d' ' -f1,2)" == "exec $TEST_PKG_PATH/bin/gcc.real" ]
+}
+
+@test "g++ is wrapped" {
+  [ "$(file -bi "$TEST_PKG_PATH"/bin/g++)" == "text/x-shellscript; charset=us-ascii" ]
+  [ -x "$TEST_PKG_PATH"/bin/g++.real ]
+
+  [ "$(tail -n1 "$TEST_PKG_PATH"/bin/g++ | cut -d' ' -f1,2)" == "exec $TEST_PKG_PATH/bin/g++.real" ]
+}
+
+@test "cpp is wrapped" {
+  [ "$(file -bi "$TEST_PKG_PATH"/bin/cpp)" == "text/x-shellscript; charset=us-ascii" ]
+  [ -x "$TEST_PKG_PATH"/bin/cpp.real ]
+
+  [ "$(tail -n1 "$TEST_PKG_PATH"/bin/cpp | cut -d' ' -f1,2)" == "exec $TEST_PKG_PATH/bin/cpp.real" ]
+}
+
+# We also need to be certain our wrapper scripts have the expected binutils and glibc version. 
+# This is a safeguard against an accidental build where glibc or binutils resolved to the wrong 
+# version during generation of the scripts. This is most likely to occur in a refresh-type scenario
+# where multiple pieces of software (including hab-plan-build) are being updated and built as a
+# group.  
+
+@test "binutils and glibc paths in wrappers are correct" {
+  export DEBUG=true
+  run hab pkg exec $TEST_PKG_IDENT gcc
+  [ "$(grep "\-B/hab/pkgs/core/binutils" <<< "$output")" == "  -B/hab/pkgs/${BINUTILS_DEP}/bin/" ]
+  [ "$(grep "\-B/hab/pkgs/core/glibc" <<< "$output")" == "  -B/hab/pkgs/${GLIBC_DEP}/lib/" ]
+  unset DEBUG
+}
+
+

--- a/gcc/tests/bats/test.bats
+++ b/gcc/tests/bats/test.bats
@@ -4,10 +4,10 @@ setup() {
   GLIBC_DEP=$(grep glibc /hab/pkgs/$TEST_PKG_IDENT/DEPS)
 }
 
-# gcc,g++ and cpp are wrapped with shell scripts to allow us to carefully set the 
+# gcc,g++ and cpp are wrapped with shell scripts to allow us to carefully set the
 # environment and flags passed to the underlying command. Testing core/gcc is best
 # tested by building additional software with the resulting package. The following
-# asserts that we didn't have an unexpected failure or accidental change in our 
+# asserts that we didn't have an unexpected failure or accidental change in our
 # build process by asserting:
 #
 # That the commmand are shell scripts
@@ -35,11 +35,11 @@ setup() {
   [ "$(tail -n1 "$TEST_PKG_PATH"/bin/cpp | cut -d' ' -f1,2)" == "exec $TEST_PKG_PATH/bin/cpp.real" ]
 }
 
-# We also need to be certain our wrapper scripts have the expected binutils and glibc version. 
-# This is a safeguard against an accidental build where glibc or binutils resolved to the wrong 
+# We also need to be certain our wrapper scripts have the expected binutils and glibc version.
+# This is a safeguard against an accidental build where glibc or binutils resolved to the wrong
 # version during generation of the scripts. This is most likely to occur in a refresh-type scenario
 # where multiple pieces of software (including hab-plan-build) are being updated and built as a
-# group.  
+# group.
 
 @test "binutils and glibc paths in wrappers are correct" {
   export DEBUG=true
@@ -48,5 +48,3 @@ setup() {
   [ "$(grep "\-B/hab/pkgs/core/glibc" <<< "$output")" == "  -B/hab/pkgs/${GLIBC_DEP}/lib/" ]
   unset DEBUG
 }
-
-

--- a/gcc/tests/test.sh
+++ b/gcc/tests/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "$0")"
+
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/bats/test.bats" --tap


### PR DESCRIPTION
Release Notes:
https://www.gnu.org/software/gcc/gcc-9/changes.html

This updates GCC to version 9.1 and adds some simple testing to ensure our wrapper scripts around the compilers are functioning as intended. 

One notable change is that we are enabling control-flow instrumentation. This is necessary in order to enable the same feature on glibc (#2717). 

>--enable-cet
>--disable-cet
>    Enable building target run-time libraries with control-flow instrumentation, see -fcf-protection option. When --enable-cet is specified target libraries are configured to add -fcf-protection and, if needed, other target specific options to a set of building options.
>
>    The option is disabled by default. When --enable-cet=auto is used, it is enabled on Linux/x86 if target binutils supports Intel CET instructions and disabled otherwise. In this case the target libraries are configured to get additional -fcf-protection option.


 In order to fully test this version of GCC in the context of Habitat, it's necessary to build out all core-plans that have gcc/gcc-libs as a dependency.  At the time of this PR, I've built out ~80% of core-plans with no unexpected errors related to this version of GCC.  