### PR TITLE
[consul] Update consul to 1.5.3

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.5.2
+pkg_version=1.5.3
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=d4aaf1956c39ed778d10642e301d382ce37fcddf268366700f2a45e737157ef3
+pkg_shasum=b402e1a0db26adb9638a9e85c6c672acd137df233e8c69f26180f2e2fd6f4cbc
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)

--- a/consul/tests/test.sh
+++ b/consul/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -20,11 +22,8 @@ hab pkg binlink core/busybox-static nc
 hab pkg binlink core/busybox-static ip
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab sup term
-hab sup run &
-sleep 5
-
-hab svc load "${TEST_PKG_IDENT}"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
 
 # Allow service start
 WAIT_SECONDS=10


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build consul
source results/last_build.env
hab studio run "./consul/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```

![tenor-262953212](https://user-images.githubusercontent.com/24568/62013955-b7b8c200-b1d5-11e9-85ff-0a22f8babfe2.gif)
