### PR TITLE
[sccache] Update sccache to 0.2.9, add tests, fix build, add features

### DIFF
--- a/sccache/plan.sh
+++ b/sccache/plan.sh
@@ -1,22 +1,34 @@
 pkg_name=sccache
 pkg_origin=core
-pkg_version=0.2.4
+pkg_version=0.2.9
 pkg_license=('Apache-2.0')
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://github.com/mozilla/sccache/archive/${pkg_version}.tar.gz
-pkg_shasum="82d8d553a0cf2752e71266523f9aac30c1b5a12fa6b1faea8c7c6e1ec9827371"
-pkg_bin_dirs=(bin)
 pkg_upstream_url="https://github.com/mozilla/sccache"
 pkg_description="sccache is ccache with cloud storage"
-pkg_deps=(core/glibc core/gcc-libs core/openssl)
-pkg_build_deps=(core/rust core/gcc core/pkg-config core/openssl core/make)
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/mozilla/sccache/archive/${pkg_version}.tar.gz"
+pkg_shasum=a24cf714dad8f3f1a50a7ae32665451e36487e3c76f5d92d57f5e4ef7176c0c3
+pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/openssl
+)
+pkg_build_deps=(
+  core/rust
+  core/gcc
+  core/pkg-config
+  core/openssl
+  core/make
+)
 pkg_svc_user="root"
 pkg_svc_group="root"
 
 do_build() {
-  cargo build --release
+  cargo build \
+    --features="all" \
+    --release
 }
 
 do_install() {
-  cargo install --root "${pkg_prefix}"
+  install -v -D "${CACHE_PATH}/target/release/sccache" "${pkg_prefix}/bin/sccache"
 }

--- a/sccache/tests/test.bats
+++ b/sccache/tests/test.bats
@@ -1,0 +1,20 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} sccache --version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} sccache --help
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "sccache\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 4226" {
+  result="$(netstat -peanut | grep sccache | awk '{print $4}' | awk -F':' '{print $NF}')"
+  [ "${result}" -eq 4226 ]
+}

--- a/sccache/tests/test.sh
+++ b/sccache/tests/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Adds all backend features to the build
* Fixes the build so it doesn't compile twice
* Update to 0.2.9
* Add tests

### Testing

```
hab pkg build sccache
source results/last_build.env
hab studio run "./sccache/tests/test.sh ${pkg_ident}"
```

### Sample output

```
Waiting 5 seconds for service to start...
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 4226

4 tests, 0 failures
```