### PR TITLE
[graphviz] Fix download location

### DIFF
--- a/graphviz/plan.sh
+++ b/graphviz/plan.sh
@@ -5,9 +5,9 @@ pkg_license=("EPL-1.0")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Graphviz - Graph Visualization Software"
 pkg_upstream_url="https://graphviz.gitlab.io/"
-pkg_dirname="${pkg_name}-stable_release_${pkg_version}"
-pkg_source="https://gitlab.com/graphviz/graphviz/-/archive/stable_release_${pkg_version}/${pkg_dirname}.tar.bz2"
-pkg_shasum="92f654c95b412920777ceddf90e6564ffa871a77e4f6155ab437a2d3a2129e2b"
+pkg_dirname="${pkg_name}-${pkg_version}"
+pkg_source="https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz"
+pkg_shasum="ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421"
 pkg_deps=(
   core/glibc
   core/libtool
@@ -22,16 +22,17 @@ pkg_build_deps=(
     core/gcc
     core/make
     core/pkg-config
+    core/git
 )
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 do_prepare() {
-  # TODO: if we don't copy this aclocal will fail. need to figure out how to fix this
-  cp "$(pkg_path_for core/pkg-config)/share/aclocal/pkg.m4" "$(pkg_path_for core/automake)/share/aclocal/"
+  ACLOCAL_PATH="$ACLOCAL_PATH:$(pkg_path_for core/pkg-config)/share/aclocal"
+  ACLOCAL_PATH="$ACLOCAL_PATH:$(pkg_path_for core/automake)/share/aclocal"
+  export ACLOCAL_PATH
 
-  libtoolize
   ./autogen.sh
 }
 

--- a/graphviz/tests/test.bats
+++ b/graphviz/tests/test.bats
@@ -1,12 +1,7 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "dot is on the path" {
-  [ "$(command -v dot)" ]
-}
-
 @test "minimal dot to svg works" {
-  run dot -Tsvg -o ${BATS_TEST_DIRNAME}/output.svg < "${BATS_TEST_DIRNAME}/input.dot"
+  run hab pkg exec $TEST_PKG_IDENT dot -Tsvg -o ${BATS_TEST_DIRNAME}/output.svg < "${BATS_TEST_DIRNAME}/input.dot"
+  echo $output >&3
   [ $status -eq 0 ]
   [ -f "${BATS_TEST_DIRNAME}/output.svg" ]
-  rm -rf "${BATS_TEST_DIRNAME}/otuput.svg"
+  rm -f "${BATS_TEST_DIRNAME}/output.svg"
 }

--- a/graphviz/tests/test.sh
+++ b/graphviz/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Graphviz has moved their downloads to a non-versioned tarball :joy:  This updates the download location and updates the tests to the current standard. 