### PR TITLE
[cuda] Change jre to coretto

### DIFF
--- a/cuda/plan.sh
+++ b/cuda/plan.sh
@@ -19,7 +19,7 @@ pkg_deps=(
   core/ncurses
   core/gcc
   core/python2
-  core/jre8
+  core/corretto8
   core/coreutils
   core/busybox-static
 )
@@ -131,7 +131,7 @@ EOF
 
   # Remove included copy of java and link to system java
   rm -fr "${pkg_prefix}/jre"
-  sed "s|../jre/bin/java|$(pkg_path_for core/jre8)/bin/java|g" \
+  sed "s|../jre/bin/java|$(pkg_path_for core/corretto8)/bin/java|g" \
     -i "${pkg_prefix}/libnsight/nsight.ini" \
     -i "${pkg_prefix}/libnvvp/nvvp.ini"
 


### PR DESCRIPTION
This package is currently unsupported, but remains in core as a reference and hope that we will be able to re-enable builds in the future #2325 .  In order to fully deprecate the jre/jdk packages, we need to move all dependencies off of it.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>