### PR TITLE
[scaffolding-ruby] fix broken pipe

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -393,8 +393,9 @@ scaffolding_run_assets_precompile() {
 
   if _has_gem rake && _has_rakefile; then
     pushd "$scaffolding_app_prefix" > /dev/null
-    if _rake -P --trace | grep -q '^rake assets:precompile$'; then
-      build_line "Detected and running Rake 'assets:precompile'"
+    build_line "Detecting if there's a precompile rake task"
+    if [ "$(_rake --tasks assets:precompile | grep -c assets:precompile)" -ge 1 ]; then
+      build_line "...running 'rake assets:precompile'"
       export DATABASE_URL=${DATABASE_URL:-"postgresql://nobody@nowhere/fake_db_to_appease_rails_env"}
       _rake assets:precompile
     fi


### PR DESCRIPTION
I noticed that running `rake -P --trace | grep -q '^rake assets:precompile$'` would error for me with a broken pipe, 
![image](https://user-images.githubusercontent.com/13700297/62136167-74487b80-b2db-11e9-8600-e65a16ee20cb.png)

I noticed the same thing within studio when it got down to the scaffolding_run_assets_precompile() function and reported it in issue #2837

This pr splits out the command and the evaluation of the grep return code.

Hope that's ok

Best Regards

Gary
 
Signed-off-by: Gary Bright <digitalgaz@hotmail.com>