### PR TITLE
[logstash2] Replace jdk8 with corretto8

### DIFF
--- a/logstash2/plan.sh
+++ b/logstash2/plan.sh
@@ -9,7 +9,7 @@ pkg_source=https://download.elastic.co/logstash/logstash/logstash-${pkg_version}
 pkg_shasum=957647af07e54c7d18c6e3b543030edae461d447d27412ebb7637cd7eb109f4f
 pkg_deps=(
   core/coreutils
-  core/jre8
+  core/corretto8
   core/jruby1
 )
 pkg_build_deps=()


### PR DESCRIPTION
### Outstanding Task
- [ ] Waiting on decision to merge or close because of issue #2902

### Completed Task
- [x] Raised issue #2902 
- [x] Confirmed that while logstash2 builds with corretto8, it fails to run in the same way that it fails with jre8