### PR TITLE
[gnatsd] Update build process

### DIFF
--- a/bin/ci/test_helpers.sh
+++ b/bin/ci/test_helpers.sh
@@ -26,7 +26,7 @@ ci_ensure_supervisor_running() {
     hab sup run > /hab/sup/default/sup.log 2>&1 &
   fi
 
-  for retry in {1..5}; do
+  for retry in {1..20}; do
     sleep 1
     hab sup status > /dev/null 2>&1 && break
     echo "Waiting for Supervisor to start: $retry"
@@ -41,7 +41,7 @@ ci_ensure_supervisor_running() {
 # Loads the specified service
 # Retries until the service shows running or it specified timeout (default 5 seconds)
 # period has passed.
-ci_ensure_service_loaded() {
+ci_load_service() {
   service="$1"
   timeout="${2:-5}"
 

--- a/bin/ci/test_helpers.sh
+++ b/bin/ci/test_helpers.sh
@@ -1,0 +1,64 @@
+# This file is a collection of commonly used functions in testing core-plans
+
+# Attempts to start a supervisor.
+# Detects if a supervisor is already running and emits a warning if one is found
+# Shares logging path with the studio supervisor.
+# This is to allow local testing of packages, which will likely happen in a
+# studio, to behave as close as possible to CI.
+ci_ensure_supervisor_running() {
+  # We can't use `hab sup status` as the exit code for `not running` vs.
+  # `running but recieved an error` is the same. In the case of the later
+  # we'll catch the error in the retry logic that ensures the supervisor
+  # is running before handing control back to the tests
+  #
+  # The studio doesn't contain ps by default so we need to use the presence
+  # of the LOCK file to attempt to determine if the supervisor is running.
+  #
+  # Failure case: Supervisor is stopped, but LOCK file is still present
+  if [ -f /hab/sup/default/LOCK ]; then
+    echo "--- :warning: Supervisor LOCK file found, not starting the supervisor"
+  else
+    echo "--- :habicat: Starting the supervisor"
+    if [ ! -f /hab/sup/default/sup.log ]; then
+      mkdir -p /hab/sup/default
+      touch /hab/sup/default/sup.log
+    fi
+    hab sup run > /hab/sup/default/sup.log 2>&1 &
+  fi
+
+  for retry in {1..5}; do
+    sleep 1
+    hab sup status > /dev/null 2>&1 && break
+    echo "Waiting for Supervisor to start: $retry"
+  done
+
+  if [ "$retry" -eq 5 ]; then
+    echo "--- :boomboom: Unable to connect to supervisor"
+    exit 1
+  fi
+}
+
+# Loads the specified service
+# Retries until the service shows running or it specified timeout (default 5 seconds)
+# period has passed.
+ci_ensure_service_loaded() {
+  service="$1"
+  timeout="${2:-5}"
+
+  echo "--- :habicat: Loading service $service"
+  hab svc load "$service"
+
+  for retry in $(seq 1 "$timeout"); do
+    sleep 1
+    state="$(hab svc status | grep $service |awk '{print $4}')"
+    if [ "$state" == "up" ]; then
+      break
+    fi
+    echo "Waiting for $service to start: $retry"
+  done
+
+  if [ "$retry" -eq "$timeout" ]; then
+    echo "--- :boomboom: Unable to load service $service"
+    exit 1
+  fi
+}

--- a/gnatsd/plan.sh
+++ b/gnatsd/plan.sh
@@ -1,4 +1,5 @@
 pkg_name=gnatsd
+pkg_distname=nats-server
 pkg_origin=core
 pkg_version=1.4.1
 pkg_description="A High Performance NATS Server written in Go."
@@ -6,7 +7,8 @@ pkg_upstream_url=https://github.com/nats-io/gnatsd
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/nats-io/gnatsd/archive/v${pkg_version}.tar.gz"
-pkg_shasum=1d319ec9466d5b4d56b8dc0c059bbb50942a8e988c3dcc155271476c3ae629a1
+pkg_shasum=63c1b782e423cbbd83c64bf32d2d65d00031907efdd418b17a48bf4c853e54e4
+pkg_dirname="$pkg_distname-$pkg_version"
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)

--- a/gnatsd/tests/test.bats
+++ b/gnatsd/tests/test.bats
@@ -1,16 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v gnatsd)" ]
-}
-
 @test "Version matches" {
-  result="$(gnatsd -v)"
-  [ "$result" = "nats-server version ${pkg_version}" ]
+  expected_version="$(cut -d/ -f3 <<< "$TEST_PKG_IDENT")"
+  result="$(hab pkg exec $TEST_PKG_IDENT gnatsd -v)"
+  [ "$result" = "nats-server version ${expected_version}" ]
 }
 
 @test "Help command" {
-  run gnatsd -h
+  run hab pkg exec $TEST_PKG_IDENT gnatsd -h
   [ $status -eq 0 ]
 }
 

--- a/gnatsd/tests/test.sh
+++ b/gnatsd/tests/test.sh
@@ -25,7 +25,7 @@ hab pkg install "${TEST_PKG_IDENT}"
 
 
 ci_ensure_supervisor_running
-ci_ensure_service_loaded "$TEST_PKG_IDENT"
+ci_load_service "$TEST_PKG_IDENT"
 
 bats "$(dirname "${0}")/test.bats"
 

--- a/gnatsd/tests/test.sh
+++ b/gnatsd/tests/test.sh
@@ -1,34 +1,29 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
+hab svc load "${TEST_PKG_IDENT}"
+sleep 5
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+bats "$(dirname "${0}")/test.bats"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 10
-fi
-
-bats "${TESTDIR}/test.bats"
+hab svc unload "${TEST_PKG_IDENT}"

--- a/gnatsd/tests/test.sh
+++ b/gnatsd/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source bin/ci/test_helpers.sh
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -21,8 +23,9 @@ hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab svc load "${TEST_PKG_IDENT}"
-sleep 5
+
+ci_ensure_supervisor_running
+ci_ensure_service_loaded "$TEST_PKG_IDENT"
 
 bats "$(dirname "${0}")/test.bats"
 


### PR DESCRIPTION
`nats-io/gnatsd` has been renamed to `nats-io/nats-server`. The upstream provider has also repackaged their tarballs with the updated name.  This PR is in place to correct that.

This package should be renamed to `core/nats-server`, however they have also released a new major version that doesn't appear to be backwards compatible and the 1.x series don't appear to be released anymore.  

I think the right thing to do in this case is to take this PR as-is (barring any errors in CI), so that we have a gnatsd artifact post-refresh to allow people to make that transition.   

Once the refresh is complete, a new nats-server package that tracks the 2.x series should be released and this package can be deprecated.  

This should give users an upgrade path through the refresh, and allow them to make the transition from gnatsd to nats-server without a potential breaking release. 

If it turns out that the 1.x series is still supported, then I think we'll still want to punt on the rename until post-refresh to give users an upgrade path through it before making the name transition. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>