### PR TITLE
[packer] Update packer to 1.4.2, update tests

### DIFF
--- a/packer/plan.ps1
+++ b/packer/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="packer"
 $pkg_origin="core"
-$pkg_version="1.3.5"
+$pkg_version="1.4.2"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('MPL2')
 $pkg_bin_dirs=@("bin")
 $pkg_source="https://releases.hashicorp.com/packer/${pkg_version}/packer_${pkg_version}_windows_amd64.zip"
-$pkg_shasum="57d30d5d305cf877532e93526c284438daef5db26d984d16ee85e38a7be7cfbb"
+$pkg_shasum="0db7527e81672d51fc436081eff0e49e8873baee0564e427c5dc73a3f44fa840"
 
 function Invoke-Install {
   Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_name-$pkg_version/$pkg_name.exe" $pkg_prefix\bin

--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.3.5
+pkg_version=1.4.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="14922d2bca532ad6ee8e936d5ad0788eba96f773bcdcde8c2dc7c95f830841ec"
+pkg_shasum=2fcbd1662ac76dc4dec381bdc7b5e6316d5b9d48e0774a32fe6ef9ec19f47213
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)
@@ -20,5 +20,5 @@ do_build() {
 }
 
 do_install() {
-  install -D packer "$pkg_prefix/bin/packer"
+  install -D packer "${pkg_prefix}/bin/packer"
 }

--- a/packer/tests/test.bats
+++ b/packer/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(packer version | head -1 | awk '{print $2}')"
-  [ "$result" = "v${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} packer version | head -1 | awk '{print $2}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run packer --help
+  run hab pkg exec ${TEST_PKG_IDENT} packer --help
   [ "$status" -eq 0 ]
 }

--- a/packer/tests/test.sh
+++ b/packer/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build packer
source results/last_build.env
hab studio run "./packer/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

![tenor-197537234](https://user-images.githubusercontent.com/24568/60575011-b6060500-9db5-11e9-8bc9-44c0882f09f3.gif)
