### PR TITLE
[QUICK-FIX] Scape DEBUG env variable

### DIFF
--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -36,7 +36,7 @@ wrap_ruby_bin() {
   cat <<EOF > "$bin"
 #!$(pkg_path_for busybox-static)/bin/sh
 set -e
-if test -n "$DEBUG"; then set -x; fi
+if test -n "\$DEBUG"; then set -x; fi
 
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -47,7 +47,7 @@ wrap_ruby_bin() {
   cat <<EOF > "$bin"
 #!$(pkg_path_for busybox-static)/bin/sh
 set -e
-if test -n "$DEBUG"; then set -x; fi
+if test -n "\$DEBUG"; then set -x; fi
 
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"


### PR DESCRIPTION
I think that the creator of these plans wanted to scape the DEBUG
environment variable for debugging, without scaping it the resulting
binary looks like:
```bash
set -e
if test -n ""; then set -x; fi
```
and instead we want this:
```bash
set -e
if test -n "$DEBUG"; then set -x; fi
```

Signed-off-by: Salim Afiune <afiune@chef.io>