### PR TITLE
[gdb] Update gdb to 8.3, update test style

### DIFF
--- a/gdb/plan.sh
+++ b/gdb/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=gdb
 pkg_origin=core
-pkg_version=8.2
+pkg_version=8.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-3.0')
 pkg_description="GDB, the GNU Project debugger, allows you to see what is going on 'inside' another program while it executes -- or what another program was doing at the moment it crashed."
 pkg_upstream_url="https://www.gnu.org/software/gdb/"
 pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=c3a441a29c7c89720b734e5a9c6289c0a06be7e0c76ef538f7bbcef389347c39
+pkg_shasum=802f7ee309dcc547d65a68d61ebd6526762d26c3051f52caebe2189ac1ffd72e
 pkg_deps=(
   core/bdwgc
   core/expat

--- a/gdb/tests/test.bats
+++ b/gdb/tests/test.bats
@@ -1,6 +1,6 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(gdb --version | head -1 | awk '{print $7}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} gdb --version | head -1 | awk '{print $7}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }

--- a/gdb/tests/test.sh
+++ b/gdb/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build gdb
source results/last_build.env
hab studio run "./gdb/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```