### PR TITLE
[netdata] Update netdata to 1.16.1, add testing

### DIFF
--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=netdata
 pkg_origin=core
-pkg_version=1.16.0
+pkg_version=1.16.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
 pkg_description="netdata is a system for distributed real-time performance and health monitoring."
 pkg_upstream_url="https://github.com/netdata/netdata"
 pkg_source="https://github.com/netdata/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=5d893f71e97be65933f9bfc9d9cf3fc42f8fb9b607b9e24eeb2c581a01334e95
+pkg_shasum=94492108a6e24e8b39c011ae35ff6f50a848d816af396fdf2b44655cecd78672
 pkg_build_deps=(
   core/autoconf
   core/autogen

--- a/netdata/tests/test.bats
+++ b/netdata/tests/test.bats
@@ -1,0 +1,20 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} netdata -v | awk '{print $2}')"
+  [ "$result" = "v${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} netdata -h
+  [ $status -eq 0 ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "netdata\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "Listening on port 19999" {
+  result="$(netstat -peanut | grep netdata | grep 19999 | awk '{print $4}' | awk -F':' '{print $NF}')"
+  [ "${result}" -eq 19999 ]
+}

--- a/netdata/tests/test.sh
+++ b/netdata/tests/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build netdata
source results/last_build.env
hab studio run "./netdata/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 19999

4 tests, 0 failures
```