### PR TITLE
[jenkins] Update Jenkins to 2.176.2, changed to openjdk, update tests

### DIFF
--- a/jenkins/hooks/run
+++ b/jenkins/hooks/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-export JAVA_HOME="{{pkgPathFor "core/jre8"}}"
+export JAVA_HOME="{{pkgPathFor "core/openjdk11"}}"
 export JENKINS_HOME="{{pkg.svc_data_path}}"
 
 exec java \

--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,13 +1,16 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.150.3
+pkg_version=2.176.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="4fc2700a27a6ccc53da9d45cc8b2abd41951b361e562e1a1ead851bea61630fd"
-pkg_deps=(core/jre8 core/curl)
+pkg_shasum=33a6c3161cf8de9c8729fd83914d781319fd1569acf487c7b1121681dba190a5
+pkg_deps=(
+  core/openjdk11
+  core/curl
+)
 pkg_exports=(
   [port]=jenkins.http.port
 )

--- a/jenkins/tests/test.bats
+++ b/jenkins/tests/test.bats
@@ -1,12 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(java -jar $(hab pkg path ${HAB_ORIGIN}/jenkins)/jenkins.war --version)"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec core/openjdk11 java -jar $(hab pkg path ${TEST_PKG_IDENT})/jenkins.war --version)"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run java -jar $(hab pkg path ${HAB_ORIGIN}/jenkins)/jenkins.war --help
+  run hab pkg exec core/openjdk11 java -jar $(hab pkg path ${TEST_PKG_IDENT})/jenkins.war --help
   [ $status -eq 0 ]
 }
 

--- a/jenkins/tests/test.sh
+++ b/jenkins/tests/test.sh
@@ -1,35 +1,35 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-hab pkg install core/jre8 --binlink
-
-hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
-hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static wc
-hab pkg binlink core/busybox-static uniq
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 15
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+hab sup term
+hab sup run &
+sleep 5
+
+hab svc load "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build jenkins
source results/last_build.env
hab studio run "./jenkins/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 80 (HTTP)

4 tests, 0 failures
```