### PR TITLE
[opendistro-for-elasticsearch] blacklist the build-test process

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -5,6 +5,7 @@ set -eou pipefail
 # Don't attempt to build the following plans. They have resource requirements
 # or build times that exceed the currently available resources on our CI
 # infrastructure.
+ # See also: #2759 and #2065
 PLAN_BLACKLIST=(
  glibc
  gcc
@@ -19,6 +20,7 @@ PLAN_BLACKLIST=(
  kubernetes
  mongodb
  mysql
+ opendistro-for-elasticsearch
 )
 plan="$(basename "$1")"
 


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

Unfortunately in PR #2684 we missed the fact that both the verify step and the build-test steps of CI need to be ignored.... therefore the opendistro-for-elasticsearch build is still failing.

This will need to be fixed as well in order for that PR to land successfully.