### PR TITLE
[kafka] Replace jdk with openjdk

### DIFF
--- a/kafka/config/server.properties
+++ b/kafka/config/server.properties
@@ -19,32 +19,24 @@ socket.request.max.bytes={{socket_request_max_bytes}}
 {{/with ~}}
 
 {{#with cfg.log ~}}
-{{#if log_dirs ~}}
 log.dirs={{log_dirs}}
-{{else ~}}
-log.dirs={{../pkg.svc_var_path}}/logs
-{{/if ~}}
 num.partitions={{num_partitions}}
 num.recovery.threads.per.data.dir={{num_recovery_threads_per_data_dir}}
-log.retention.hours={{retention.log_retention_hours}}
-log.segment.bytes={{retention.log_segment_bytes}}
-log.retention.check.interval.ms={{retention.log_retention_check_interval_ms}}
-{{#with flush ~}}
+log.retention.hours={{retention.hours}}
+log.segment.bytes={{retention.segment_bytes}}
+log.retention.check.interval.ms={{retention.check_interval_ms}}
 {{#if interval_messages ~}}
-log.flush.interval.messages={{interval_messages}}
+log.flush.interval.messages={{flush.interval_messages}}
 {{/if ~}}
 {{#if interval_ms ~}}
-log.flush.interval.ms={{interval_ms}}
+log.flush.interval.ms={{flush.interval_ms}}
 {{/if ~}}
-{{/with ~}}
-{{#with retention ~}}
-log.retention.hours={{hours}}
+log.retention.hours={{retention.hours}}
 {{#if bytes ~}}
-log.retention.bytes={{bytes}}
+log.retention.bytes={{retention.bytes}}
 {{/if ~}}
-log.segment.bytes={{segment_bytes}}
-log.retention.check.interval.ms={{check_interval_ms}}
-{{/with ~}}
+log.segment.bytes={{retention.segment_bytes}}
+log.retention.check.interval.ms={{retention.check_interval_ms}}
 {{/with ~}}
 
 zookeeper.connection.timeout.ms={{cfg.zookeeper.connection_timeout_ms}}

--- a/kafka/default.toml
+++ b/kafka/default.toml
@@ -57,7 +57,7 @@ socket_request_max_bytes=104857600
 ############################# Log Basics #############################
 [log]
 # A comma seperated list of directories under which to store log files
-#log_dirs=""
+log_dirs="/hab/svc/kafka/var"
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across

--- a/kafka/hooks/run
+++ b/kafka/hooks/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-export JAVA_HOME="{{pkgPathFor "core/jre8"}}"
+export JAVA_HOME="{{pkgPathFor "core/corretto8"}}"
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:{{pkg.svc_config_path}}/log4j.properties"
 export EXTRA_ARGS="-name kafkaServer"
 

--- a/kafka/plan.sh
+++ b/kafka/plan.sh
@@ -12,7 +12,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(
   core/bash-static
   core/coreutils
-  core/jre8
+  core/corretto8
 )
 pkg_binds=(
   [zookeeper]="port"

--- a/kafka/tests/test.bats
+++ b/kafka/tests/test.bats
@@ -1,0 +1,9 @@
+@test "kafka service is running" {
+  [ "$(hab svc status | grep "kafka\.default" | awk '{print $4}' | grep up)" ]
+}
+
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "kafka matches version ${expected_version}" {
+  actual_version_array=($(cat "${SUP_LOG}" | grep --text -m 1 -oP "(?<=INFO Kafka version : )([^ ]*)"))
+  diff <( echo "${actual_version_array[0]}") <(echo "${expected_version}")
+}

--- a/kafka/tests/test.sh
+++ b/kafka/tests/test.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/curl --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+
+# clear the supervisor output
+export SUP_LOG="/hab/sup/default/sup.log"
+cat /dev/null > "${SUP_LOG}"
+
+ci_load_service "core/zookeeper"
+
+# wait for the service to start
+countdown=50
+hab svc status "${TEST_PKG_IDENT}" 2>/dev/null || hab svc load "${TEST_PKG_IDENT}" --bind zookeeper:zookeeper.default
+until ( (nc -z localhost 9092) && (grep -q "INFO Kafka version :" "${SUP_LOG}" ) ) \
+  || (( countdown <= 0 )); do
+  echo "Waiting for core/kafka service to start ${countdown}"
+  sleep 2
+  countdown=$((countdown-1))
+done
+
+# run the tests
+bats "$(dirname "${0}")/test.bats"
+
+# unload the services
+hab svc unload "${TEST_PKG_IDENT}" || true
+hab svc unload core/zookeeper || true


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting on approval and merge
- [ ] After merge, then close issue #2882

### Context
Getting kafka working required a number of fixes not only the replacement of core/jdk8 with core/corretto8:
* Fix service logging to go beneath {{pkg.svc_var_path}}.  The /hab/svc/kafka/var is owned by 'hab' service user whereas /hab/svc/kafka/logs is owned by 'root'.  Any attempts of the kafka service to write to 'logs' directory fail silently
* Add kafka file appender to log4j.properties so that service health and kafka version can be verified in tests
* Replace core/jre8 with core/corretto8
* Add tests that verify the kafka service.  Before running the tests, the zookeeper service is setup.


### Completed Tasks
- [x] core/kafka builds successfully but service fails to start because of missing zookeeper dependency
- [x] Add placeholder service level tests
- [x] Test zookeeper binding with kafka (jdk8) and zookeeper (jdk8).  Do they bind successfully?  No
- [x] Make the zookeeper binding optional so that the kafka service can be started without zookeeper running.  Does it work?  No.
- [x] Build kafka with **core/corretto8**.  Does the service work now?  Yes (and no because the binding still isn't working)
- [x] Raised #2882 an issue around kafka/zookeeper integration
- [x] Fix buildkite test.sh permission error:  ``line 1: ./kafka/tests/test.sh: Permission denied``
- [x] Fix broken kafka config: server.properties wasn't referencing default.toml correctly
- [x] Fix broken log_dir:  The service was broken trying to reference /hab/svc/kafka/logs instead of /hab/svc/kafka/var
- [x] Add service tests that first ensure zookeeper is running and bindable and then bind, run and verify the kafka service
- [x] Remove /hab/svc/kafka/var/kafka.log; use instead redirect of supervisor stdout.
- [x] Add countdown in test.sh when waiting for kafka service startup