### PR TITLE
[artifactory-pro] minor version up 6.11.3

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.11.1
+pkg_version=6.11.3
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=4a761698ee00a87507ffc16616faebe88d213aeac6d3502023b3d91117cb838f
+pkg_shasum=61cc41c177cf34780e643759157971a81ce6c72fe73ea2f182b9a79dfbcfc028
 pkg_deps=(core/bash core/openjdk11)
 pkg_exports=(
   [port]=port


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

[Release notes](https://bintray.com/jfrog/artifactory/jfrog-artifactory-oss-zip/6.11.3)

## Testing
```
hab pkg build artifactory-pro
source results/last_build.env
hab studio run "./artifactory-pro/tests/test.sh ${pkg_ident}"
```