### PR TITLE
[scaffolding-go] Use public hab func pkg_path_for

### DIFF
--- a/scaffolding-go/lib/scaffolding.sh
+++ b/scaffolding-go/lib/scaffolding.sh
@@ -4,7 +4,7 @@
 # after the scaffolding is loaded.
 scaffolding_load() {
   local lib_dir
-  lib_dir="$(_pkg_path_for_build_deps "$pkg_scaffolding")/lib"
+  lib_dir="$(pkg_path_for "$pkg_scaffolding")/lib"
 
   # When the user enables go module support,
   # we don't need to setup the GOPATH


### PR DESCRIPTION
Instead of using `_pkg_path_for_build_deps` that is not fully exposed inside
the habitat build process, use `pkg_path_for` that is the exposed version of
the helper function.