### PR TITLE
[perl] Update to 5.30

### DIFF
--- a/perl/no-sys-dirs.patch
+++ b/perl/no-sys-dirs.patch
@@ -1,7 +1,7 @@
-diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
---- perl-5.26.1.orig/Configure	2017-09-22 14:27:02.000000000 +0000
-+++ perl-5.26.1/Configure	2018-02-18 20:41:45.072171685 +0000
-@@ -111,15 +111,7 @@
+diff -ru perl-5.30.0.orig/Configure perl-5.30.0/Configure
+--- perl-5.30.0.orig/Configure	2019-05-11 09:50:20.000000000 +0000
++++ perl-5.30.0/Configure	2019-07-29 15:03:18.646978657 +0000
+@@ -108,15 +108,7 @@
  fi
  
  : Proper PATH setting
@@ -18,7 +18,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  
  for p in $paths
  do
-@@ -1443,8 +1435,7 @@
+@@ -1431,8 +1423,7 @@
  i_whoami=''
  : Possible local include directories to search.
  : Set locincpth to "" in a hint file to defeat local include searches.
@@ -28,7 +28,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  :
  : no include file wanted by default
  inclwanted=''
-@@ -1458,17 +1449,12 @@
+@@ -1446,17 +1437,12 @@
  archobjs=''
  libnames=''
  : change the next line if compiling for Xenix/286 on Xenix/386
@@ -49,7 +49,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  
  : Private path used by Configure to find libraries.  Its value
  : is prepended to libpth. This variable takes care of special
-@@ -1499,10 +1485,6 @@
+@@ -1489,10 +1475,6 @@
  : If anyone needs extra -lxxx, put those in a hint file.
  libswanted="cl pthread socket bind inet nsl ndbm gdbm dbm db malloc dl ld"
  libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
@@ -60,7 +60,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  : Do not use vfork unless overridden by a hint file.
  usevfork=false
  
-@@ -2559,7 +2541,6 @@
+@@ -2549,7 +2531,6 @@
  zip
  "
  pth=`echo $PATH | sed -e "s/$p_/ /g"`
@@ -68,7 +68,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  for file in $loclist; do
  	eval xxx=\$$file
  	case "$xxx" in
-@@ -5048,7 +5029,7 @@
+@@ -5041,7 +5022,7 @@
  : Set private lib path
  case "$plibpth" in
  '') if ./mips; then
@@ -77,7 +77,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
      fi;;
  esac
  case "$libpth" in
-@@ -8927,13 +8908,8 @@
+@@ -8865,13 +8846,8 @@
  echo " "
  case "$sysman" in
  '')
@@ -93,7 +93,7 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  	;;
  esac
  if $test -d "$sysman"; then
-@@ -21359,9 +21335,10 @@
+@@ -20971,9 +20947,10 @@
  case "$full_ar" in
  '') full_ar=$ar ;;
  esac
@@ -105,25 +105,28 @@ diff -ru perl-5.26.1.orig/Configure perl-5.26.1/Configure
  
  : see what type gids are declared as in the kernel
  echo " "
-diff -ru perl-5.26.1.orig/ext/Errno/Errno_pm.PL perl-5.26.1/ext/Errno/Errno_pm.PL
---- perl-5.26.1.orig/ext/Errno/Errno_pm.PL	2017-07-18 22:49:55.000000000 +0000
-+++ perl-5.26.1/ext/Errno/Errno_pm.PL	2018-02-18 20:45:29.840819166 +0000
-@@ -123,11 +123,7 @@
+Only in perl-5.30.0: Configure.orig
+Only in perl-5.30.0: Configure.rej
+diff -ru perl-5.30.0.orig/ext/Errno/Errno_pm.PL perl-5.30.0/ext/Errno/Errno_pm.PL
+--- perl-5.30.0.orig/ext/Errno/Errno_pm.PL	2019-05-11 09:50:20.000000000 +0000
++++ perl-5.30.0/ext/Errno/Errno_pm.PL	2019-07-29 15:03:53.783646889 +0000
+@@ -134,12 +124,7 @@
  	if ($dep =~ /(\S+errno\.h)/) {
  	     $file{$1} = 1;
  	}
 -    } elsif ($^O eq 'linux' &&
 -	      $Config{gccversion} ne '' && 
--	      $Config{gccversion} !~ /intel/i
+-	      $Config{gccversion} !~ /intel/i &&
 -	      # might be using, say, Intel's icc
+-	      $linux_errno_h
 -	     ) {
 +    } elsif (0) {
-     # When cross-compiling we may store a path for gcc's "sysroot" option:
-     my $sysroot = $Config{sysroot} || '';
- 	# Some Linuxes have weird errno.hs which generate
-diff -ru perl-5.26.1.orig/hints/freebsd.sh perl-5.26.1/hints/freebsd.sh
---- perl-5.26.1.orig/hints/freebsd.sh	2017-08-23 20:25:38.000000000 +0000
-+++ perl-5.26.1/hints/freebsd.sh	2018-02-18 20:50:05.912731422 +0000
+ 	$file{$linux_errno_h} = 1;
+     } elsif ($^O eq 'haiku') {
+ 	# hidden in a special place
+diff -ru perl-5.30.0.orig/hints/freebsd.sh perl-5.30.0/hints/freebsd.sh
+--- perl-5.30.0.orig/hints/freebsd.sh	2019-05-11 09:50:20.000000000 +0000
++++ perl-5.30.0/hints/freebsd.sh	2019-07-29 15:05:37.683651506 +0000
 @@ -127,21 +127,21 @@
          objformat=`/usr/bin/objformat`
          if [ x$objformat = xaout ]; then
@@ -152,9 +155,9 @@ diff -ru perl-5.26.1.orig/hints/freebsd.sh perl-5.26.1/hints/freebsd.sh
         ldflags="-Wl,-E "
          lddlflags="-shared "
          cccdlflags='-DPIC -fPIC'
-diff -ru perl-5.26.1.orig/hints/linux.sh perl-5.26.1/hints/linux.sh
---- perl-5.26.1.orig/hints/linux.sh	2017-07-18 22:50:00.000000000 +0000
-+++ perl-5.26.1/hints/linux.sh	2018-02-18 20:53:58.353305636 +0000
+diff -ru perl-5.30.0.orig/hints/linux.sh perl-5.30.0/hints/linux.sh
+--- perl-5.30.0.orig/hints/linux.sh	2019-05-11 09:50:20.000000000 +0000
++++ perl-5.30.0/hints/linux.sh	2019-07-29 15:05:37.683651506 +0000
 @@ -150,25 +150,6 @@
      ;;
  esac
@@ -181,7 +184,7 @@ diff -ru perl-5.26.1.orig/hints/linux.sh perl-5.26.1/hints/linux.sh
  case "$plibpth" in
  '') plibpth=`LANG=C LC_ALL=C $gcc $ccflags $ldflags -print-search-dirs | grep libraries |
  	cut -f2- -d= | tr ':' $trnl | grep -v 'gcc' | sed -e 's:/$::'`
-@@ -195,32 +176,6 @@
+@@ -205,32 +186,6 @@
    ;;
  esac
  
@@ -214,7 +217,7 @@ diff -ru perl-5.26.1.orig/hints/linux.sh perl-5.26.1/hints/linux.sh
  if ${sh:-/bin/sh} -c exit; then
    echo ''
    echo 'You appear to have a working bash.  Good.'
-@@ -298,33 +253,6 @@
+@@ -308,33 +263,6 @@
  	;;
  esac
  
@@ -248,3 +251,4 @@ diff -ru perl-5.26.1.orig/hints/linux.sh perl-5.26.1/hints/linux.sh
  # Linux on Synology.
  if [ -f /etc/synoinfo.conf -a -d /usr/syno ]; then
      # Tested on Synology DS213 and DS413
+Only in perl-5.30.0/hints: linux.sh.orig

--- a/perl/plan.ps1
+++ b/perl/plan.ps1
@@ -1,9 +1,9 @@
 $pkg_name="perl"
 $pkg_origin="core"
-$pkg_version="5.26.1"
+$pkg_version="5.30.0"
 $pkg_description="Perl 5 is a highly capable, feature-rich programming language with over 29 years of development."
 $pkg_upstream_url="http://www.perl.org/"
-$pkg_license=@("gpl", "perlartistic")
+$pkg_license=@("GPL-1.0-or-later", "Artistic-1.0-Perl")
 $pkg_source="https://github.com/Perl/perl5/archive/v$pkg_version.zip"
 $pkg_shasum="2b3747deadea0510ef9e567e6a8b692e7dd4ecad024f1a5a6108b971093a95fd"
 $pkg_deps=@("core/visual-cpp-redist-2015")

--- a/perl/plan.sh
+++ b/perl/plan.sh
@@ -1,15 +1,15 @@
 pkg_name=perl
 pkg_origin=core
-pkg_version=5.28.0
+pkg_version=5.30.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Perl 5 is a highly capable, feature-rich programming language with over 29 \
 years of development.\
 "
 pkg_upstream_url="http://www.perl.org/"
-pkg_license=('gpl' 'perlartistic')
+pkg_license=('GPL-1.0-or-later' 'Artistic-1.0-Perl')
 pkg_source="http://www.cpan.org/src/5.0/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="7e929f64d4cb0e9d1159d4a59fc89394e27fa1f7004d0836ca0d514685406ea8"
+pkg_shasum="851213c754d98ccff042caa40ba7a796b2cee88c5325f121be5cbb61bbf975f2"
 pkg_deps=(
   core/glibc
   core/zlib

--- a/perl/tests/fixtures/hello.pl
+++ b/perl/tests/fixtures/hello.pl
@@ -1,0 +1,9 @@
+# https://metacpan.org/pod/Perl::Tutorial::HelloWorld
+# The traditional first program.
+
+# Strict and warnings are recommended.
+use strict;
+use warnings;
+
+# Print a message.
+print "Hello, World!\n";

--- a/perl/tests/test.bats
+++ b/perl/tests/test.bats
@@ -1,5 +1,4 @@
-@test "Version matches plan" {
-  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
-  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" perl --version | grep 'This is perl' | grep -oP '(?<=\(v)(.*?)(?=\) built for x86_64-linux-thread-multi)')"
-  diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
+@test "Runs hello-world" {
+  run hab pkg exec $TEST_PKG_IDENT perl $BATS_TEST_DIRNAME/fixtures/hello.pl
+  [ "$output" == "Hello, World!" ]
 }

--- a/perl/tests/test.sh
+++ b/perl/tests/test.sh
@@ -1,23 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
 set -euo pipefail
 
-#/ Usage: test.sh <pkg_ident>
-#/
-#/ Example: test.sh core/opa/0.11.0/20190531065119
-#/
-
-TESTDIR="$(dirname "${0}")"
-
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
-  exit 1
+	exit 1
 fi
 
-TEST_PKG_IDENT="$1"
-
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install "${TEST_PKG_IDENT}"
-
-export TEST_PKG_IDENT
-bats "${TESTDIR}/test.bats"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This updates Perl to the latest stable release, 5.30.   Note: Perl uses odd numbered version to track development, so while there is a 5.31 available we should stay on 5.30. 

The no-sys-dirs patch has been updated to align with a small change made in the `Errno_pm.PL` file.  The remainder of changes in the file are line number changes to the diff to reflect changes made in the source file. 