### PR TITLE
[jetty] Replace jdk with openjdk11

### DIFF
--- a/jetty/hooks/init
+++ b/jetty/hooks/init
@@ -3,4 +3,4 @@
 # Move directories that ship in the package into place
 cp -a "{{pkg.path}}/jetty" "{{pkg.svc_var_path}}/"
 
-chown -R hab:hab "{{pkg.svc_path}}/var/*"
+chown -R hab:hab "{{pkg.svc_var_path}}"

--- a/jetty/hooks/run
+++ b/jetty/hooks/run
@@ -3,11 +3,6 @@
 exec 2>&1
 
 export JETTY_HOME="{{pkg.svc_var_path}}/jetty"
-
-if path={{pkgPathFor "core/jdk7"}}; then
-  export JAVA_HOME=$path
-elif path={{pkgPathFor "core/jdk8"}}; then
-  export JAVA_HOME=$path
-fi
+export JAVA_HOME="{{pkgPathFor "core/openjdk11"}}"
 
 exec ${JETTY_HOME}/bin/jetty.sh run

--- a/jetty/plan.sh
+++ b/jetty/plan.sh
@@ -8,7 +8,7 @@ pkg_shasum=3fbce5530d8d9a66f43034782b0f249df3d98e3e97ef849e7f740eab612b963f
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Jetty webserver and Java container"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/which core/coreutils core/bash core/jdk7)
+pkg_deps=(core/which core/coreutils core/bash core/openjdk11)
 
 do_unpack() {
     local source_dir=$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}

--- a/jetty/tests/test.bats
+++ b/jetty/tests/test.bats
@@ -1,0 +1,9 @@
+@test "jetty service is running" {
+  [ "$(hab svc status | grep "jetty\.default" | awk '{print $4}' | grep up)" ]
+}
+
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "jetty matches version ${expected_version}" {
+  actual_version="$(curl -sS -I http://127.0.0.1:8080/ | grep -oP "(?<=Server: Jetty\()([^v]*)" | sed 's/\.$//g')"
+  diff <(echo "$actual_version") <(echo "${expected_version}")
+}

--- a/jetty/tests/test.sh
+++ b/jetty/tests/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/curl --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "$TEST_PKG_IDENT"
+
+# run the tests
+bats "$(dirname "${0}")/test.bats"
+
+# unload the service
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
### Outstanding Tasks
- [x] Raised issue #2873 because jetty is failing to start.
- [x] Replace jdk with openjdk11 and build is successful.
- [x] Fix issue #2873 where jetty service fails to start because of missing/incorrect directory
- [x] Add tests
- [x] Fix tests, remove comments, amend source of test_helpers.sh
- [ ] Waiting on approval and merge