### PR TITLE
[yarn] Update yarn to 1.17.3, update tests

### DIFF
--- a/yarn/plan.sh
+++ b/yarn/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=yarn
 pkg_origin=core
-pkg_version=1.16.0
+pkg_version=1.17.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don’t ever have to worry."
 pkg_upstream_url=https://yarnpkg.com/
 pkg_license=('BSD-2-Clause')
 pkg_source="https://yarnpkg.com/downloads/${pkg_version}/yarn-v${pkg_version}.tar.gz"
-pkg_shasum=df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029
+pkg_shasum=e3835194409f1b3afa1c62ca82f561f1c29d26580c9e220c36866317e043c6f3
 pkg_bin_dirs=(bin)
 pkg_build_deps=()
 pkg_deps=(

--- a/yarn/tests/test.bats
+++ b/yarn/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(yarn --version)"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} yarn --version)"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run yarn --Help
+  run hab pkg exec ${TEST_PKG_IDENT} yarn --Help
   [ "$status" -eq 0 ]
 }

--- a/yarn/tests/test.sh
+++ b/yarn/tests/test.sh
@@ -1,22 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab pkg install core/node --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build yarn
source results/last_build.env
hab studio run "./yarn/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

![tenor-71779212](https://user-images.githubusercontent.com/24568/61502503-30b65d80-aa0f-11e9-975e-9cf59e664cee.gif)
