### PR TITLE
Add libidn2 and deps to base-plans.txt

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -78,6 +78,9 @@ check @fnichol @smacfarlane
 libidn @fnichol @smacfarlane
 cacerts @fnichol @smacfarlane
 openssl @fnichol @reset @echohack @smacfarlane
+libiconv @smacfarlane
+libunistring @smacfarlane
+libidn2 @smacfarlane
 wget @fnichol @smacfarlane
 unzip @fnichol @nellshamrell @smacfarlane
 rq @fnichol @smacfarlane

--- a/base-plans.txt
+++ b/base-plans.txt
@@ -57,6 +57,9 @@ core-plans/check
 core-plans/cacerts
 core-plans/openssl-fips
 core-plans/openssl
+core-plans/libiconv
+core-plans/libunistring
+core-plans/libidn2
 core-plans/wget
 core-plans/unzip
 core-plans/rq


### PR DESCRIPTION
With the addition of libidn2 as a dependency to wget (#1981), it also needs to be considered base plan.  It bring with it two additional dependencies, libunistring and libiconv which are also added to the base-plans list.


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>