### PR TITLE
[strace] Update strace to 5.2

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=5.1
+pkg_version=5.2
 pkg_license=("LGPL-2.1-or-later")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=f5a341b97d7da88ee3760626872a4899bf23cf8dee56901f114be5b1837a9a8b
+pkg_shasum=d513bc085609a9afd64faf2ce71deb95b96faf46cd7bc86048bc655e4e4c24d2
 pkg_deps=(
   core/glibc
   core/libunwind


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build strace
source results/last_build.env
hab studio run "./strace/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```