### PR TITLE
[terraform] Updating to 0.12.4

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.12.3
+pkg_version=0.12.4
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
 pkg_filename="${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=75e4323b8514074f8c2118ea382fc677c8b1d1730eda323ada222e0fac57f7db
+pkg_shasum=0231562f26262de233e8e8fac668196af21b7aff355bb04f3ee1606cca239c0a
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Hello all,

This PR brings Terraform up to 0.12.4. To test the build, please run the following:
```
hab pkg build terraform
source results/last_build.env
hab studio run "./terraform/tests/test.sh ${pkg_ident}"
```
The result should be:
```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```

Please let me know if there are any questions. 
