### PR TITLE
[flatbuffers] Update to 1.11

### DIFF
--- a/flatbuffers/plan.sh
+++ b/flatbuffers/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=flatbuffers
 pkg_origin=core
-pkg_version=1.10.0
+pkg_version=1.11.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="$(cat << EOF
@@ -10,15 +10,18 @@ pkg_description="$(cat << EOF
 EOF
 )"
 pkg_source="https://github.com/google/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="3714e3db8c51e43028e10ad7adffb9a36fc4aa5b1a363c2d0c4303dd1be59a7c"
+pkg_shasum="3f4a286642094f45b1b77228656fbd7ea123964f19502f9ecfd29933fd23a50b"
 pkg_upstream_url="http://google.github.io/flatbuffers/index.html"
 pkg_deps=(
+  core/glibc
+  core/gcc-libs
 )
 pkg_build_deps=(
   core/cmake
   core/gcc
   core/make
 )
+pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib64)
 

--- a/flatbuffers/tests/test.bats
+++ b/flatbuffers/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} flatc --version | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/flatbuffers/tests/test.sh
+++ b/flatbuffers/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This update allows us to build against upcoming glibc2.29 and gcc9.1 packages. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>