### PR TITLE
[elixir] Update elixir to 1.9.1

### DIFF
--- a/elixir/plan.sh
+++ b/elixir/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=elixir
-pkg_version=1.9.0
+pkg_version=1.9.1
 pkg_description="A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain."
 pkg_upstream_url=http://elixir-lang.org
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/elixir-lang/elixir/archive/v${pkg_version}.tar.gz"
-pkg_shasum=dbf4cb66634e22d60fe4aa162946c992257f700c7db123212e7e29d1c0b0c487
+pkg_shasum=94daa716abbd4493405fb2032514195077ac7bc73dc2999922f13c7d8ea58777
 pkg_deps=(
   core/busybox
   core/cacerts


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build elixir
source results/last_build.env
hab studio run "./elixir/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Trivial Elixir code tests

2 tests, 0 failures
```

![tenor-229233132](https://user-images.githubusercontent.com/24568/61500194-15465500-aa05-11e9-8f0d-d41ecfb80342.gif)
