### PR TITLE
Update dgraph to 1.0.16, update tests

### DIFF
--- a/dgraph/plan.sh
+++ b/dgraph/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=dgraph
 pkg_origin=core
-pkg_version="1.0.12"
+pkg_version="1.0.16"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/${pkg_name}-io/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-linux-amd64.tar.gz"
-pkg_shasum="e76412204e45c447084f97d439c2f619955bd2a6643cdb7e9185a020884a1cd8"
+pkg_shasum=c778603e747e98fccf212d823c396f72be28153b7832f3804447f39a4ea6a92f
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/patchelf)
 pkg_bin_dirs=(bin)
@@ -17,6 +17,7 @@ do_build() {
 
 do_install() {
   cp "${HAB_CACHE_SRC_PATH}/${pkg_name}" "${pkg_prefix}/bin/${pkg_name}" || exit 1
-  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
+  patchelf \
+    --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
     "${pkg_prefix}/bin/${pkg_name}"
 }

--- a/dgraph/tests/test.bats
+++ b/dgraph/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(dgraph version | grep 'Dgraph version' | awk '{print $4}')"
-  [ "$result" = "v${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} dgraph version | grep 'Dgraph version' | awk '{print $4}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command is functional" {
-  run dgraph help
+  run hab pkg exec ${TEST_PKG_IDENT} dgraph help
   [ $status -eq 0 ]
 }

--- a/dgraph/tests/test.sh
+++ b/dgraph/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build dgraph
source results/last_build.env
hab studio run "./dgraph/tests/test.sh"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command is functional

2 tests, 0 failures
```

![tenor-119131823](https://user-images.githubusercontent.com/24568/61502758-17fa7780-aa10-11e9-93a4-94229b502079.gif)
