### PR TITLE
[libmpc] Update build and add tests

### DIFF
--- a/libmpc/plan.sh
+++ b/libmpc/plan.sh
@@ -8,7 +8,7 @@ GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily \
 high precision and correct rounding of the result.\
 "
 pkg_upstream_url="http://www.multiprecision.org/"
-pkg_license=('lgpl')
+pkg_license=('LGPL-3.0-or-later')
 pkg_source="https://ftp.gnu.org/gnu/${_distname}/${_distname}-${pkg_version}.tar.gz"
 pkg_shasum="6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
 pkg_dirname="${_distname}-${pkg_version}"
@@ -31,6 +31,15 @@ do_prepare() {
 
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   build_line "Updating LDFLAGS=$LDFLAGS"
+
+  # GCC will set the dynamic linker if we don't provide it. Since this package
+  # is built after glibc, but before GCC, we would end with segfaults during the
+  # build process because it will set the RPATH to look at _new_ glibc, but the
+  # dynamic linker will be the _old_ glibc. By setting it here, we ensure that
+  # all the versions line up.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
+  CFLAGS="$CFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+  build_line "Updating CFLAGS=$CFLAGS"
 }
 
 do_check() {

--- a/libmpc/tests/test.sh
+++ b/libmpc/tests/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "$0")"
+
+TEST_PKG_IDENT="$1"
+
+echo "MPC is a library-only package. Please verify by building with DO_CHECK=true"


### PR DESCRIPTION
There are no version updates, but a small change to the build process was required to allow this to build outside of stage1/stage2 which is also  explained inline

> GCC will set the dynamic linker if we don't provide it. Since this package is built after glibc, but before GCC, we would end with segfaults during the
build process because it will set the RPATH to look at _new_ glibc, but the
dynamic linker will be the _old_ glibc. By setting it here, we ensure that
all the versions line up.

This package provides only libraries so the test is an empty stub to conform with our testing practices. 
