### PR TITLE
[cerebro] Update Cerebro to 0.8.4, update tests, migrate to openjdk

### DIFF
--- a/cerebro/config/application.conf
+++ b/cerebro/config/application.conf
@@ -1,57 +1,13 @@
-# Secret will be used to sign session cookies, CSRF tokens and for other encryption utilities.
-# It is highly recommended to change this value before running cerebro in production.
+# Full configuration example here: https://github.com/lmenezes/cerebro/blob/master/conf/application.conf
 secret = "{{cfg.secret}}"
-
-# Application base path
 basePath = "/"
-
-# Defaults to RUNNING_PID at the root directory of the app.
-# To avoid creating a PID file set this value to /dev/null
-#pidfile.path = "/var/run/cerebro.pid"
 pidfile.path=/dev/null
-
-# Rest request history max size per user
 rest.history.size = {{cfg.history_size}}
-
-# Path of local database file
-#data.path: "/var/lib/cerebro/cerebro.db"
 data.path = "{{pkg.svc_data_path}}/cerebro.db"
-
 es = {
   gzip = {{cfg.elasticsearch.gzip}}
 }
-
-# Authentication
 auth = {
-  # Example of LDAP authentication
-  #type: ldap
-    #settings: {
-      #url = "ldap://host:port"
-      #base-dn = "ou=active,ou=Employee"
-      #method  = "simple"
-      #user-domain = "domain.com"
-    #}
-  # Example of simple username/password authentication
-  #type: basic
-    #settings: {
-      #username = "admin"
-      #password = "1234"
-    #}
 }
-
-# A list of known hosts
 hosts = [
-  #{
-  #  host = "http://localhost:9200"
-  #  name = "Some Cluster"
-  #},
-  # Example of host with authentication
-  #{
-  #  host = "http://some-authenticated-host:9200"
-  #  name = "Secured Cluster"
-  #  auth = {
-  #    username = "username"
-  #    password = "secret-password"
-  #  }
-  #}
 ]

--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -1,21 +1,22 @@
 pkg_name=cerebro
 pkg_origin=core
-pkg_version="0.8.3"
+pkg_version=0.8.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Cerebro: Elasticsearch Administration"
+pkg_upstream_url="https://github.com/lmenezes/cerebro"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum="fdda73f7d56c4ead29590a8b1567d0bbfc3b39c14d2b7bde75a440954e2f435b"
-pkg_deps=(core/coreutils core/jre8)
+pkg_shasum=a36c5d4dd335bbf50fa19fe8efd3cb1c8cb49d7093f0486f06f5fd05c1397cbe
+pkg_deps=(
+	core/coreutils
+	core/openjdk11
+)
 pkg_bin_dirs=(bin)
 pkg_exports=(
   [port]=port
 )
 pkg_exposes=(port)
-pkg_svc_user="hab"
-pkg_svc_group="$pkg_svc_user"
-pkg_description="Cerebro: Elasticsearch Administration"
-pkg_upstream_url="https://github.com/lmenezes/cerebro"
 
 do_build() {
 	return 0

--- a/cerebro/tests/test.bats
+++ b/cerebro/tests/test.bats
@@ -1,4 +1,4 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Service is running" {
   [ "$(hab svc status | grep "cerebro\.default" | awk '{print $4}' | grep up)" ]
@@ -6,5 +6,5 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 
 @test "Version matches" {
   result="$(curl http://localhost:9000 | grep appVersion | awk '{print $6}' | tr -d "'\"\>" | tr -d 'v')"
-  [ "$result" = "${pkg_version}" ]
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }

--- a/cerebro/tests/test.sh
+++ b/cerebro/tests/test.sh
@@ -1,30 +1,31 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
 
-hab pkg install core/curl --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 30
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/curl --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Update testing
* Update version to 0.8.4
* Migrate to openjdk

### Testing

```
hab pkg build cerebro
source results/last_build.env
hab studio run "./cerebro/tests/test.sh ${pkg_ident}"
```

### Sample output

```
Waiting 5 seconds for service to start...
 ✓ Service is running
 ✓ Version matches

2 tests, 0 failures
```