### PR TITLE
[findutils] Patch to work with glibc-2.29 

### DIFF
--- a/findutils/correct-glibc-fflush.patch
+++ b/findutils/correct-glibc-fflush.patch
@@ -1,0 +1,143 @@
+From 80cdfba079627e15129a926a133825b961d41e36 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 5 Mar 2018 10:56:29 -0800
+Subject: [PATCH] fflush: adjust to glibc 2.28 libio.h removal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Daniel P. Berrangé in:
+https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html
+* lib/fflush.c (clear_ungetc_buffer_preserving_position)
+(disable_seek_optimization, rpl_fflush):
+* lib/fpurge.c (fpurge):
+* lib/freadahead.c (freadahead):
+* lib/freading.c (freading):
+* lib/fseeko.c (fseeko):
+* lib/stdio-impl.h (_IO_IN_BACKUP) [_IO_EOF_SEEN]:
+Define if not already defined.
+
+Upstream-commit: 4af4a4a71827c0bc5e0ec67af23edef4f15cee8e
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/fflush.c     | 6 +++---
+ gl/lib/fpurge.c     | 2 +-
+ gl/lib/freadahead.c | 2 +-
+ gl/lib/freading.c   | 2 +-
+ gl/lib/fseeko.c     | 4 ++--
+ gl/lib/stdio-impl.h | 6 ++++++
+ 6 files changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/gl/lib/fflush.c b/gl/lib/fflush.c
+index 5ae3e41..7a82470 100644
+--- a/gl/lib/fflush.c
++++ b/gl/lib/fflush.c
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --git a/gl/lib/fpurge.c b/gl/lib/fpurge.c
+index f313b22..ecdf82d 100644
+--- a/gl/lib/fpurge.c
++++ b/gl/lib/fpurge.c
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --git a/gl/lib/freadahead.c b/gl/lib/freadahead.c
+index 094daab..3f8101e 100644
+--- a/gl/lib/freadahead.c
++++ b/gl/lib/freadahead.c
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --git a/gl/lib/freading.c b/gl/lib/freading.c
+index 0512b19..8c48fe4 100644
+--- a/gl/lib/freading.c
++++ b/gl/lib/freading.c
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --git a/gl/lib/fseeko.c b/gl/lib/fseeko.c
+index 1c65d2a..9026408 100644
+--- a/gl/lib/fseeko.c
++++ b/gl/lib/fseeko.c
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+diff --git a/gl/lib/stdio-impl.h b/gl/lib/stdio-impl.h
+index 502d891..ea38ee2 100644
+--- a/gl/lib/stdio-impl.h
++++ b/gl/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+-- 
+2.16.2
+
+

--- a/findutils/correct-glibc-makedev.patch
+++ b/findutils/correct-glibc-makedev.patch
@@ -1,0 +1,81 @@
+From 80628047a6cc83f82e0c410a82b8f7facd9d50f2 Mon Sep 17 00:00:00 2001
+From: Eric Blake <eblake@redhat.com>
+Date: Wed, 14 Sep 2016 19:21:42 -0500
+Subject: [PATCH] mountlist: include sysmacros.h for glibc
+
+On Fedora rawhide (glibc 2.25), './gnulib-tool --test mountlist'
+reports:
+../../gllib/mountlist.c: In function 'read_file_system_list':
+../../gllib/mountlist.c:534:13: warning: '__makedev_from_sys_types' is deprecated:
+  In the GNU C Library, `makedev' is defined by <sys/sysmacros.h>.
+  For historical compatibility, it is currently defined by
+  <sys/types.h> as well, but we plan to remove this soon.
+  To use `makedev', include <sys/sysmacros.h> directly.
+  If you did not intend to use a system-defined macro `makedev',
+  you should #undef it after including <sys/types.h>.
+  [-Wdeprecated-declarations]
+             me->me_dev = makedev (devmaj, devmin);
+             ^~
+In file included from /usr/include/features.h:397:0,
+                 from /usr/include/sys/types.h:25,
+                 from ./sys/types.h:28,
+                 from ../../gllib/mountlist.h:23,
+                 from ../../gllib/mountlist.c:20:
+/usr/include/sys/sysmacros.h:89:1: note: declared here
+ __SYSMACROS_DEFINE_MAKEDEV (__SYSMACROS_FST_IMPL_TEMPL)
+ ^
+
+Fix it by including the right headers.  We also need a fix to
+autoconf's AC_HEADER_MAJOR, but that's a separate patch.
+
+* m4/mountlist.m4 (gl_PREREQ_MOUTLIST_EXTRA): Include
+AC_HEADER_MAJOR.
+* lib/mountlist.c (includes): Use correct headers.
+
+Signed-off-by: Eric Blake <eblake@redhat.com>
+
+Upstream-commit: 4da63c5881f60f71999a943612da9112232b9161
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/mountlist.c | 6 ++++++
+ gl/m4/mountlist.m4 | 3 ++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/gl/lib/mountlist.c b/gl/lib/mountlist.c
+index c3d2852..0b6f92e 100644
+--- a/gl/lib/mountlist.c
++++ b/gl/lib/mountlist.c
+@@ -37,6 +37,12 @@
+ # include <sys/param.h>
+ #endif
+ 
++#if MAJOR_IN_MKDEV
++# include <sys/mkdev.h>
++#elif MAJOR_IN_SYSMACROS
++# include <sys/sysmacros.h>
++#endif
++
+ #if defined MOUNTED_GETFSSTAT   /* OSF_1 and Darwin1.3.x */
+ # if HAVE_SYS_UCRED_H
+ #  include <grp.h> /* needed on OSF V4.0 for definition of NGROUPS,
+diff --git a/gl/m4/mountlist.m4 b/gl/m4/mountlist.m4
+index ec58dc8..82b2dcb 100644
+--- a/gl/m4/mountlist.m4
++++ b/gl/m4/mountlist.m4
+@@ -1,4 +1,4 @@
+-# serial 11
++# serial 12
+ dnl Copyright (C) 2002-2006, 2009-2015 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+@@ -15,5 +15,6 @@ AC_DEFUN([gl_PREREQ_MOUNTLIST_EXTRA],
+ [
+   dnl Note gl_LIST_MOUNTED_FILE_SYSTEMS checks for mntent.h, not sys/mntent.h.
+   AC_CHECK_HEADERS([sys/mntent.h])
++  AC_HEADER_MAJOR()dnl for use of makedev ()
+   gl_FSTYPENAME
+ ])
+-- 
+2.16.2
+
+

--- a/findutils/tests/test.bats
+++ b/findutils/tests/test.bats
@@ -1,0 +1,4 @@
+@test "Simple find with exec" {
+  run hab pkg exec "${TEST_PKG_IDENT}" find -name plan.sh
+  [ "$status" -eq 0 ]
+}

--- a/findutils/tests/test.sh
+++ b/findutils/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This adds two patches to allow findutils to build with glibc-2.29 

https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html
https://lists.gnu.org/archive/html/autoconf/2016-09/msg00021.html

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>