### PR TITLE
[openssl] Add windows and linux tests to core/openssl VERSION 2

### DIFF
--- a/automake/tests/test.bats
+++ b/automake/tests/test.bats
@@ -1,11 +1,4 @@
-TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
-
-@test "Automake version command returns expected version" {
-  result="$(hab pkg exec "${TEST_PKG_IDENT}" automake --version | head -1 | cut -d' ' -f4)"
-  [ "$result" = "$TEST_PKG_VERSION"  ]
-}
-
 @test  "aclocal displays help" {
-  run hab pkg exec $TEST_PKG_IDENT aclocal --help
+  run hab pkg exec $TEST_PKG_VERSION aclocal --help
   [ "$status" -eq 0 ]
 }

--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="openssl"
 $pkg_origin="core"
-$pkg_version="1.0.2r"
+$pkg_version="1.0.2s"
 $_pkg_version_text=($pkg_version).Replace(".", "_")
 $pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
 $pkg_upstream_url="https://www.openssl.org"
 $pkg_license=@("OpenSSL")
 $pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
-$pkg_shasum="06d0aba3a24097fc2db0050814ffeb5e99d104d61b50fddf1cc7a8f136341fde"
+$pkg_shasum="cae88e63ba0e478bca36c7a8fdea225138cf0f4be32b1120c45a1765a9bcf539"
 $pkg_deps=@("core/visual-cpp-redist-2015")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
 $pkg_bin_dirs=@("bin")

--- a/openssl/plan.sh
+++ b/openssl/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=openssl
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.2r
+pkg_version=1.0.2s
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 OpenSSL is an open source project that provides a robust, commercial-grade, \
@@ -12,7 +12,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://www.openssl.org/source/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6"
+pkg_shasum="cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc

--- a/openssl/tests/test.bats
+++ b/openssl/tests/test.bats
@@ -1,0 +1,10 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "openssl version matches ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" openssl version | awk '{print $1,$2}')"
+  diff <( echo "$actual_version" ) <( echo "OpenSSL ${expected_version}-fips" )
+}
+
+@test "Encodes successfully" {
+  actual="$(echo "a_byte_character" | hab pkg exec "${TEST_PKG_IDENT}" openssl enc -base64)"
+  diff <( echo "$actual" ) <( echo "YV9ieXRlX2NoYXJhY3Rlcgo=" )
+}

--- a/openssl/tests/test.pester.ps1
+++ b/openssl/tests/test.pester.ps1
@@ -1,0 +1,20 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/openssl" {
+    Context "openssl" {
+        $OutputVariable = (hab pkg exec $PackageIdentifier openssl version | Out-String).Trim()
+        $OutputVariable -match "(?<=^OpenSSL )([^ ]*)"
+        It "version matches $PackageVersion" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+
+        $OutputVariable = ("a_byte_character" | hab pkg exec $PackageIdentifier openssl enc -base64| Out-String).Trim()
+        It "returns correct encoded string" {
+            "$OutputVariable" | Should -BeExactly "YV9ieXRlX2NoYXJhY3Rlcg0K"
+        }
+    }
+}

--- a/openssl/tests/test.ps1
+++ b/openssl/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/openssl/tests/test.sh
+++ b/openssl/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [x] Close this PR and move changes to PR #2956 because an extra master commit was somehow introduced during a merge

### Context
See #2740 for background to this PR.

PR #2740 introduced windows and linux tests to the openssl core plan.  However, since the changes needed to be based not off core-plans master but the refresh/2019q3 branch, then this new PR has been opened and the old PR closed. 

**NOTE:** Although Matt Wrock's critical fix has been merged into master, the refresh/2019q3 branch does not yet contain it is still behind master.  Therefore Matt's commit has been cherry-picked into this.

### Completed Tasks
- [x] Cherry pick into the new refresh PR Matt Wrock's fix, which in master but not yet the refresh brach, ``git cherry-pick ec3db147a058669b40f944a15db4afcb528511b5``.  Otherwise the windows build/test will fail.
- [x] Determine latest version 1.1.1
- [x] Scott confirmed that core/openssl should not be uplifted from 1.0.2 to 1.1.1.
- [x] Bump up the version to 1.0.2s (or whatever the latest 1.0.2 version is)