### PR TITLE
[bazel] Change jdk to coretto

### DIFF
--- a/bazel/plan.sh
+++ b/bazel/plan.sh
@@ -17,7 +17,7 @@ pkg_build_deps=(
 )
 pkg_deps=(
   core/glibc
-  core/jdk8
+  core/corretto8
   core/gcc-libs
   core/zip
   core/unzip


### PR DESCRIPTION
This package currently doesn't build so this change hasn't been validated, but is a requirement to finish the deprecation of jre/jdk.  The complexity of this packages build process, and the low usage of this package have, unfortunately, made fixing the builds a low priority and are out of scope for the JRE/JDK deprecation. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>