### PR TITLE
[nginx] Update nginx to 1.17.2

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.17.1"
+$pkg_version="1.17.2"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="ef537959fbe10a1f138246e0a7c4e82ce97195ef058e851335d350f3d9562673"
+$pkg_shasum="cc8460633ffd1879f86897a2acc7d83c0b5d34c7815febb4208167244eb18abd"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.17.1
+pkg_version=1.17.2
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=6f1825b4514e601579986035783769c456b888d3facbab78881ed9b58467e73e
+pkg_shasum=5e333687464e1d6dfb86fc22d653b99a6798dda40093b33186eeeec5a97e69ec
 pkg_deps=(
   core/glibc
   core/libedit

--- a/nginx/tests/test.sh
+++ b/nginx/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -19,11 +21,8 @@ hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static ps
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab sup term
-hab sup run &
-sleep 5
-
-hab svc load "${TEST_PKG_IDENT}"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
 
 # Allow service start
 WAIT_SECONDS=5


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build nginx
source results/last_build.env
hab studio run "./nginx/tests/test.sh ${pkg_ident}"
```

### Sample output

```
Waiting 5 seconds for service to start...
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

6 tests, 0 failures
```