### PR TITLE
[ansible] Update ansible to 2.8.2

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,11 +1,13 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version="2.8.1"
+pkg_version=2.8.2
+pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."
+pkg_upstream_url="https://www.ansible.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=("GPL-3.0")
+pkg_license=("GPL-3.0-only")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="0f06a784e138244491c74409240b4a0ee495e2f349cdda67398837c5915bb556"
+pkg_shasum=17239947c2bc13abcbb3fe9ce61c227e4b3a1018da84d58a82c33e41e677ddbc
 pkg_deps=(
   core/libffi
   core/python2
@@ -18,8 +20,6 @@ pkg_build_deps=(
   core/make
 )
 pkg_bin_dirs=(bin)
-pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."
-pkg_upstream_url="https://www.ansible.com/"
 
 do_setup_environment() {
   push_runtime_env PYTHONPATH "$(pkg_path_for python2)/lib/python2.7/site-packages"

--- a/ansible/tests/test.bats
+++ b/ansible/tests/test.bats
@@ -1,10 +1,11 @@
-expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
 @test "Version matches" {
-  result="$(hab pkg exec $TEST_PKG_IDENT ansible --version | head -1 | awk '{print $2}')"
-  [ "$result" = "${expected_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} ansible --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help Command" {
-  run hab pkg exec $TEST_PKG_IDENT ansible --help
+  run hab pkg exec ${TEST_PKG_IDENT} ansible --help
   [ $status -eq 0 ]
 }

--- a/ansible/tests/test.sh
+++ b/ansible/tests/test.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
 set -euo pipefail
 
-TESTDIR="$(dirname "${0}")"
-
-if [ -z "${1:-}" ]; then
-  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
-  exit 1
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-TEST_PKG_IDENT="$1"
-
-hab pkg install core/bats --binlink
-hab pkg install "$TEST_PKG_IDENT"
-
+TEST_PKG_IDENT="${1}"
 export TEST_PKG_IDENT
-bats "${TESTDIR}/test.bats"
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* [Changelog](https://github.com/ansible/ansible/blob/stable-2.8/changelogs/CHANGELOG-v2.8.rst#v2-8-2)

### Testing

```
hab pkg build ansible
source results/last_build.env
hab studio run "./ansible/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
```