### PR TITLE
[corretto][corretto8] Add jre/bin to entries to be patched

### DIFF
--- a/corretto/plan.sh
+++ b/corretto/plan.sh
@@ -51,7 +51,7 @@ do_install() {
 
   find "${pkg_prefix}"/bin -type f -executable \
     -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
-    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
+    -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "${pkg_prefix}/lib" -type f -name "*.so" \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;

--- a/corretto8/plan.sh
+++ b/corretto8/plan.sh
@@ -36,7 +36,11 @@ do_install() {
 
   find "${pkg_prefix}"/bin -type f -executable \
     -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
-    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
+    -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
+
+  find "${pkg_prefix}"/jre/bin -type f -executable \
+    -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
+    -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "${pkg_prefix}/lib" -type f -name "*.so" \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;


### PR DESCRIPTION
This adds jre/bin to the list of directories that contains binaries needing attention from patchelf.  

It also makes a small change to use `--set-interpreter` rather than `--interpreter`. The `--help` for patchelf doesn't list `--interpreter` so the full flag should be preferred (even though it works :smile: )

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>