### PR TITLE
[jruby1] Replace jdk with openjdk

### DIFF
--- a/jruby1/plan.sh
+++ b/jruby1/plan.sh
@@ -11,10 +11,9 @@ pkg_deps=(
   core/bash
   core/coreutils
   core/glibc
-  core/jre8
+  core/corretto8
 )
 pkg_build_deps=(
-  core/jdk8
   core/make
   core/which
 )
@@ -25,7 +24,7 @@ pkg_dirname=jruby-${pkg_version}
 
 do_build() {
   export JAVA_HOME
-  JAVA_HOME=$(pkg_path_for core/jdk8)
+  JAVA_HOME=$(pkg_path_for core/corretto8)
   ./mvnw
 }
 

--- a/jruby1/tests/test.bats
+++ b/jruby1/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "jruby1 matches version ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" jruby --version | awk '{print $2}')"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}

--- a/jruby1/tests/test.sh
+++ b/jruby1/tests/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks:
- [ ] Wait for approval and merge

### Context

After replacing the jdk8/jre8 with openjdk11, core/ruby1 fails to build:

```java
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project jruby-core: Compilation failure
[ERROR] /hab/cache/src/jruby-1.7.27/core/src/main/java/org/jruby/management/BeanManagerImpl.java:[94,26] error: cannot find symbol
```

### Completed Tasks:
- [x] Fix the compilation error: replace jdk8 with corretto8 not openjdk11 or corretto
- [x] Squash commits
- [x] Remove duplicate dependency from plan.sh; resolve and alert Scott when done.
- [x] Squashed commits