### PR TITLE
[elasticsearch] Update elasticsearch plan to 6.6.1 and switch from jre8 to openjdk11

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -5,8 +5,10 @@ set -eou pipefail
 # Don't attempt to build the following plans. They have resource requirements
 # or build times that exceed the currently available resources on our CI
 # infrastructure.
- # See also: #2759 and #2065
+# See also: #2759 and #2065
+
 PLAN_BLACKLIST=(
+ elasticsearch
  glibc
  gcc
  ghc

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   core/busybox-static
   core/glibc
   core/zlib
-  core/jre8
+  core/openjdk11
   core/wget
 )
 pkg_bin_dirs=(es/bin)

--- a/elasticsearch/tests/test.bats
+++ b/elasticsearch/tests/test.bats
@@ -1,7 +1,6 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
 @test "Version matches" {
-  result="$(elasticsearch --version | awk '{print $2}' | tr -d ',')"
+  expected_version=$(cut -d/ -f3 $TEST_PKG_IDENT)
+  result="$(hab pkg exec $TEST_PKG_IDENT elasticsearch --version | awk '{print $2}' | tr -d ',')"
   [ "$result" = "${pkg_version}" ]
 }
 


### PR DESCRIPTION
This resolves the merge conflicts in #2308 and supersedes that PR.  Thanks for you work on this @itmustbejj  !

Signed-off-by: Josh Hudson <jhudson@chef.io>