### PR TITLE
[libunistring] update to 0.9.10

### DIFF
--- a/libunistring/plan.sh
+++ b/libunistring/plan.sh
@@ -1,17 +1,16 @@
 pkg_name=libunistring
 pkg_origin=core
-pkg_version=0.9.6
+pkg_version=0.9.10
 pkg_description="Library functions for manipulating Unicode strings"
 pkg_upstream_url="https://www.gnu.org/software/libunistring/"
-pkg_license=('LGPL-3.0')
+pkg_license=('LGPL-3.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ftp.gnu.org/gnu/libunistring/libunistring-${pkg_version}.tar.xz"
-pkg_shasum=2df42eae46743e3f91201bf5c100041540a7704e8b9abfd57c972b2d544de41b
+pkg_shasum=eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
 
 do_check() {
   make check


### PR DESCRIPTION
This is a minor version bump required to allow libunistring to be built against glibc2.29 

This package provides no executable commands so the `pkg_bin_dirs` line has been removed. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>