### PR TITLE
[vim] Update to latest release

### DIFF
--- a/vim/plan.sh
+++ b/vim/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=vim
 pkg_origin=core
-pkg_version=8.1.0577
+pkg_version=8.1.1694
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Vim is a highly configurable text editor built to make creating and changing \
@@ -10,7 +10,7 @@ systems and with Apple OS X.\
 pkg_upstream_url="http://www.vim.org/"
 pkg_license=("Vim")
 pkg_source="http://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="16a6a8590a36b9c114a2c4a171598a4d07ac9c214fb80bc490c76bfa7e6446dd"
+pkg_shasum="51dc24a7954cc9f8d75be02870ce32dcd7185139688f998b27d135e34de57ca4"
 pkg_deps=(
   core/acl
   core/attr

--- a/vim/tests/test.bats
+++ b/vim/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} vim --version | head -n3 | tail -n1)"
+  [ "$result" = "Compiled by Habitat, vim release ${TEST_PKG_VERSION}" ]
+}

--- a/vim/tests/test.sh
+++ b/vim/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This updates to the 8.1.1694 to address https://nvd.nist.gov/vuln/detail/CVE-2019-12735 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>