### PR TITLE
[bc] Add tests

### DIFF
--- a/bc/plan.sh
+++ b/bc/plan.sh
@@ -1,3 +1,5 @@
+# Disable shellcheck that would require quotes around pkg_name
+# shellcheck disable=SC2209
 pkg_name=bc
 pkg_origin=core
 pkg_version=1.07.1

--- a/bc/tests/test.bats
+++ b/bc/tests/test.bats
@@ -1,0 +1,11 @@
+@test "Version is correct" {
+  expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} bc -v | head -1)"
+  [ "$result" = "bc ${expected_version}" ]
+}
+
+@test "Simple calculation" {
+  run hab pkg exec ${TEST_PKG_IDENT} bc <<< '1 + 1'
+  [ $status -eq 0 ]
+  [ $output = '2' ]
+}

--- a/bc/tests/test.sh
+++ b/bc/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
The current version and license info appear to be up-to-date, so the only thing needed for base plan refresh is to add some tests.

Signed-off-by: James Stocks <jstocks@chef.io>