### PR TITLE
[scaffolding-go] Go Module Mode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ log/
 results/
 tmp/
 tags
+*.swp

--- a/scaffolding-go/README.md
+++ b/scaffolding-go/README.md
@@ -1,8 +1,16 @@
 # Go Scaffolding
-The go scaffolding can be use to package application from a remote repository or from local source. It automatically configures the `GOPATH` environment variable and can download Go dependendencies via `go get`.
+The go scaffolding can be use to package application from a remote repository or
+from local source. It has two available modes:
+* GOPATH Mode
+* Module Mode
+
+## GOPATH Mode
+In this mode, the Go Scaffolding will automatically configure
+the `GOPATH` environment variable and directory structure.
 
 ### From a remote repository
-By adding the `pkg_source` variable you will be telling the go scaffolding to package the application from a remote repository.
+By adding the `pkg_source` variable you will be telling the go scaffolding to
+package the application from a remote repository.
 
 An example of a `plan.sh`:
 ```
@@ -14,9 +22,12 @@ pkg_source="http://github.com/afiune/hello-go"
 ```
 
 ### From local source
-If you are building an application from local source, you have to avoid defining the `pkg_source` variable, this way the go scaffolding will prapare the Go Workspace to build and package your local application.
+If you are building an application from local source, you have to avoid defining
+the `pkg_source` variable, this way the go scaffolding will prapare a Go Workspace
+to build and package your local application.
 
-Optionally, you can define the `scaffolding_go_base_path` if you are planning to keep your code in a source repository somewhere.
+Optionally, you can define the `scaffolding_go_base_path` if you are planning to
+keep your code in a source repository somewhere.
 
 An example of a `plan.sh`:
 ```
@@ -27,15 +38,30 @@ pkg_scaffolding=core/scaffolding-go
 scaffolding_go_base_path=github.com/afiune
 ```
 
+## Go Module Mode
+This mode allows you to build your go application outside a Go
+Workspace, it requires the existence of the [`go.mod` file.](https://golang.org/cmd/go/#hdr-The_go_mod_file)
+
+An example of a `plan.sh`:
+```
+pkg_name=hello-go
+pkg_origin=afiune
+pkg_version="0.1.0"
+pkg_scaffolding=core/scaffolding-go
+scaffolding_go_module=on
+```
+
 ## Getting Started with Scaffolding
-See https://www.habitat.sh/docs/concepts-scaffolding/ to learn how to get started with Scaffolding.
+See https://www.habitat.sh/docs/concepts-scaffolding/ to learn how to get started
+with Scaffolding.
 
 ## Variables
 | Variable | Type | Value | Default |
 | -------- | ---- | ----- | ------- |
-|`scaffolding_go_gopath`| String |_(Optional)_ Value for `GOPATH`|`$SRC_PATH`|
+|`scaffolding_go_gopath`| String | _(Optional)_ Value for `GOPATH` | `$SRC_PATH` |
 |`scaffolding_go_base_path`| String | _(Optional)_  The base path that will be used in the import path construction. Eg: `github.com/myorg`| `localhost/user`|
 |`scaffolding_go_build_deps`| Array  | _(Optional)_ Array of URLs to `go get` | Undefined |
+|`scaffolding_go_module`| String  | _(Optional)_  Enable or disable go module support: `off` or `on`| `auto` |
 
 ## Callbacks
 ### Scaffolding

--- a/scaffolding-go/lib/go_module.sh
+++ b/scaffolding-go/lib/go_module.sh
@@ -1,0 +1,40 @@
+#
+# Go Module Mode
+#
+
+do_default_before() {
+  return 0
+}
+
+do_default_download() {
+  return 0
+}
+
+do_default_clean() {
+  build_line "Clean go cache"
+  pushd "$SRC_PATH" > /dev/null
+    go clean -r -i
+  popd > /dev/null
+}
+
+do_default_verify() {
+  return 0
+}
+
+do_default_unpack() {
+  return 0
+}
+
+do_default_build() {
+  pushd "$SRC_PATH" > /dev/null
+    if [[ -f "Makefile" ]]; then
+      make
+    else
+      go build
+    fi
+  popd > /dev/null
+}
+
+do_default_install() {
+  mv "${SRC_PATH}/${pkg_name}" "${pkg_prefix}/bin/"
+}

--- a/scaffolding-go/lib/go_module.sh
+++ b/scaffolding-go/lib/go_module.sh
@@ -36,5 +36,7 @@ do_default_build() {
 }
 
 do_default_install() {
+  # Avoids the need to have pkg_bin_dirs=(bin) on every plan
+  mkdir -p "${pkg_prefix}/bin/"
   mv "${SRC_PATH}/${pkg_name}" "${pkg_prefix}/bin/"
 }

--- a/scaffolding-go/lib/gopath_mode.sh
+++ b/scaffolding-go/lib/gopath_mode.sh
@@ -66,7 +66,7 @@ scaffolding_go_before() {
 
 scaffolding_go_get() {
   local deps
-  deps=($pkg_source ${scaffolding_go_build_deps[@]})
+  deps=("$pkg_source" "${scaffolding_go_build_deps[@]}")
   build_line "Downloading Go build dependencies"
   if [[ "${#deps[@]}" -gt 0 ]] ; then
     for dependency in "${deps[@]}" ; do

--- a/scaffolding-go/lib/gopath_mode.sh
+++ b/scaffolding-go/lib/gopath_mode.sh
@@ -1,0 +1,146 @@
+#
+# DO NOT OVERRIDE `do_default_xxxxx` IN PLANS!
+#
+
+# This strips URI prefixes from strings passed into the function. This is
+# required for `go get` to function since it does not support URI.
+_sanitize_pkg_source() {
+  local uri
+  local scheme
+  uri="$1"
+  scheme="$(echo "$uri" | grep :// | sed -e's%^\(.*://\).*%\1%g')"
+  printf "%s" "${uri/$scheme/}"
+}
+
+#
+# Scaffolding Variables
+#
+
+# Path constuctor for GOPATH
+export scaffolding_go_gopath=${scaffolding_go_gopath:-"${HAB_CACHE_SRC_PATH}/scaffolding-go-gopath"}
+
+# Set GOPATH
+#
+# The GOPATH is very important to develop go applications, it has a very strict directory
+# structure that we need to follow.
+#
+# => Read more about it at: https://golang.org/doc/code.html#Workspaces
+export GOPATH="$scaffolding_go_gopath"
+
+# Path to the Workspace src/ directory
+export scaffolding_go_workspace_src="$GOPATH/src"
+
+# Base path
+#
+# When you start having sub-packages or dependencies you are going to need to choose a
+# unique base_path, if you don't specify one, we will use the default localhost/user.
+#
+# => Read more about it at: https://golang.org/doc/code.html#ImportPaths
+export scaffolding_go_base_path=${scaffolding_go_base_path:-"localhost/user"}
+
+# If $pkg_source is set, it means that we are building a packages from source.
+# Otherwise we will try to build the package from the local /src. To do that we
+# need to check if $scaffolding_go_base_path is set, if not we will use the
+# default `localhost/user` since Go looks at this path structure to create
+# the directory structure inside the Go Workspace.
+if [ "$pkg_source" ]; then
+  scaffolding_go_pkg_path="$scaffolding_go_workspace_src/$(_sanitize_pkg_source "$pkg_source")"
+else
+  scaffolding_go_pkg_path="$scaffolding_go_workspace_src/$scaffolding_go_base_path/$pkg_name"
+fi
+
+export scaffolding_go_pkg_path
+
+#
+# Scaffolding Callback Functions
+#
+
+scaffolding_go_before() {
+  # Initialize the Go Workspace package path if we are tryng to build the
+  # package from local /src, that is when there is no $pkg_source set.
+  if [ ! "$pkg_source" ]; then
+    mkdir -p "$scaffolding_go_workspace_src/$scaffolding_go_base_path"
+    ln -sf "${SRC_PATH:-/src}" "$scaffolding_go_pkg_path"
+  fi
+}
+
+scaffolding_go_get() {
+  local deps
+  deps=($pkg_source ${scaffolding_go_build_deps[@]})
+  build_line "Downloading Go build dependencies"
+  if [[ "${#deps[@]}" -gt 0 ]] ; then
+    for dependency in "${deps[@]}" ; do
+      go get "$(_sanitize_pkg_source "$dependency")"
+    done
+  fi
+}
+
+# Fetch golang specific build dependencies.
+scaffolding_go_download() {
+  scaffolding_go_get
+}
+
+# Recursively clean GOPATH and dependencies.
+scaffolding_go_clean() {
+  local clean_args
+  clean_args="-r -i"
+  if [[ -n "$DEBUG" ]]; then
+    clean_args="$clean_args -x"
+  fi
+
+  build_line "Clean the cache"
+
+  pushd "$scaffolding_go_pkg_path" >/dev/null
+  # shellcheck disable=SC2086
+  go clean $clean_args
+  popd >/dev/null
+}
+
+# Assume a automake/autoconf build script if the go project uses one.
+# Otherwise, attempt to just run go build.
+scaffolding_go_build() {
+  export PATH="$PATH:$GOPATH/bin"
+
+  pushd "$scaffolding_go_pkg_path" >/dev/null
+  if [[ -f "$scaffolding_go_pkg_path/Makefile" ]]; then
+    make
+  else
+    go build
+  fi
+  popd >/dev/null
+}
+
+scaffolding_go_install() {
+  pushd "$scaffolding_go_pkg_path" >/dev/null
+  go install
+  popd >/dev/null
+  cp -r "${scaffolding_go_gopath:?}/bin" "${pkg_prefix}/${bin}"
+}
+
+do_default_before() {
+  scaffolding_go_before
+}
+
+do_default_download() {
+  scaffolding_go_download
+}
+
+do_default_clean() {
+  scaffolding_go_clean
+}
+
+do_default_verify() {
+  return 0
+}
+
+do_default_unpack() {
+  return 0
+}
+
+do_default_build() {
+  scaffolding_go_build
+}
+
+do_default_install() {
+  scaffolding_go_install
+}

--- a/scaffolding-go/lib/gopath_mode.sh
+++ b/scaffolding-go/lib/gopath_mode.sh
@@ -114,6 +114,8 @@ scaffolding_go_install() {
   pushd "$scaffolding_go_pkg_path" >/dev/null
   go install
   popd >/dev/null
+  # Avoids the need to have pkg_bin_dirs=(bin) on every plan
+  mkdir -p "${pkg_prefix}/bin/"
   cp -r "${scaffolding_go_gopath:?}/bin" "${pkg_prefix}/${bin}"
 }
 

--- a/scaffolding-go/lib/scaffolding.sh
+++ b/scaffolding-go/lib/scaffolding.sh
@@ -1,158 +1,20 @@
-#
-# DO NOT OVERRIDE `do_default_xxxxx` IN PLANS!
-#
-
-#
-# Internal functions. Do not use these in your plans as they can change.
-#
-
-# This strips URI prefixes from strings passed into the function. This is
-# required for `go get` to function since it does not support URI.
-_sanitize_pkg_source() {
-  local uri
-  local scheme
-  uri="$1"
-  scheme="$(echo "$uri" | grep :// | sed -e's%^\(.*://\).*%\1%g')"
-  printf "%s" "${uri/$scheme/}"
-}
-
 # The default_begin phase is executed prior to loading the scaffolding. As such
 # we have a scaffolding specific callback to allow us to run anything we need
 # to execute before download and build. This callback executes immediately
 # after the scaffolding is loaded.
 scaffolding_load() {
-  return 0
-}
+  local lib_dir
+  lib_dir="$(_pkg_path_for_build_deps "$pkg_scaffolding")/lib"
 
-#
-# Scaffolding Variables
-#
+  # When the user enables go module support,
+  # we don't need to setup the GOPATH
+  export GO111MODULE=${scaffolding_go_module:-"auto"}
 
-# Path constuctor for GOPATH
-export scaffolding_go_gopath=${scaffolding_go_gopath:-"${HAB_CACHE_SRC_PATH}/scaffolding-go-gopath"}
-
-# Set GOPATH
-#
-# The GOPATH is very important to develop go applications, it has a very strict directory
-# structure that we need to follow.
-#
-# => Read more about it at: https://golang.org/doc/code.html#Workspaces
-export GOPATH="$scaffolding_go_gopath"
-
-# Path to the Workspace src/ directory
-export scaffolding_go_workspace_src="$GOPATH/src"
-
-# Base path
-#
-# When you start having sub-packages or dependencies you are going to need to choose a
-# unique base_path, if you don't specify one, we will use the default localhost/user.
-#
-# => Read more about it at: https://golang.org/doc/code.html#ImportPaths
-export scaffolding_go_base_path=${scaffolding_go_base_path:-"localhost/user"}
-
-# If $pkg_source is set, it means that we are building a packages from source.
-# Otherwise we will try to build the package from the local /src. To do that we
-# need to check if $scaffolding_go_base_path is set, if not we will use the
-# default `localhost/user` since Go looks at this path structure to create
-# the directory structure inside the Go Workspace.
-if [[ $pkg_source ]]; then
-  scaffolding_go_pkg_path="$scaffolding_go_workspace_src/$(_sanitize_pkg_source "$pkg_source")"
-else
-  scaffolding_go_pkg_path="$scaffolding_go_workspace_src/$scaffolding_go_base_path/$pkg_name"
-fi
-
-export scaffolding_go_pkg_path
-
-#
-# Scaffolding Callback Functions
-#
-
-scaffolding_go_before() {
-  # Initialize the Go Workspace package path if we are tryng to build the
-  # package from local /src, that is when there is no $pkg_source set.
-  if [[ ! $pkg_source ]]; then
-    mkdir -p "$scaffolding_go_workspace_src/$scaffolding_go_base_path"
-    ln -sf "${SRC_PATH:-/src}" "$scaffolding_go_pkg_path"
-  fi
-}
-
-scaffolding_go_get() {
-  local deps
-  deps=($pkg_source ${scaffolding_go_build_deps[@]})
-  build_line "Downloading Go build dependencies"
-  if [[ "${#deps[@]}" -gt 0 ]] ; then
-    for dependency in "${deps[@]}" ; do
-      go get "$(_sanitize_pkg_source "$dependency")"
-    done
-  fi
-}
-
-# Fetch golang specific build dependencies.
-scaffolding_go_download() {
-  scaffolding_go_get
-}
-
-# Recursively clean GOPATH and dependencies.
-scaffolding_go_clean() {
-  local clean_args
-  clean_args="-r -i"
-  if [[ -n "$DEBUG" ]]; then
-    clean_args="$clean_args -x"
-  fi
-
-  build_line "Clean the cache"
-
-  pushd "$scaffolding_go_pkg_path" >/dev/null
-  # shellcheck disable=SC2086
-  go clean $clean_args
-  popd >/dev/null
-}
-
-# Assume a automake/autoconf build script if the go project uses one.
-# Otherwise, attempt to just run go build.
-scaffolding_go_build() {
-  export PATH="$PATH:$GOPATH/bin"
-
-  pushd "$scaffolding_go_pkg_path" >/dev/null
-  if [[ -f "$scaffolding_go_pkg_path/Makefile" ]]; then
-    make
+  if [[ "$GO111MODULE" == "on" ]]; then
+    build_line "Using Go Module Scaffolding"
+    source "${lib_dir}/go_module.sh"
   else
-    go build
+    build_line "Using GOPATH Mode Scaffolding"
+    source "${lib_dir}/gopath_mode.sh"
   fi
-  popd >/dev/null
-}
-
-scaffolding_go_install() {
-  pushd "$scaffolding_go_pkg_path" >/dev/null
-  go install
-  popd >/dev/null
-  cp -r "${scaffolding_go_gopath:?}/bin" "${pkg_prefix}/${bin}"
-}
-
-do_default_before() {
-  scaffolding_go_before
-}
-
-do_default_download() {
-  scaffolding_go_download
-}
-
-do_default_clean() {
-  scaffolding_go_clean
-}
-
-do_default_verify() {
-  return 0
-}
-
-do_default_unpack() {
-  return 0
-}
-
-do_default_build() {
-  scaffolding_go_build
-}
-
-do_default_install() {
-  scaffolding_go_install
 }

--- a/scaffolding-go/plan.sh
+++ b/scaffolding-go/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/habitat-sh/core-plans"
 pkg_deps=(
-  ${pkg_deps[@]}
+  "${pkg_deps[@]}"
   core/go
   core/git
   core/gcc

--- a/scaffolding-go/plan.sh
+++ b/scaffolding-go/plan.sh
@@ -2,7 +2,7 @@ pkg_name=scaffolding-go
 pkg_description="Scaffolding for Go Applications"
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version="0.1.0"
+pkg_version="0.2.0"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/habitat-sh/core-plans"
@@ -14,3 +14,9 @@ pkg_deps=(
   core/make
 )
 pkg_scaffolding=core/scaffolding-base
+
+do_install() {
+  install -D -m 0644 "$PLAN_CONTEXT/lib/scaffolding.sh" "$pkg_prefix/lib/scaffolding.sh"
+  install -D -m 0644 "$PLAN_CONTEXT/lib/gopath_mode.sh" "$pkg_prefix/lib/gopath_mode.sh"
+  install -D -m 0644 "$PLAN_CONTEXT/lib/go_module.sh" "$pkg_prefix/lib/go_module.sh"
+}


### PR DESCRIPTION
From the introduction of Go version `1.11` we have available a new way of building go
applications called Go Module Mode (aka "module-aware mode"). This mode does not
require you to configure a Go Workspace and it also has an alternative to maintain your
app package dependencies.

Go Docs:
https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more

This change is introducing said mode to the Go Scaffolding, but keeping the previous
behavior available to build packages inside a Go Workspace. (GOPATH mode)

New scaffolding variable `scaffolding_go_module` to switch between modes.
When enabling ` scaffolding_go_module=on` the scaffolding will build in module mode,
Otherwise, it will default to GOPATH mode. 

_Note that I bumped the minor version of the plan to `0.2.0`._