### PR TITLE
[telegraf] Update telegraf to 1.11.4

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version=1.11.3
+pkg_version=1.11.4
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum=565a1b5cc9cbfd797f245a25addcecf791b3381f6b137994dd8e56850b1c3d1a
+pkg_shasum=8c7ce7398fe61b349607e05efb37626eb4d5ab018bb219be25781f67bcedb645
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config ${pkg_svc_config_path}/telegraf.conf"
 pkg_build_deps=(


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build telegraf
source results/last_build.env
hab studio run "./telegraf/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running

2 tests, 0 failures
```