### PR TITLE
[dotnet-core-sdk] Updating Linux/Windows plan to 2.2.401

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,14 +1,14 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="2.2.301"
+$pkg_version="2.2.401"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/3c7fcb0b-52ee-40b2-853d-710c58883371/78bbdf5fcd85697e8e306c355d02d0b0/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="996a001ce2c415a24f21cee698ca1e2581ed5adced5b82763cb12326060feba0"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/4de548ef-9b51-4b1f-ae3a-60ebd6a6f2b5/01fce24fe286e7475fdbecc60f1daee5/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_shasum="adff0b27798ce6233ee8952ee83b02d9f197214fab77c9ee311b1ce904f52bb7"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=2.2.301
+pkg_version=2.2.401
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/3224f4c4-8333-4b78-b357-144f7d575ce5/ce8cb4b466bba08d7554fe0900ddc9dd/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=63fef1550a6f7680c2c32cbf3ba1111f99d09b91126c0aaf2fbaf19d2d90ec84
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/228832ea-805f-45ab-8c88-fa36165701b9/16ce29a06031eeb09058dee94d6f5330/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=32cb42407b0171742310cefb187fd63f1380841af97f2ee914ec47c3ebed9422
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Hey all,

This PR updates dotnet-core-sdk to version 2.2.401. To test the build, please run:
```
hab pkg build dotnet-core-sdk
source results/last_build.env
hab studio run "./dotnet-core-sdk/tests/test.sh ${pkg_ident}"
```

The result should be:
```
 ✓ Version matches
 ✓ Info command

2 tests, 0 failures
```

Please let me know if there are any questions. Thanks! 
