### PR TITLE
[dotnet-core-sdk] Updating Linux/Windows plans to 2.2.301 w/new tests

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="2.2.202"
+$pkg_version="2.2.301"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/1c2407a4-feb7-471a-82f0-bd3fa32ad967/74db7ac9a886ae58d779c89cf2777657/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="4a83be23efaed263f6a1fa07bd144c0a590e08d0e40d464550e0c3ec87e4f77d"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/3c7fcb0b-52ee-40b2-853d-710c58883371/78bbdf5fcd85697e8e306c355d02d0b0/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_shasum="996a001ce2c415a24f21cee698ca1e2581ed5adced5b82763cb12326060feba0"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=2.2.202
+pkg_version=2.2.301
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/2cecc1f4-5c77-4a9f-a2fa-8bfcee4d4bf0/4e68e8e0e0aac72711eb34c3a9988e45/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=3e3fdf2e6c8053a87f07c16f6e9c55d1be6d28d8273a67cce3207a9f58c14de1
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/3224f4c4-8333-4b78-b357-144f7d575ce5/ce8cb4b466bba08d7554fe0900ddc9dd/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=63fef1550a6f7680c2c32cbf3ba1111f99d09b91126c0aaf2fbaf19d2d90ec84
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils

--- a/dotnet-core-sdk/tests/test.bats
+++ b/dotnet-core-sdk/tests/test.bats
@@ -1,11 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(dotnet --version)"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} dotnet --version)"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Info command" {
-  run dotnet --info
+  run hab pkg exec ${TEST_PKG_IDENT} dotnet --info
   [ $status -eq 0 ]
 }

--- a/dotnet-core-sdk/tests/test.sh
+++ b/dotnet-core-sdk/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Hey all,

To test this update, please run the following:
```
hab pkg build dotnet-core-sdk
source results/last_build.env
hab studio run "./dotnet-core-sdk/tests/test.sh ${pkg_ident}"
```

The results should be:
```
 ✓ Version matches
 ✓ Info command

2 tests, 0 failures
```

Let me know if there are any questions. Thanks! 