### PR TITLE
[jenkins]  Replace jdk with corretto

### DIFF
--- a/jenkins/hooks/run
+++ b/jenkins/hooks/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-export JAVA_HOME="{{pkgPathFor "core/jre8"}}"
+export JAVA_HOME="{{pkgPathFor "core/corretto8"}}"
 export JENKINS_HOME="{{pkg.svc_data_path}}"
 
 exec java \

--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
 pkg_shasum="4fc2700a27a6ccc53da9d45cc8b2abd41951b361e562e1a1ead851bea61630fd"
-pkg_deps=(core/jre8 core/curl)
+pkg_deps=(core/corretto8 core/curl)
 pkg_exports=(
   [port]=jenkins.http.port
 )

--- a/jenkins/tests/test.bats
+++ b/jenkins/tests/test.bats
@@ -1,13 +1,7 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Version matches" {
-  result="$(java -jar $(hab pkg path ${HAB_ORIGIN}/jenkins)/jenkins.war --version)"
-  [ "$result" = "${pkg_version}" ]
-}
-
-@test "Help command" {
-  run java -jar $(hab pkg path ${HAB_ORIGIN}/jenkins)/jenkins.war --help
-  [ $status -eq 0 ]
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "jenkins binary version matches ${expected_version}" {
+  actual_version="$(java -jar $(hab pkg path ${HAB_ORIGIN}/jenkins)/jenkins.war --version)"
+  diff <( echo "$actual_version") <( echo "${expected_version}")
 }
 
 @test "Service is running" {
@@ -15,5 +9,6 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 }
 
 @test "Listening on port 80 (HTTP)" {
-  [ "$(netstat -peanut | grep java | awk '{print $4}' | awk -F':' '{print $2}' | grep 80)" ]
+  # ensure that both ipv6 "::ffff:172.17.0.2:80" and ipv4 "172.17.0.2:80" will match
+  [ "$(netstat -peanutl | grep java | awk '{print $4}' | awk -F':' '{print $NF}' | grep 80 )" ]
 }


### PR DESCRIPTION
### Outstanding tasks
- [ ] Scott updated Graham?  Approved and merged?

### Completed tasks
- [x] Fix the service level tests: needed to extract eth0 IP, needed to update test.sh to wait for service setup before running tests
- [x] Fix buildkite test failure: the test is expecting an ipv4 IP address when buildkite is returning an ipv6 one instead.
- [x] Try using core/corretto to fix the Java 8 problem for the service.
- [x] Fix the test.bats according to predominant's comment
- [x] Extract the interface, e.g., eth0 using iproute
- [x] Rebuild with core/corretto8.  Tests continue to work.
- [x] Reuse the bin/ci/test_helpers.sh and verify tests continue to pass
- [x] Squash the commits