### PR TITLE
[zeromq] Update lib references on Windows

### DIFF
--- a/zeromq/plan.ps1
+++ b/zeromq/plan.ps1
@@ -31,9 +31,9 @@ function Invoke-Build {
 }
 
 function Invoke-Install {
-    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\bin\Release\libzmq-v140-mt-4_2_5.dll" "$pkg_prefix\bin\" -Force
-    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\bin\Release\libzmq-v140-mt-4_2_5.dll" "$pkg_prefix\bin\zmq.dll" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\bin\Release\libzmq-v140-mt-4_3_1.dll" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\bin\Release\libzmq-v140-mt-4_3_1.dll" "$pkg_prefix\bin\zmq.dll" -Force
     Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\lib\Release\*.lib" "$pkg_prefix\lib\" -Force
-    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\lib\Release\libzmq-v140-mt-4_2_5.lib" "$pkg_prefix\lib\zmq.lib" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\cmake-build\lib\Release\libzmq-v140-mt-4_3_1.lib" "$pkg_prefix\lib\zmq.lib" -Force
     Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\libzmq-$pkg_version\include\*" "$pkg_prefix\include\" -Force
 }


### PR DESCRIPTION
This updates the library version references in the `Invoke-Install` phase of zeromq.  My Windows system isn't available at the moment so I haven't verified this works yet.  Once I've done that, I'll add a comment here that this is ready to be merged. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>