### PR TITLE
[mesa] Update download url

### DIFF
--- a/mesa/plan.sh
+++ b/mesa/plan.sh
@@ -6,6 +6,7 @@ pkg_upstream_url="https://www.mesa3d.org"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://mesa.freedesktop.org/archive/${pkg_name}-${pkg_version}.tar.xz"
+pkg_source="https://mesa.freedesktop.org/archive/older-versions/17.x/${pkg_name}-${pkg_version}.tar.xz"
 pkg_shasum=7f7f914b7b9ea0b15f2d9d01a4375e311b0e90e55683b8e8a67ce8691eb1070f
 pkg_deps=(
   core/elfutils

--- a/mesa/tests/test.sh
+++ b/mesa/tests/test.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+
+echo "This package provides libraries and headers and currently has no tests"


### PR DESCRIPTION
Mesa download URL has changed. There are new major versions available, but it requires additional X packages to be built. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>