### PR TITLE
[node10] Update node10 to 10.16.0 and add tests

### DIFF
--- a/node/tests/test.bats
+++ b/node/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node/tests/test.pester.ps1
+++ b/node/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node/tests/test.ps1
+++ b/node/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node/tests/test.sh
+++ b/node/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node10/plan.ps1
+++ b/node10/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node10"
 $pkg_origin="core"
-$pkg_version="10.15.2"
+$pkg_version="10.16.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="12a802653c0737a4ba882a06511ad1fb58cfe038bf55b082c7fe6243bdf03cf5"
+$pkg_shasum="4d106b32293453f1ed037650c3051db854f853f7cef5a06e659e5c7d978cadb7"

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node10
 pkg_origin=core
-pkg_version=10.15.2
+pkg_version=10.16.0
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=3b81ea6b0ae1c887ed4215d6a0b9349284c811bd98c8ddd7a0370f6cc9eb8182
+pkg_shasum=d00f1ffdb0a7413eaaf3afc393fb652ea713db135dcd3ccf6809370a07395713
 pkg_dirname="node-v${pkg_version}"

--- a/node10/tests/test.bats
+++ b/node10/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node10/tests/test.pester.ps1
+++ b/node10/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node10/tests/test.ps1
+++ b/node10/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node10/tests/test.sh
+++ b/node10/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node11/tests/test.bats
+++ b/node11/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node11/tests/test.pester.ps1
+++ b/node11/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node11/tests/test.ps1
+++ b/node11/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node11/tests/test.sh
+++ b/node11/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node12/tests/test.bats
+++ b/node12/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node12/tests/test.pester.ps1
+++ b/node12/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node12/tests/test.ps1
+++ b/node12/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node12/tests/test.sh
+++ b/node12/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node6/tests/test.bats
+++ b/node6/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node6/tests/test.pester.ps1
+++ b/node6/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node6/tests/test.ps1
+++ b/node6/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node6/tests/test.sh
+++ b/node6/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node8/tests/test.bats
+++ b/node8/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node8/tests/test.pester.ps1
+++ b/node8/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node8/tests/test.ps1
+++ b/node8/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node8/tests/test.sh
+++ b/node8/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/node9/tests/test.bats
+++ b/node9/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} node --version | head -1 | awk '{print $1}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help Command" {
+  run hab pkg exec ${TEST_PKG_IDENT} node --help
+  [ $status -eq 0 ]
+}

--- a/node9/tests/test.pester.ps1
+++ b/node9/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+          hab pkg exec $PackageIdentifier node --help
+          $? | Should be $true
+        }
+    }
+}

--- a/node9/tests/test.ps1
+++ b/node9/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}

--- a/node9/tests/test.sh
+++ b/node9/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

This PR updates node10 to 10.16.0 and adds tests for all node plans.

It may be worth discussing a standard for plans with many major versions (like node, postgresql) and how we should be calling these tests -- is it better to have a test script execute the same code for the parent `node` plan? or should each version plan copy-pasta its own boilerplate test code? I can see arguments either way.

## Testing
### Linux
```
hab pkg build core/node10
source results/last_build.env
hab pkg run "./node10/tests/test.sh ${pkg_ident}"
```

### Windows
```
hab pkg build core/node10
. ./results/last_build.ps1
hab pkg run "./node10/tests/test.ps1 $pkg_ident"
```