### PR TITLE
[logstash] Replace jdk with corretto8

### DIFF
--- a/logstash/hooks/init
+++ b/logstash/hooks/init
@@ -3,3 +3,4 @@
 exec 2>&1
 
 mkdir -p {{pkg.svc_var_path}}/data
+mkdir -p {{pkg.svc_var_path}}/log

--- a/logstash/plan.sh
+++ b/logstash/plan.sh
@@ -8,8 +8,9 @@ pkg_license=(Apache-2.0)
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=72dcd1cf21e55cd44503ca7c452aaaa88286564ba1450d5d05941f88e2699cc3
 pkg_deps=(core/bash
-  core/jre8
+  core/corretto8
   core/coreutils
+  core/sed
 )
 pkg_build_deps=(core/bash)
 pkg_bin_dirs=(bin)

--- a/logstash/tests/test.bats
+++ b/logstash/tests/test.bats
@@ -1,24 +1,14 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v logstash)" ]
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "logstash binary matches version ${expected_version}" {
+  local actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" logstash --version | awk '{print $2}')"
+  diff <(echo "${actual_version}") <(echo "${expected_version}")
 }
 
-@test "Version matches" {
-  result="$(logstash --version | awk '{print $2}')"
-  [ "$result" = "${pkg_version}" ]
-}
-
-@test "Help command" {
-  run logstash --help
-  [ $status -eq 0 ]
-}
-
-@test "Service is running" {
+@test "service is running" {
   [ "$(hab svc status | grep "logstash\.default" | awk '{print $4}' | grep up)" ]
 }
 
-@test "A single process" {
+@test "service has single process" {
   result="$(ps aux | grep -v grep | grep -v "test" | grep logstash | wc -l)"
   [ "${result}" -eq 1 ]
 }

--- a/logstash/tests/test.sh
+++ b/logstash/tests/test.sh
@@ -1,34 +1,38 @@
 #!/bin/sh
+set -euo pipefail
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-hab pkg install core/bats --binlink
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
 
-hab pkg install core/jre8 --binlink
-
-hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
-hab pkg binlink core/busybox-static wc
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 5
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/corretto8 --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ifconfig
+hab pkg binlink core/busybox-static wc
+hab pkg binlink core/busybox-static ps
+
+hab pkg install "${TEST_PKG_IDENT}"
+
+
+ci_ensure_supervisor_running
+ci_load_service "$TEST_PKG_IDENT"
+
+# run the tests
+bats "$(dirname "${0}")/test.bats"
+
+# unload the service
+hab svc unload "${TEST_PKG_IDENT}" || true
+# kill %1


### PR DESCRIPTION
### Outstanding tasks
- [x] Scott approved
- [ ] Fix comment; squash commits and merge myself.
- [ ] Waiting on code owner predominant to approve.

### Completed Tasks
- [x] Fix broken test, missing sed dependency by adding core/sed to $pkg_deps
- [x] Verified that corretto8 fixes the issue.  Java exception **Unrecognized VM   option 'UseParNewGC'** no longer occurs.
- [x] Update the tests and re-use the bin/ci/test_helpers.sh
- [x] Squash commits
- [x] Fix tests amend source of test_helpers.sh; remove comments