### PR TITLE
[cmake] Fix so that builds in windows studio

### DIFF
--- a/cmake/plan.ps1
+++ b/cmake/plan.ps1
@@ -12,11 +12,14 @@ $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {
-  lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
   mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  Move-Item "cmake-$pkg_version-win64-x64/SourceDir/cmake" "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  try {
+    lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+  }
+  finally { Pop-Location }
 }
 
 function Invoke-Install {
-  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/cmake/*" "$pkg_prefix" -Recurse -Force
+  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/cmake-$pkg_version-win64-x64/SourceDir/cmake/*" "$pkg_prefix" -Recurse -Force
 }

--- a/cmake/tests/test.bats
+++ b/cmake/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" cmake --version | grep 'cmake version' | awk '{print $3}')"
+  diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
+}

--- a/cmake/tests/test.pester.ps1
+++ b/cmake/tests/test.pester.ps1
@@ -1,0 +1,15 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/cmake" {
+    Context "cmake" {
+        $OutputVariable = (hab pkg exec $PackageIdentifier cmake --version | Out-String)
+        $OutputVariable -match  "(?<=cmake version )([0-9\.]*)"
+        It "returns --version that matches the plan" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/cmake/tests/test.ps1
+++ b/cmake/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/cmake/tests/test.sh
+++ b/cmake/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting on approval and merge

### Context
The core/cmake fails to build within the windows docker studio on Azure Windows 2016 ``hab studio enter -D``.  The error is "**Move-Item...is denied**":

```powershell
d-----         7/2/2019   5:20 AM                cmake-3.13.2
Move-Item : Access to the path 'C:\src\cmake\cmake-3.13.2-win64-x64\SourceDir\cmake' is denied.
At C:\src\cmake\plan.ps1:17 char:3
+   Move-Item "cmake-$pkg_version-win64-x64/SourceDir/cmake" "$HAB_CACH ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : WriteError: (C:\src\cmake\cm...SourceDir\cmake:DirectoryInfo) [Move-Item], IOException
+ FullyQualifiedErrorId : MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand

[HAB-STUDIO] Habitat:\src>
```

If, however, the build is done from the windows host, then the build succeeds:

```powershell
PS C:\Users\azureuser\Documents\habitat\core-plans> hab pkg build cmake
...
...
   cmake:
   cmake: I love it when a plan.ps1 comes together.
   cmake:


PS C:\Users\azureuser\Documents\habitat\core-plans>
```

### Completed Tasks
- [x] Built linux artifact fine.
- [x] Observed that cmake build fails only in the windows studio not on the windows host
  - Confirmed that the core/cmake build fails within the windows docker studio both on my Mac/vagrant windows and also on Azure Windows 2016.
  - Confirmed that the build succeeds when run on the host ``hab pkg build cmake``, not within the windows docker studio
- [x] Write Pester tests on Azure for the working windows build on Azure.  Note that using the artifact from Azure didn't work on my Mac because the signing key was different.  
- [x] Implement alternate to "Move-Item" that works on both windows 2016 and from within the windows studio docker:  Use core/rust plans.ps1 as pattern.
- [x] Collect test results for both the build/test on windows 2016 and from within the windows studio.  Add these as a comment to the PR.
- [x] Change the title on the cmake issue to be 'fix all windows packages that fail to build in windows studio' and add list of potential candidate core-plans.
- [x] Squash commits
- [x] Added missing sign off to commit message to fix DCO test failure