### PR TITLE
[node10] Update node10 to 10.16.1

### DIFF
--- a/node10/plan.ps1
+++ b/node10/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node10"
 $pkg_origin="core"
-$pkg_version="10.16.0"
+$pkg_version="10.16.1"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="4d106b32293453f1ed037650c3051db854f853f7cef5a06e659e5c7d978cadb7"
+$pkg_shasum="dc99f8c0be1e8bb1abfaa194113712ba85cc749bd32990f84cdcdd3b619f6a1c"

--- a/node10/plan.sh
+++ b/node10/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node10
 pkg_origin=core
-pkg_version=10.16.0
+pkg_version=10.16.1
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=d00f1ffdb0a7413eaaf3afc393fb652ea713db135dcd3ccf6809370a07395713
+pkg_shasum=98c92edcfced73b572917d01a53aa9deefec85d8a2fe96c46fe10ee1d0a7763d
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build node10
source results/last_build.env
hab studio run "./node10/tests/test.sh"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
```

![tenor-154627426](https://user-images.githubusercontent.com/24568/62262611-48043a80-b454-11e9-9db6-dd1664c9dd36.gif)
