### PR TITLE
[python-minimal] New plan 

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1215,6 +1215,8 @@ plan_path = "python37"
 paths = [
   "python/*"
 ]
+[python-minimal]
+plan_path = "python-minimal"
 [qemu]
 plan_path = "qemu"
 [R]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,6 +95,7 @@ vim @fnichol @nellshamrell @smacfarlane
 libbsd @fnichol @smacfarlane
 clens @fnichol @smacfarlane
 mg @fnichol @smacfarlane
+python-minimal @smacfarlane
 powershell @mwrock
 7zip @mwrock
 docker-credential-helper @mwrock

--- a/base-plans.txt
+++ b/base-plans.txt
@@ -50,6 +50,7 @@ core-plans/make
 core-plans/patch
 core-plans/texinfo
 core-plans/util-linux
+core-plans/python-minimal
 core-plans/tcl
 core-plans/expect
 core-plans/dejagnu

--- a/python-minimal/README.md
+++ b/python-minimal/README.md
@@ -1,0 +1,20 @@
+# python-minimal
+
+This package is intended to be used only as a build dependency for glibc.
+
+If you would like to use Python in your applications, please look at `core/python` or one of the other versioned Python packages.
+
+## Why does this package exist?
+
+With glibc2.29, python was introduced as a build dependency. If we were to include `core/python` as a build dependency for `core/glibc`
+it would increase the number of items that are considered "base plans", i.e. plans that are required in order to bootstrap the Habitat
+ecosystem. This would make packages like Python and sqlite more difficult to update. Having `core/python` as a build dependency for
+`core/glibc` means that the footprint of packages that would cause the world to rebuild would be greatly increased, resulting in slower
+updates for those packages or more churn across our entire ecosystem.
+
+As a result, this package (`python-minimal`) was introduced so that we have a version of Python that has minimal depdencies, should need
+infrequent updates, and keeps the number of packages that would cause a "world rebuild" to a minimum.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>

--- a/python-minimal/plan.sh
+++ b/python-minimal/plan.sh
@@ -1,0 +1,62 @@
+pkg_name=python-minimal
+pkg_distname=Python
+pkg_version=3.7.0
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively. \
+  \
+  This package is not intended for regular use. Please use core/python instead."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/python bin/python3 bin/python3.7)
+
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/linux-headers
+  core/make
+  core/util-linux
+)
+
+do_build() {
+  export LDFLAGS="$LDFLAGS -lgcc_s"
+
+  ./configure --prefix="$pkg_prefix" --without-ensurepip
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # link pythonx.x to python for pkg_interpreters
+  local minor=${pkg_version%.*}
+  local major=${minor%.*}
+  ln -rs "$pkg_prefix/bin/pip$minor" "$pkg_prefix/bin/pip"
+  ln -rs "$pkg_prefix/bin/pydoc$minor" "$pkg_prefix/bin/pydoc"
+  ln -rs "$pkg_prefix/bin/python$minor" "$pkg_prefix/bin/python"
+  ln -rs "$pkg_prefix/bin/python$minor-config" "$pkg_prefix/bin/python-config"
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle$major"
+  rm -vf "$pkg_prefix/bin/idle$minor"
+
+  platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
+  cat <<EOF > "$platlib/_manylinux.py"
+# Disable binary manylinux1(CentOS 5) wheel support
+manylinux1_compatible = False
+EOF
+}

--- a/python-minimal/tests/test.sh
+++ b/python-minimal/tests/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+echo "This package is intended only for use with build glibc."
+echo "Please verify any changes to this by building glibc with the updated version of this package."


### PR DESCRIPTION
With glibc2.29, python was introduced as a build dependency. If we were to include `core/python` as a build dependency for `core/glibc` it would increase the number of items that are considered "base plans", i.e. plans that are required in order to bootstrap the Habitat ecosystem. This would make packages like Python and sqlite more difficult to update. Having `core/python` as a build dependency for `core/glibc` also would mean that the footprint of packages that would cause the world to rebuild would be greatly increased, resulting in slower updates for those packages, or more churn across our entire ecosystem.

As a result, this package (`python-minimal`) was introduced so that we have a version of Python that has minimal dependencies, should need infrequent updates, and keeps the number of packages that would cause a "world rebuild" to a minimum.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>