### PR TITLE
Disable shellcheck 1008 and 2239

### DIFF
--- a/bin/ci/shellcheck.sh
+++ b/bin/ci/shellcheck.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Exclude hooks and config because the handlebars syntax confuses shellcheck
 #
 # Exclude the following shellcheck issues since they're pervasive and innocuous:
+# https://github.com/koalaman/shellcheck/wiki/SC1008
 # https://github.com/koalaman/shellcheck/wiki/SC1090
 # https://github.com/koalaman/shellcheck/wiki/SC1091
 # https://github.com/koalaman/shellcheck/wiki/SC1117
@@ -20,9 +21,10 @@ set -euo pipefail
 # https://github.com/koalaman/shellcheck/wiki/SC2153
 # https://github.com/koalaman/shellcheck/wiki/SC2154
 # https://github.com/koalaman/shellcheck/wiki/SC2164
+# https://github.com/koalaman/shellcheck/wiki/SC2239
 
-SHELLCHECK_IGNORE="SC1090,SC1091,SC1117,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"
-
+SHELLCHECK_IGNORE="SC1008,SC1090,SC1091,SC1117,SC2034,SC2039"
+SHELLCHECK_IGNORE="${SHELLCHECK_IGNORE},SC2140,SC2148,SC2153,SC2154,SC2164,SC2239"
 plan_path="$1"
 
 echo "--- :bash: [$plan_path] Running shellcheck"


### PR DESCRIPTION
This disables Shellchecks 1008 and 2239, which will almost always be false positives in the context of core-plans.  In the same way we disable [SC2148](https://github.com/koalaman/shellcheck/wiki/SC2148) because plan.sh shouldn't start with a `#!`, a number of our scripts start with template values that are evaluated at build to inject a correct, full path. 

https://github.com/koalaman/shellcheck/wiki/SC1008
https://github.com/koalaman/shellcheck/wiki/SC2239

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>