### PR TITLE
[kibana] Change node dependency to node11

### DIFF
--- a/kibana/plan.sh
+++ b/kibana/plan.sh
@@ -8,14 +8,13 @@ pkg_upstream_url=https://www.elastic.co/products/kibana
 pkg_source=https://github.com/elastic/${pkg_name}/archive/v${pkg_version}.tar.gz
 pkg_shasum=3f9b9179bae432e45411f7b207578d8232ca2d6fc184a5780b6d696d6037b55a
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz
-pkg_deps=(core/node)
+pkg_deps=(core/node11)
 pkg_build_deps=(
   core/cacerts
   core/coreutils
   core/gcc
   core/git
   core/make
-  core/node
   core/python2
 )
 pkg_exports=(


### PR DESCRIPTION
Kibana currently fails to build because one of its dependencies (node-sass) does not support node12.  Newer versions of node-sass do support node12, however digging through the package.json and yarn.lock of releases, no versions of Kibana ship with that version yet.  

For now, we'll switch our dependency to node11 in order to get this package building again. A version bump at this point would be a major version up and require changing the build process. As this change is to unblock the base plans refresh, I'm splitting that work out to be done post-refresh. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>