### PR TITLE
[cockroach] Update cockroach to 19.1.3, Update tests

### DIFF
--- a/cockroach/plan.sh
+++ b/cockroach/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=cockroach
 pkg_origin=core
-pkg_version=2.1.6
+pkg_version=19.1.3
 pkg_description="CockroachDB is a cloud-native SQL database for building global, scalable cloud services that survive disasters."
 pkg_upstream_url=https://github.com/cockroachdb/cockroach
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://binaries.cockroachdb.com/cockroach-v${pkg_version}.src.tgz
-pkg_shasum=04a399a619fc898fbd457c60784416e17af22b05f02be101b2fe64c536163eeb
+pkg_source="https://binaries.cockroachdb.com/cockroach-v${pkg_version}.src.tgz"
+pkg_shasum=65e4c4ebb9c31a0d4e0522ad62d1f95663e594b05227ccedc7b05271bd5fd34a
 pkg_dirname="${pkg_name}-v${pkg_version}"
 pkg_build_deps=(
   core/autoconf

--- a/cockroach/tests/test.bats
+++ b/cockroach/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v cockroachoss)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(cockroachoss version | head -1 | awk '{print $3}')"
-  [ "$result" = "v${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} cockroachoss version | head -1 | awk '{print $3}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run cockroachoss help
+  run hab pkg exec ${TEST_PKG_IDENT} cockroachoss help
   [ $status -eq 0 ]
 }
 

--- a/cockroach/tests/test.sh
+++ b/cockroach/tests/test.sh
@@ -1,34 +1,35 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
-hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static wc
-hab pkg binlink core/busybox-static uniq
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 3
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+hab sup term
+hab sup run &
+sleep 5
+
+hab svc load "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build cockroach
source results/last_build.env
hab studio run  "./cockroach/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on ports: 8080, 26257

4 tests, 0 failures
```

![tenor-71555675](https://user-images.githubusercontent.com/24568/61501207-53de0e80-aa09-11e9-8aee-aa1fe26f1dcb.gif)
