### PR TITLE
[rabbitmq] Update RabbitMQ to 3.7.16, update test style

### DIFF
--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=rabbitmq
 pkg_distname="${pkg_name}-server"
 pkg_origin=core
-pkg_version=3.7.14
+pkg_version=3.7.16
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL')
 pkg_description="Open source multi-protocol messaging broker"
 pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source="https://github.com/rabbitmq/rabbitmq-server/releases/download/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz"
-pkg_shasum=6790812bd05c6c28314fc01f3813cfd29ffa645c89161c9d4d0fce8464249d8a
+pkg_shasum=7f7a8a587b6beba3b86e1a2a9bf60da4bd19b0aacfec025559bbbbf13fd1418b
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/coreutils

--- a/rabbitmq/tests/test.bats
+++ b/rabbitmq/tests/test.bats
@@ -1,10 +1,3 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v rabbitmqctl)" ]
-  [ "$(command -v rabbitmq-server)" ]
-}
-
 @test "Service is running" {
   [ "$(hab svc status | grep "rabbitmq\.default" | awk '{print $4}' | grep up)" ]
 }

--- a/rabbitmq/tests/test.sh
+++ b/rabbitmq/tests/test.sh
@@ -1,32 +1,35 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
+hab sup term
+hab sup run &
+sleep 5
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+hab svc load "${TEST_PKG_IDENT}"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
+# Allow service start
+WAIT_SECONDS=20
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
 
-  # Give some time for the service to start up
-  sleep 30
-fi
+bats "$(dirname "${0}")/test.bats"
 
-bats "${TESTDIR}/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build rabbitmq
source results/last_build.env
hab studio run "./rabbitmq/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Service is running
 ✓ Listening on port 4369, 5672, 25672

2 tests, 0 failures
```