### PR TITLE
[multichain] Added multichain plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -929,6 +929,8 @@ plan_path = "msgpack"
 plan_path = "msodbcsql17"
 [mssql]
 plan_path = "mssql"
+[multichain]
+plan_path = "multichain"
 [musl]
 plan_path = "musl"
 [mysql]

--- a/multichain/README.md
+++ b/multichain/README.md
@@ -1,0 +1,35 @@
+# Multichain
+
+Open platform for building blockchains.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service Package
+
+Although this ships as a service package, it really can only be useful and secure when wrapped with a Configuration Plan. Do not deploy this for production use without customization.
+
+## Usage
+
+```
+hab pkg install core/multichain
+hab svc load core/multuchain
+```
+
+Check command line / log output for credentials and connection information.
+
+## Bindings
+
+* `port` is exposed for other multichaind servers to connect to
+* `rpcport` is exposed for RPC / CLI communication and configuration
+
+## Topologies
+
+This should be deployed in a standalone topology.
+
+## Update Strategies
+
+Do not deploy Multichaind with an update strategy. Currently the requirements of the service and package paths don't allow auto-updating.

--- a/multichain/config/multichain.conf
+++ b/multichain/config/multichain.conf
@@ -1,0 +1,5 @@
+rpcuser={{cfg.user.rpcuser}}
+rpcpassword={{cfg.user.rpcpassword}}
+port={{cfg.system.port}}
+rpcport={{cfg.system.rpcport}}
+rpcallowip={{cfg.system.rpcallowip}}

--- a/multichain/default.toml
+++ b/multichain/default.toml
@@ -1,0 +1,79 @@
+[user]
+rpcuser = "multichainrpc"
+rpcpassword = "CwcAgE6YS8BdEUKowLJwArBdTucBo1nA99C1oVP2boeB"
+
+[basic]
+chain-protocol = "multichain"
+chain-description = "MultiChain based chain"
+root-stream-name = "root"
+root-stream-open = true
+chain-is-testnet = false
+target-block-time = 15
+maximum-block-size = 8388608
+
+[permissions]
+anyone-can-connect = false
+anyone-can-send = false
+anyone-can-receive = false
+anyone-can-receive-empty = true
+anyone-can-create = false
+anyone-can-issue = false
+anyone-can-mine = false
+anyone-can-activate = false
+anyone-can-admin = false
+support-miner-precheck = true
+allow-arbitrary-outputs = false
+allow-p2sh-outputs = true
+allow-multisig-outputs = true
+
+[consensus]
+setup-first-blocks = 60
+mining-diversity = 0.3
+admin-consensus-upgrade = 0.5
+admin-consensus-admin = 0.5
+admin-consensus-activate = 0.5
+admin-consensus-mine = 0.5
+admin-consensus-create = 0.0
+admin-consensus-issue = 0.0
+
+[runtime]
+lock-admin-mine-rounds = 10
+mining-requires-peers = true
+mine-empty-rounds = 10
+mining-turnover = 0.5
+
+[native]
+initial-block-reward = 0
+first-block-reward = -1
+reward-halving-interval = 52560000
+reward-spendable-delay = 1
+minimum-per-output = 0
+maximum-per-output = 100000000000000
+minimum-relay-fee = 0
+native-currency-multiple = 100000000
+
+[mining]
+skip-pow-check = false
+pow-minimum-bits = 8
+target-adjust-freq = -1
+allow-min-difficulty-blocks = false
+
+[transactions]
+only-accept-std-txs = true
+max-std-tx-size = 4194304
+max-std-op-returns-count = 32
+max-std-op-return-size = 2097152
+max-std-op-drops-count = 5
+max-std-element-size = 8192
+
+[system]
+port = 2781
+rpcport = 2780
+chain-name = "chain1"
+protocol-version = 10011
+network-message-start = "fbe0f9fc"
+address-pubkeyhash-version = "008ee913"
+address-scripthash-version = "05cba56a"
+private-key-version = "809297fc"
+address-checksum-value = "9fb48503"
+rpcallowip="127.0.0.1"

--- a/multichain/hooks/init
+++ b/multichain/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+multichain-util create {{cfg.system.chain-name}} -datadir={{pkg.svc_data_path}}
+rm {{pkg.svc_data_path}}/multichain.conf
+ln -s {{pkg.svc_config_path}}/multichain.conf {{pkg.svc_data_path}}/

--- a/multichain/hooks/run
+++ b/multichain/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+
+exec multichaind \
+  {{cfg.system.chain-name}}{{#if bind.multichain}}@{{#with bind.muiltichain.first as |mc|}}{{mc.sys.ip}}:{{mc.cfg.port}}{{/with}}{{/if}} \
+  -datadir={{pkg.svc_data_path}}

--- a/multichain/plan.sh
+++ b/multichain/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=multichain
+pkg_origin=core
+pkg_version=1.0.8
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("GPL-3.0-only")
+pkg_description="MultiChain is an open source platform for private blockchains."
+pkg_upstream_url="https://www.multichain.com"
+pkg_source="https://www.multichain.com/download/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=5905bc7f236d0f7ff3978bbc6e791cafdfb34e8ca5b2f5fe5fca535a1336d575
+pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/patchelf
+)
+pkg_exports=(
+  [port]=system.port
+  [rpcport]=system.rpcport
+)
+pkg_exposes=(port rpcport)
+pkg_binds_optional=(
+  [multichain]="port rpcport"
+)
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  local bin_path="${pkg_prefix}/bin/"
+
+  install -D multichain-cli "${bin_path}"
+  install -D multichain-util "${bin_path}"
+  install -D multichaind "${bin_path}"
+  install -D multichaind-cold "${bin_path}"
+
+  find "${bin_path}" -type f -executable \
+    -exec patchelf --interpreter "$(pkg_path_for core/glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Testing of this is a manual process, due to the way it spews connection information to the command line, and the nature of managing the blockchain platform.

Open to suggestions on good / meaningful ways to automate these tests in future PR's.

This ships with a VERY basic service configuration, but is not designed to be used. Its a reference only, and this is stated in the README.

### Testing

```
hab pkg build multichain
source results/last_build.env
hab studio enter

> hab svc load core/multichain
> sl
```

### Sample output

```
multichain.default(SR): Initializing
multichain.default hook[init]:(HK): 
multichain.default hook[init]:(HK): MultiChain 1.0.8 Utilities (latest protocol 10011)
multichain.default hook[init]:(HK): 
multichain.default hook[init]:(HK): Blockchain parameter set was successfully generated.
multichain.default hook[init]:(HK): You can edit it in /hab/svc/multichain/data/chain1/params.dat before running multichaind for the first time.
multichain.default hook[init]:(HK): 
multichain.default hook[init]:(HK): To generate blockchain please run "multichaind chain1 -daemon".
multichain.default(SV): Starting service as user=hab, group=hab
multichain.default(O): Looking for genesis block...
multichain.default(O): Genesis block found
multichain.default(O): 
multichain.default(O): Other nodes can connect to this node using:
multichain.default(O): multichaind chain1@172.17.0.3:2781
multichain.default(O): 
multichain.default(O): Node ready.
multichain.default(O): 
```

![tenor-23343579](https://user-images.githubusercontent.com/24568/60643648-bb735600-9e6e-11e9-8701-a2a07f786531.gif)
