### PR TITLE
[bzip2] Add windows and linux tests to core/bzip2 VERSION 3

### DIFF
--- a/bzip2/plan.ps1
+++ b/bzip2/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="bzip2"
 $pkg_origin="core"
-$pkg_version="1.0.6"
+$pkg_version="1.0.8"
 $pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
 $pkg_description="bzip2 is a free and open-source file compression program that uses the Burrows–Wheeler algorithm. It only compresses single files and is not a file archiver."
 $pkg_upstream_url="http://www.bzip.org/"
 $pkg_license=("bzip2")
-$pkg_source="https://github.com/nemequ/$pkg_name/archive/v${pkg_version}.zip"
-$pkg_shasum="1ac730150d4c13a6933101c8d21acc6de258503ae8a6a049e948a47749ddcc81"
+$pkg_source="https://fossies.org/linux/misc/${pkg_name}-${pkg_version}.zip"
+$pkg_shasum="7585f461a58476bb2697642b5bd4e6fb173404a5e59ae8cd557226b0fd388405"
 $pkg_deps=@("core/visual-cpp-redist-2015")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015")
 $pkg_bin_dirs=@("bin")

--- a/bzip2/plan.sh
+++ b/bzip2/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=bzip2
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=1.0.6
+pkg_version=1.0.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 bzip2 is a free and open-source file compression program that uses the \
@@ -10,8 +10,8 @@ archiver.\
 "
 pkg_upstream_url="http://www.bzip.org/"
 pkg_license=('bzip2')
-pkg_source="https://github.com/nemequ/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
+pkg_source="https://fossies.org/linux/misc/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc

--- a/bzip2/tests/test.bats
+++ b/bzip2/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "bzip2 version matches ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" bzip2 --help 2>&1 | grep -oP '(?<=Version )([^,]*)')"
+  diff <( echo "${actual_version}" ) <( echo "${expected_version}" )
+}

--- a/bzip2/tests/test.pester.ps1
+++ b/bzip2/tests/test.pester.ps1
@@ -1,0 +1,15 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/bzip2" {
+    Context "bzip2" {
+        $OutputVariable = (hab pkg exec $pkg_ident bzip2 --help *>&1 | Out-String)
+        $OutputVariable -match "(?<=Version )([^,]*)"
+        It "returns version that matches the $PackageVersion" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/bzip2/tests/test.ps1
+++ b/bzip2/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/bzip2/tests/test.sh
+++ b/bzip2/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [x] Cherry pick in just the change; i.e., revert automake commit in previous PR
- [x] Rebuild linux and windows and re-test.  Ping Scott
- [ ] Waiting for approval and merge

### Context

See #2741 and #2916 for background to this PR.

PR #2741 introduced windows and linux tests to the bzip2 core plan.  #2916 re-based the PR not off core-plans master but the refresh/2019q3 branch.  This PR removes a master commit that was incorrectly merged into the branch
