### PR TITLE
[netdata] Update Netdata repo

### DIFF
--- a/netdata/README.md
+++ b/netdata/README.md
@@ -1,6 +1,6 @@
 # netdata
 
-[netdata](https://github.com/firehol/netdata) is a system for distributed real-time performance and health monitoring.
+[Netdata](https://github.com/firehol/netdata) is a system for distributed real-time performance and health monitoring.
 
 ## Maintainers
 
@@ -8,7 +8,7 @@
 
 ## Usage
 
-netdata strives to be as useful as possible without configuration, so to get started you just need to load the service:
+Netdata strives to be as useful as possible without configuration, so to get started you just need to load the service:
 
 ```bash
 hab svc load core/netdata

--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=netdata
 pkg_origin=core
-pkg_version="1.15.0"
+pkg_version=1.15.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
 pkg_description="netdata is a system for distributed real-time performance and health monitoring."
-pkg_upstream_url="https://github.com/firehol/netdata"
-pkg_source="https://github.com/firehol/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="60cf4a15c25c828e25ae1218a485c21ef23423f7b6a9a1148ce9eea9c9726a39"
+pkg_upstream_url="https://github.com/netdata/netdata"
+pkg_source="https://github.com/netdata/${pkg_name}/archive/v${pkg_version}.tar.gz"
+pkg_shasum=60cf4a15c25c828e25ae1218a485c21ef23423f7b6a9a1148ce9eea9c9726a39
 pkg_build_deps=(
   core/autoconf
   core/autogen
@@ -23,8 +23,6 @@ pkg_deps=(
   core/python
   core/util-linux
   core/zlib
-
-  # for fix_interpreter
   core/coreutils
 )
 pkg_bin_dirs=(sbin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Just update the upstream / origin repo for Netdata, which has moved. No promotion necessary after merge.