### PR TITLE
[caddy] Update Caddy to 1.0.1, update tests

### DIFF
--- a/caddy/plan.sh
+++ b/caddy/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=caddy
 pkg_origin=core
-pkg_version=1.0.0
+pkg_version=1.0.1
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
-pkg_source="https://github.com/mholt/caddy/releases/download/v${pkg_version}/caddy_v${pkg_version}_linux_amd64.tar.gz"
-pkg_shasum=e720c3a6593c878fc7ecc00baf4348683c0e8e35ab67d2db4d364881be96896e
+pkg_source="https://github.com/caddyserver/caddy/releases/download/v${pkg_version}/caddy_v${pkg_version}_linux_amd64.tar.gz"
+pkg_shasum=4fd3ad67078c6b16e01ed2443bc8d7abf784a757de4177607e3cad2595db3caf
 pkg_description="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 pkg_upstream_url=https://caddyserver.com
 pkg_svc_run="caddy -conf ${pkg_svc_config_path}/Caddyfile"

--- a/caddy/tests/test.bats
+++ b/caddy/tests/test.bats
@@ -1,22 +1,17 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v caddy)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  skip
-  result="$(caddy -version | head -1 | awk '{print $2}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} caddy -version | head -1 | awk '{print $2}')"
   [ "$result" = "${pkg_version}" ]
 }
 
 @test "Help command" {
-  run caddy -help
+  run hab pkg exec ${TEST_PKG_IDENT} caddy -help
   [ $status -eq 2 ]
 }
 
 @test "Basic config validation" {
-  run caddy -validate
+  run hab pkg exec ${TEST_PKG_IDENT} caddy -validate
   [ $status -eq 0 ]
 }
 

--- a/caddy/tests/test.sh
+++ b/caddy/tests/test.sh
@@ -1,35 +1,38 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
 hab pkg install core/curl --binlink
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
+hab sup term
+hab sup run &
+sleep 5
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+hab svc load "${TEST_PKG_IDENT}"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
+# Allow service start
+WAIT_SECONDS=10
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
 
-  # Give some time for the service to start up
-  sleep 10
-fi
+bats "$(dirname "${0}")/test.bats"
 
-bats "${TESTDIR}/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Updates the source repo since the upstream moved.
* Restore the version test, upstream has fixed the previous issue.

### Testing

```
hab pkg build caddy
source results/last_build.env
hab studio run "./caddy/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Basic config validation
 ✓ Service is running
 ✓ Listening on port 8080
 ✓ Simple cURL request

6 tests, 0 failures
```