### PR TITLE
[hugo] Update hugo to 0.56.1

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version=0.55.6
+pkg_version=0.56.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version=0.56.0
+pkg_version=0.56.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -1,17 +1,17 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec "${PKGIDENT}" hugo version | awk '{print $5}')"
-  [ "$result" = "v${pkg_version}" ]
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" hugo version | awk '{print $5}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run hab pkg exec "${PKGIDENT}" hugo help
+  run hab pkg exec "${TEST_PKG_IDENT}" hugo help
   [ "$status" -eq 0 ]
 }
 
 @test "Generate new site" {
-  run hab pkg exec "${PKGIDENT}" hugo new site testsite
+  run hab pkg exec "${TEST_PKG_IDENT}" hugo new site testsite
   [ "$status" -eq 0 ]
   [ -d testsite ]
   [ -f testsite/config.toml ]

--- a/hugo/tests/test.sh
+++ b/hugo/tests/test.sh
@@ -11,8 +11,8 @@ if [[ -z "${1:-}" ]]; then
 	exit 1
 fi
 
-PKGIDENT="${1}"
-export PKGIDENT
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-hab pkg install "${PKGIDENT}"
+hab pkg install "${TEST_PKG_IDENT}"
 bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build hugo
source results/last_build.env
hab studio run "./hugo/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```

![tenor-193101375](https://user-images.githubusercontent.com/24568/61919703-c31bab80-af91-11e9-9c11-73ab58392a3e.gif)
