### PR TITLE
[automake] Update to 1.16.1

### DIFF
--- a/automake/plan.sh
+++ b/automake/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=automake
 pkg_origin=core
-pkg_version=1.16
+pkg_version=1.16.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Automake is a tool for automatically generating Makefile.in files compliant \
 with the GNU Coding Standards.\
 "
 pkg_upstream_url="https://www.gnu.org/software/automake/"
-pkg_license=("GPL-2.0")
+pkg_license=("GPL-2.0-or-later")
 pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="f98f2d97b11851cbe7c2d4b4eaef498ae9d17a3c2ef1401609b7b4ca66655b8a"
+pkg_shasum="5d05bb38a23fd3312b10aea93840feec685bdf4a41146e78882848165d3ae921"
 pkg_deps=(
   core/perl
 )

--- a/automake/tests/test.bats
+++ b/automake/tests/test.bats
@@ -1,0 +1,4 @@
+@test  "aclocal displays help" {
+  run hab pkg exec $TEST_PKG_VERSION aclocal --help
+  [ "$status" -eq 0 ]
+}

--- a/automake/tests/test.sh
+++ b/automake/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Automake 1.16.1 is a security release to address CVE-2012-3386:  https://lists.gnu.org/archive/html/automake/2012-07/msg00023.html

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>