### PR TITLE
[scaffolding-ruby] allow user to choose node package

### DIFF
--- a/scaffolding-ruby/doc/reference.md
+++ b/scaffolding-ruby/doc/reference.md
@@ -51,7 +51,7 @@ The following gems will checked for in the `Gemfile.lock` to conditionally injec
 * If the `sqlite3` gem is detected, then sqlite-related Habitat packages will be injected into your Plan's `pkg_deps` array.
 * If any of several PostgreSQL-related gems are detected, then PostgreSQL-related Habitat packages will be injected into your Plan's `pkg_deps` array. See the PostgreSQL Database Detection section for more details.
 * If the `nokogiri` gem is detected, then XML/XSLT-related Habitat packages will be injected into your Plan's `pkg_deps` array.
-* If the `execjs` gem is detected, then Node-related Habitat packages will be injected into your Plan's `pkg_deps` array.
+* If the `execjs` gem is detected, then Node-related Habitat packages will be injected into your Plan's `pkg_deps` array.  By default this will be the `core/node` package.  To override this, set `scaffolding_node_pkg` within your plan file.  For example to use node 10 add  `scaffolding_node_pkg=core/node10`
 * If the `webpacker` gem is detected, then Yarn-related Habitat packages will be injected into your Plan's `pkg_deps` array.
 
 Additional checks performed by this scaffolding are:

--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -655,7 +655,8 @@ _add_git() {
 _detect_execjs() {
   if _has_gem execjs; then
     build_line "Detected 'execjs' gem in Gemfile.lock, adding node packages"
-    pkg_deps=(core/node "${pkg_deps[@]}")
+    : "${scaffolding_node_pkg:="core/node"}"
+    pkg_deps=("${scaffolding_node_pkg}" "${pkg_deps[@]}")
     debug "Updating pkg_deps=(${pkg_deps[*]}) from Scaffolding detection"
   fi
 }


### PR DESCRIPTION
This PR is related to #2837 
I need to be able to choose the version of node, in my case I need `core/node10` but the scaffolding will always default to `core/node`.

This PR updates to the `_detect_execjs` function to search the pkg_deps array to see if a node package is already defined, if not then it will add `core/node` to `pkg_deps` array as it currently does.

Hope that's OK

Gary

Signed-off-by: Gary Bright <digitalgaz@hotmail.com>