### PR TITLE
[coreutils] Re-add diffutils as a dependency

### DIFF
--- a/coreutils/plan.sh
+++ b/coreutils/plan.sh
@@ -25,6 +25,7 @@ pkg_build_deps=(
   core/gcc
   core/m4
   core/perl
+  core/diffutils
 )
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/env)


### PR DESCRIPTION
Without diffutils, coreutils generate a different build and fails multiple tests. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>