### PR TITLE
[ant][maven][jffi] Change JDK 

### DIFF
--- a/ant/plan.sh
+++ b/ant/plan.sh
@@ -12,14 +12,14 @@ pkg_build_deps=(
 )
 pkg_deps=(
   core/coreutils
-  core/jdk8
+  core/corretto8
   core/sed
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 
 do_prepare() {
-  JAVA_HOME="$(pkg_path_for core/jdk8)"
+  JAVA_HOME="$(pkg_path_for core/corretto8)"
   export JAVA_HOME
   cd "${HAB_CACHE_SRC_PATH}/${pkg_name}-rel-${pkg_version}"
   sed -i 's|/usr/bin/python|/usr/bin/python2|' src/script/runant.py

--- a/jffi/plan.sh
+++ b/jffi/plan.sh
@@ -1,21 +1,20 @@
 pkg_name=jffi
 pkg_origin=core
-pkg_version="1.2.18"
+pkg_version="1.2.19"
 pkg_license=('Apache-2.0')
 pkg_description="Java Foreign Function Interface"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/jnr/jffi/archive/${pkg_name}-${pkg_version}.tar.gz"
 pkg_dirname="${pkg_name}-${pkg_name}-${pkg_version}"
-pkg_shasum="05326c985153e4c86449b9732cbaa39c7570f079cd0f1276c2f5df40ebacbd92"
+pkg_shasum="a872e5f0378a7d187a1b2fa7de55fbb4a67cba83ea786dea5ba3218f7f9f9f45"
 pkg_upstream_url="https://github.com/jnr/jffi"
 pkg_deps=(
   core/glibc
   core/libffi
   core/gcc-libs
-  core/jre8
+  core/corretto8
 )
 pkg_build_deps=(
-  core/jdk8
   core/ant
   core/pkg-config
   core/make
@@ -31,7 +30,7 @@ do_prepare() {
 
   export USE_SYSTEM_LIBFFI=1
   export JAVA_HOME
-  JAVA_HOME="$(pkg_path_for jdk8)"
+  JAVA_HOME="$(pkg_path_for corretto8)"
 }
 
 do_build() {

--- a/maven/plan.sh
+++ b/maven/plan.sh
@@ -10,7 +10,7 @@ pkg_shasum=025921fff6ba827a25413ffc08fb1933565eb1f07ee2d3f228911913ee4f3c3f
 pkg_dirname="apache-$pkg_name-$pkg_version"
 pkg_deps=(
   core/coreutils
-  core/jdk8
+  core/corretto8
   core/which
 )
 pkg_build_deps=(core/maven)
@@ -19,7 +19,7 @@ pkg_lib_dirs=(lib)
 
 do_prepare() {
   export JAVA_HOME
-  JAVA_HOME="$(pkg_path_for jdk8)"
+  JAVA_HOME="$(pkg_path_for corretto8)"
   build_line "Setting JAVA_HOME=$JAVA_HOME"
 }
 


### PR DESCRIPTION
This is in preparation for deprecating the JRE and JDK packages.  I had originally intended to use openjdk as it's been around longer so more Java software declares support for it.  However, jffi won't build with openjdk11 (https://github.com/jnr/jffi/issues/55). Maven for windows is also using corretto and consistency is important. 

jffi depends on maven and ant so these three need to move as a single PR.

This also depends on #2803 being merged and promoted. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>