### PR TITLE
[gmp] Update and add tests

### DIFF
--- a/gmp/plan.sh
+++ b/gmp/plan.sh
@@ -7,7 +7,7 @@ GMP is a free library for arbitrary precision arithmetic, operating on signed \
 integers, rational numbers, and floating-point numbers.\
 "
 pkg_upstream_url="https://gmplib.org"
-pkg_license=('gplv3')
+pkg_license=('GPL-3.0-or-later')
 pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
 pkg_shasum="87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
 pkg_deps=(
@@ -30,11 +30,21 @@ do_prepare() {
   # Set RUNPATH for c++ compiled code
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   build_line "Updating LDFLAGS=$LDFLAGS"
+
+  # GCC will set the dynamic linker if we don't provide it. Since this package
+  # is built after glibc, but before GCC, we would end with segfaults during the
+  # build process because it will set the RPATH to look at _new_ glibc, but the
+  # dynamic linker will be the _old_ glibc. By setting it here, we ensure that
+  # all the versions line up.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
+  CFLAGS="$CFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+  build_line "Updating CFLAGS=$CFLAGS"
 }
 
 do_build() {
   ./configure \
     --prefix="$pkg_prefix" \
+    --enable-fat \
     --build=x86_64-unknown-linux-gnu
   make -j"$(nproc)"
 }

--- a/gmp/tests/test.sh
+++ b/gmp/tests/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "$0")"
+
+TEST_PKG_IDENT="$1"
+
+echo "GMP is a library-only package. Please verify by building with DO_CHECK=true"


### PR DESCRIPTION
This enables a build flag that should improve performance across systems where this library is used.  

>Fat binary, --enable-fat
>
>    Using --enable-fat selects a “fat binary” build on x86, where optimized low level subroutines are chosen at runtime according to the CPU detected. This means more code, but gives good performance on all x86 chips. (This option might become available for more architectures in the future.)

There are no version updates, but a small change to the build process was required to allow this to build outside of stage1/stage2 which is also  explained inline

> GCC will set the dynamic linker if we don't provide it. Since this package is built after glibc, but before GCC, we would end with segfaults during the
build process because it will set the RPATH to look at _new_ glibc, but the
dynamic linker will be the _old_ glibc. By setting it here, we ensure that
all the versions line up.

This package provides only libraries so the test is an empty stub to conform with our testing practices. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>