### PR TITLE
[bash] Update to latest version 

### DIFF
--- a/bash/bash-patches.sh
+++ b/bash/bash-patches.sh
@@ -3,46 +3,22 @@ _patch_url_base="$_url_base/${_distname}-${_base_version}-patches/${_distname}${
 
 # All official patch file URLs
 _patch_files=(
-  ${_patch_url_base}-001
-  ${_patch_url_base}-002
-  ${_patch_url_base}-003
-  ${_patch_url_base}-004
-  ${_patch_url_base}-005
-  ${_patch_url_base}-006
-  ${_patch_url_base}-007
-  ${_patch_url_base}-008
-  ${_patch_url_base}-009
-  ${_patch_url_base}-010
-  ${_patch_url_base}-011
-  ${_patch_url_base}-012
-  ${_patch_url_base}-013
-  ${_patch_url_base}-014
-  ${_patch_url_base}-015
-  ${_patch_url_base}-016
-  ${_patch_url_base}-017
-  ${_patch_url_base}-018
-  ${_patch_url_base}-019
+  "${_patch_url_base}"-001
+  "${_patch_url_base}"-002
+  "${_patch_url_base}"-003
+  "${_patch_url_base}"-004
+  "${_patch_url_base}"-005
+  "${_patch_url_base}"-006
+  "${_patch_url_base}"-007
 )
 
 # All official patch file shasums
 _patch_shasums=(
-  3e28d91531752df9a8cb167ad07cc542abaf944de9353fe8c6a535c9f1f17f0f
-  7020a0183e17a7233e665b979c78c184ea369cfaf3e8b4b11f5547ecb7c13c53
-  51df5a9192fdefe0ddca4bdf290932f74be03ffd0503a3d112e4199905e718b2
-  ad080a30a4ac6c1273373617f29628cc320a35c8cd06913894794293dc52c8b3
-  221e4b725b770ad0bb6924df3f8d04f89eeca4558f6e4c777dfa93e967090529
-  6a8e2e2a6180d0f1ce39dcd651622fb6d2fd05db7c459f64ae42d667f1e344b8
-  de1ccc07b7bfc9e25243ad854f3bbb5d3ebf9155b0477df16aaf00a7b0d5edaf
-  86144700465933636d7b945e89b77df95d3620034725be161ca0ca5a42e239ba
-  0b6bdd1a18a0d20e330cc3bc71e048864e4a13652e29dc0ebf3918bea729343c
-  8465c6f2c56afe559402265b39d9e94368954930f9aa7f3dfa6d36dd66868e06
-  dd56426ef7d7295e1107c0b3d06c192eb9298f4023c202ca2ba6266c613d170d
-  fac271d2bf6372c9903e3b353cb9eda044d7fe36b5aab52f21f3f21cd6a2063e
-  1b25efacbc1c4683b886d065b7a089a3601964555bcbf11f3a58989d38e853b6
-  a7f75cedb43c5845ab1c60afade22dcb5e5dc12dd98c0f5a3abcfb9f309bb17c
-  d37602ecbeb62d5a22c8167ea1e621fcdbaaa79925890a973a45c810dd01c326
-  501f91cc89fadced16c73aa8858796651473602c722bb29f86a8ba588d0ff1b1
-  773f90b98768d4662a22470ea8eec5fdd8e3439f370f94638872aaf884bcd270
-  5bc494b42f719a8b0d844b7bd9ad50ebaae560e97f67c833c9e7e9d53981a8cc
-  27170d6edfe8819835407fdc08b401d2e161b1400fe9d0c5317a51104c89c11e
+  f2fe9e1f0faddf14ab9bfa88d450a75e5d028fedafad23b88716bd657c737289
+  87e87d3542e598799adb3e7e01c8165bc743e136a400ed0de015845f7ff68707
+  4eebcdc37b13793a232c5f2f498a5fcbf7da0ecb3da2059391c096db620ec85b
+  14447ad832add8ecfafdce5384badd933697b559c4688d6b9e3d36ff36c62f08
+  5bf54dd9bd2c211d2bfb34a49e2c741f2ed5e338767e9ce9f4d41254bf9f8276
+  d68529a6ff201b6ff5915318ab12fc16b8a0ebb77fda3308303fcc1e13398420
+  17b41e7ee3673d8887dd25992417a398677533ab8827938aa41fad70df19af9b
 )

--- a/bash/plan.sh
+++ b/bash/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=bash
 _distname="$pkg_name"
 pkg_origin=core
-_base_version=4.4
-pkg_version=${_base_version}.19
+_base_version=5.0
+pkg_version=${_base_version}.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
  Bash is the GNU Project's shell. Bash is the Bourne Again SHell. Bash is an \
@@ -13,10 +13,10 @@ improvements over sh for both programming and interactive use. In addition, \
 most sh scripts can be run by Bash without modification.\
 "
 pkg_upstream_url="http://www.gnu.org/software/bash/bash.html"
-pkg_license=('gplv3+')
+pkg_license=('GPL-3.0-or-later')
 _url_base="http://ftp.gnu.org/gnu/$_distname"
 pkg_source="$_url_base/${_distname}-${_base_version}.tar.gz"
-pkg_shasum="d86b3392c1202e8ff5a423b302e6284db7f8f435ea9f39b5b1b20fd3ac36dfcb"
+pkg_shasum="b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d"
 pkg_dirname="${_distname}-$_base_version"
 pkg_deps=(
   core/glibc
@@ -29,6 +29,7 @@ pkg_build_deps=(
   core/patch
   core/make
   core/gcc
+  core/perl
 )
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/bash bin/sh)
@@ -92,7 +93,7 @@ do_check() {
   for cmd in /bin/rm /bin/cat /bin/touch /bin/chmod /usr/bin/printf /bin/echo; do
     if [[ ! -r "$cmd" ]]; then
       ln -sv "$(pkg_path_for coreutils)/bin/$(basename "$cmd")" "$cmd"
-      clean_cmds+=($cmd)
+      clean_cmds+=("$cmd")
     fi
   done
 

--- a/bash/tests/test.bats
+++ b/bash/tests/test.bats
@@ -1,0 +1,4 @@
+@test "can execute commands" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} bash -c 'echo "$BASH"' )"
+  [ "$result" == "/hab/pkgs/$TEST_PKG_IDENT/bin/bash" ]
+}

--- a/bash/tests/test.sh
+++ b/bash/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This updates Bash to 5.0.7, with the latest set of patches (the .7) :wink: 

It also adds a small test to ensure that it can execute and sets internal variables correctly. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>