### PR TITLE
[httpd] Update httpd to 2.4.39, update test style

### DIFF
--- a/httpd/plan.sh
+++ b/httpd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=httpd
 pkg_origin=core
-pkg_version=2.4.38
+pkg_version=2.4.39
 pkg_description="The Apache HTTP Server"
 pkg_upstream_url="http://httpd.apache.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://archive.apache.org/dist/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=38d0b73aa313c28065bf58faf64cec12bf7c7d5196146107df2ad07541aa26a6
+pkg_shasum=8b95fe249f3a6c50aad3ca125eef3e02d619116cde242e1bc3c266b7b5c37c30
 pkg_deps=(
   core/apr
   core/apr-util
@@ -33,23 +33,23 @@ pkg_exports=(
   [port]=serverport
 )
 pkg_exposes=(port)
-pkg_svc_run="httpd -DFOREGROUND -f $pkg_svc_config_path/httpd.conf"
+pkg_svc_run="httpd -DFOREGROUND -f ${pkg_svc_config_path}/httpd.conf"
 pkg_svc_user="root"
 pkg_svc_group="root"
 
 do_build() {
-    ./configure \
-      --prefix="$pkg_prefix" \
-      --with-expat="$(pkg_path_for core/expat)" \
-      --with-iconv="$(pkg_path_for core/libiconv)" \
-      --with-pcre="$(pkg_path_for core/pcre)" \
-      --with-apr="$(pkg_path_for core/apr)" \
-      --with-apr-util="$(pkg_path_for core/apr-util)" \
-      --with-z="$(pkg_path_for core/zlib)" \
-      --with-ssl="$(pkg_path_for core/openssl)" \
-      --enable-modules="none" \
-      --enable-mods-static="none" \
-      --enable-mods-shared="reallyall" \
-      --enable-mpms-shared="prefork event worker"
-    make
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --with-expat="$(pkg_path_for core/expat)" \
+    --with-iconv="$(pkg_path_for core/libiconv)" \
+    --with-pcre="$(pkg_path_for core/pcre)" \
+    --with-apr="$(pkg_path_for core/apr)" \
+    --with-apr-util="$(pkg_path_for core/apr-util)" \
+    --with-z="$(pkg_path_for core/zlib)" \
+    --with-ssl="$(pkg_path_for core/openssl)" \
+    --enable-modules="none" \
+    --enable-mods-static="none" \
+    --enable-mods-shared="reallyall" \
+    --enable-mpms-shared="prefork event worker"
+  make
 }

--- a/httpd/tests/test.bats
+++ b/httpd/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v httpd)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(httpd -v | head -1 | awk '{print $3}')"
-  [ "$result" = "Apache/${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} httpd -v | head -1 | awk '{print $3}')"
+  [ "$result" = "Apache/${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run httpd -h
+  run hab pkg exec ${TEST_PKG_IDENT} httpd -h
   # httpd help command exits with status 1, for some reason
   [ $status -eq 1 ]
 }

--- a/httpd/tests/test.sh
+++ b/httpd/tests/test.sh
@@ -1,34 +1,36 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static wc
-hab pkg binlink core/busybox-static uniq
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
+hab sup term
+hab sup run &
+sleep 5
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+hab svc load "${TEST_PKG_IDENT}"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
 
-  # Give some time for the service to start up
-  sleep 3
-fi
+bats "$(dirname "${0}")/test.bats"
 
-bats "${TESTDIR}/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build httpd
source results/last_build.env
hab studio run "./httpd/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Multiple processes
 ✓ Listening on port 80

5 tests, 0 failures
```