### PR TITLE
[gzip] Update version

### DIFF
--- a/gzip/plan.sh
+++ b/gzip/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=gzip
 pkg_origin=core
-pkg_version=1.9
+pkg_version=1.10
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 GNU Gzip is a popular data compression program originally written by Jean-loup \
 Gailly for the GNU project.\
 "
 pkg_upstream_url="https://www.gnu.org/software/gzip/"
-pkg_license=('gplv3+')
+pkg_license=('GPL-3.0-or-later')
 pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="ae506144fc198bd8f81f1f4ad19ce63d5a2d65e42333255977cf1dcf1479089a"
+pkg_shasum="8425ccac99872d544d4310305f915f5ea81e04d0f437ef1a230dc9d1c819d7c0"
 pkg_deps=(
   core/glibc
   core/less

--- a/gzip/tests/test.bats
+++ b/gzip/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Can execute simple command" {
+  run hab pkg exec ${TEST_PKG_IDENT} gzip --help
+
+  [ "$status" -eq 0 ]
+}

--- a/gzip/tests/test.sh
+++ b/gzip/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats" 


### PR DESCRIPTION
This minor version up allows gzip to build against glibc-2.29
 
[1.10 Release notes](https://savannah.gnu.org/forum/forum.php?forum_id=9339)

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>