### PR TITLE
[php] Update bison dependency

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -27,7 +27,7 @@ pkg_deps=(
 )
 pkg_build_deps=(
   core/autoconf
-  core/bison2
+  core/bison
   core/gcc
   core/libgd
   core/make


### PR DESCRIPTION
Bison2 hasn't been released in 7 years while the 3 series is still receiving updates.  This PR updates the build dependency for PHP to use the more modern version of Bison so that we may deprecate the bison2 package. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>