### PR TITLE
[vault] Update vault to 1.1.5, update testing

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=1.1.1
+pkg_version=1.1.5
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=134261417c8129a92992cba75bf7ebce8ee4d6100de18b722cce7507782e272c
+pkg_shasum=5bb292388d5efc30b020a5ebc53c7d8bc8a0a76435fdddb87e9bf1c589697aa0
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)

--- a/vault/tests/test.bats
+++ b/vault/tests/test.bats
@@ -1,12 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(vault version | awk '{print $2}')"
-  [ "$result" = "v${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} vault version | awk '{print $2}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run vault --help
+  run hab pkg exec ${TEST_PKG_IDENT} vault --help
   [ $status -eq 0 ]
   [ "${lines[0]}" = "Usage: vault <command> [args]" ]
 }
@@ -35,5 +35,5 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
   local sealed_result="$(echo "${health}" | jq '.sealed == false')"
   [ "${sealed_result}" = "true" ]
   local version_result="$(echo "${health}" | jq -r '.version')"
-  [ "${version_result}" = "${pkg_version}" ]
+  [ "${version_result}" = "${TEST_PKG_VERSION}" ]
 }

--- a/vault/tests/test.sh
+++ b/vault/tests/test.sh
@@ -1,36 +1,26 @@
 #!/bin/sh
+set -euo pipefail
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+source bin/ci/test_helpers.sh
 
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install core/curl --binlink
 hab pkg install core/jq-static --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
+hab pkg install "${TEST_PKG_IDENT}"
 
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
-
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 5
-fi
-
-bats "${TESTDIR}/test.bats"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"
+hab svc unload "${TEST_PKG_IDENT}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build vault
source results/last_build.env
hab studio run "./vault/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 8200, 8201
 ✓ Good response from /sys/health endpoint

6 tests, 0 failures
```