### PR TITLE
[dpkg] Update version

### DIFF
--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dpkg
 pkg_origin=core
-pkg_version=1.19.4
+pkg_version=1.19.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('GPL-2.0')
+pkg_license=('GPL-2.0-or-later')
 pkg_upstream_url="https://wiki.debian.org/dpkg"
 pkg_description="dpkg is a package manager for Debian-based systems"
 pkg_source="http://http.debian.net/debian/pool/main/d/${pkg_name}/${pkg_name}_${pkg_version}.tar.xz"
-pkg_shasum="c15234e98655689586bff2d517a6fdc6135d139c54d52ae9cfa6a90007fee0ae"
+pkg_shasum="4c27fededf620c0aa522fff1a48577ba08144445341257502e7730f2b1a296e8"
 pkg_deps=(
   core/bzip2
   core/glibc
@@ -14,6 +14,7 @@ pkg_deps=(
   core/tar
   core/zlib
   core/xz
+  core/gcc-libs
 )
 pkg_build_deps=(
   core/autoconf
@@ -28,13 +29,12 @@ pkg_build_deps=(
   core/pkg-config
   core/xz
   core/zlib
+  core/diffutils
 )
 pkg_bin_dirs=(bin sbin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
-do_build() {
-  ./configure --prefix="${pkg_prefix}"
-
-  make
+do_check() {
+	make check
 }

--- a/dpkg/tests/test.bats
+++ b/dpkg/tests/test.bats
@@ -1,6 +1,6 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(dpkg --version | head -1 | awk '{print $7}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec $TEST_PKG_IDENT dpkg --version | head -1 | awk '{print $7}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }

--- a/dpkg/tests/test.sh
+++ b/dpkg/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This updates the version of dpkg, 1.19.4 is no longer hosted.  

The do_build implementation was the default so it was removed. do_check was added, along with a dependency of `gcc-libs` and a build dependency of `diffutils` for `make check` to pass.  

It also updates the testing to match the latest standards. 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>