### PR TITLE
[minio] Update minio to 2019-07-31T18-57-56Z, simplify version check

### DIFF
--- a/minio/plan.sh
+++ b/minio/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=minio
 pkg_origin=core
-pkg_version="2019-04-09T01-22-30Z"
+pkg_version="2019-07-31T18-57-56Z"
 pkg_description="Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure."
 pkg_upstream_url="https://minio.io"
 pkg_source="https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.${pkg_version}"
-pkg_shasum="88b56053d46175a60ed11ffac5335f42e48d395de9217839bc288f5554bb2476"
+pkg_shasum=78fc08a095bd1985a96ebc727fd3855840dd2c79d6f3bd2b542a940d7b183a42
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_bin_dirs=(bin)

--- a/minio/tests/test.bats
+++ b/minio/tests/test.bats
@@ -1,14 +1,9 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v minio)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches, via help output" {
-  run minio --help
-  [ "$status" -eq 0 ]
-  version="$(echo "${lines[-1]}" | sed 's/:/-/g')"
-  [ "$version" = "  ${pkg_version}" ]
+  result=$(hab pkg exec ${TEST_PKG_IDENT} minio --help | tail -1 | tr -d ' ' | sed 's/:/-/g')
+  [ "$?" -eq 0 ]
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Service is running" {

--- a/minio/tests/test.sh
+++ b/minio/tests/test.sh
@@ -1,31 +1,35 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
+set -euo pipefail
 
-SKIPBUILD=${SKIPBUILD:-0}
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
 
-hab pkg install core/bats --binlink
-
-hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
-hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static wc
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 5
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static wc
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build minio
source results/last_build.env
hab studio run "./minio/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches, via help output
 ✓ Service is running
 ✓ A single process
 ✓ Listening on port 9000

4 tests, 0 failures
```

![tenor-211134958](https://user-images.githubusercontent.com/24568/62272367-e6ed5e80-b475-11e9-9ba0-97de3273fa9e.gif)
