### PR TITLE
[gocd-server] Replace jdk with corretto8 VERSION 2

### DIFF
--- a/automake/tests/test.bats
+++ b/automake/tests/test.bats
@@ -1,11 +1,4 @@
-TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
-
-@test "Automake version command returns expected version" {
-  result="$(hab pkg exec "${TEST_PKG_IDENT}" automake --version | head -1 | cut -d' ' -f4)"
-  [ "$result" = "$TEST_PKG_VERSION"  ]
-}
-
 @test  "aclocal displays help" {
-  run hab pkg exec $TEST_PKG_IDENT aclocal --help
+  run hab pkg exec $TEST_PKG_VERSION aclocal --help
   [ "$status" -eq 0 ]
 }

--- a/gocd-server/hooks/run
+++ b/gocd-server/hooks/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-JAVA_HOME="{{pkgPathFor "core/jre8"}}"
+JAVA_HOME="{{pkgPathFor "core/corretto8"}}"
 SERVER_WORK_DIR="{{pkg.svc_var_path}}"
 SERVER_MEM="{{cfg.memory}}"
 SERVER_MAX_MEM="{{cfg.max-memory}}"

--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -12,7 +12,7 @@ pkg_filename="go-server-${pkg_version}-${pkg_buildnumber}.zip"
 pkg_dirname="go-server-${pkg_version}"
 pkg_deps=(
   core/git
-  core/jre8
+  core/corretto8
 )
 pkg_bin_dirs=(bin)
 pkg_exports=(

--- a/gocd-server/tests/test.bats
+++ b/gocd-server/tests/test.bats
@@ -1,0 +1,9 @@
+@test "gocd-server service is running" {
+  [ "$(hab svc status | grep "gocd-server\.default" | awk '{print $4}' | grep up)" ]
+}
+
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "gocd-server matches version ${expected_version}" {
+  actual_version_array=($(cat /hab/sup/default/sup.log | grep --text -m 1 -oP "(?<=GoCD Version: )([^-]*)"))
+  diff <( echo "${actual_version_array[0]}") <(echo "${expected_version}")
+}

--- a/gocd-server/tests/test.sh
+++ b/gocd-server/tests/test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/curl --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static nc
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+
+# clear the supervisor output
+export SUP_LOG="/hab/sup/default/sup.log"
+cat /dev/null > "${SUP_LOG}"
+
+ci_load_service "${TEST_PKG_IDENT}"
+
+# run the tests
+bats "$(dirname "${0}")/test.bats"
+
+# unload the service
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
### Outstanding Tasks
- [x] Close this PR and move changes to PR #2957 because an extra master commit was somehow introduced during a merge

### Context

See #2883 for background to this PR.

PR #2883 replaced jdk with corretto.  However, since the changes needed to be based not off core-plans master but the refresh/2019q3 branch, then this new PR has been opened and the old PR closed.

### Completed Tasks
- [x] Fix the broken tests: Pull in the master branch file './bin/ci/test_helps.sh'