### PR TITLE
[papi] Update to latest version

### DIFF
--- a/papi/plan.sh
+++ b/papi/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=papi
 pkg_origin=core
-pkg_version=5.6.0
+pkg_version=5.7.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Performance API"
 pkg_upstream_url="http://icl.cs.utk.edu/papi/"
 pkg_license=('BSD-3-Clause')
 pkg_source="http://icl.utk.edu/projects/${pkg_name}/downloads/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="49b7293f9ca2d74d6d80bd06b5c4be303663123267b4ac0884cbcae4c914dc47"
+pkg_shasum="d1a3bb848e292c805bc9f29e09c27870e2ff4cda6c2fba3b7da8b4bba6547589"
 pkg_deps=(
   core/glibc
 )
@@ -20,6 +20,7 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)
+
 
 do_prepare() {
   export LIBRARY_PATH
@@ -35,5 +36,11 @@ do_build() {
 do_install() {
   pushd src > /dev/null
     do_default_install
+  popd > /dev/null
+}
+
+do_check() {
+  pushd src > /dev/null
+    make test
   popd > /dev/null
 }


### PR DESCRIPTION
This updates to the latest version of papi, which is needed to build under the upcoming glibc/gcc updates. 
 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>