### PR TITLE
[base-plans.txt] Update to ensure successful refresh/2019q3

### DIFF
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -1,4 +1,5 @@
 core-plans/linux-headers
+core-plans/python-minimal
 core-plans/glibc
 core-plans/zlib
 core-plans/file
@@ -8,8 +9,8 @@ core-plans/gmp
 core-plans/mpfr
 core-plans/libmpc
 core-plans/gcc
-core-plans/patchelf FIRST_PASS=true
 core-plans/gcc-libs
+core-plans/patchelf FIRST_PASS=true
 core-plans/patchelf
 core-plans/bzip2
 core-plans/pkg-config
@@ -58,6 +59,9 @@ core-plans/check
 core-plans/cacerts
 core-plans/openssl-fips
 core-plans/openssl
+core-plans/libunistring
+core-plans/libiconv
+core-plans/libidn2
 core-plans/wget
 core-plans/unzip
 core-plans/rq

--- a/libunistring/plan.sh
+++ b/libunistring/plan.sh
@@ -1,17 +1,16 @@
 pkg_name=libunistring
 pkg_origin=core
-pkg_version=0.9.6
+pkg_version=0.9.10
 pkg_description="Library functions for manipulating Unicode strings"
 pkg_upstream_url="https://www.gnu.org/software/libunistring/"
-pkg_license=('LGPL-3.0')
+pkg_license=('LGPL-3.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ftp.gnu.org/gnu/libunistring/libunistring-${pkg_version}.tar.xz"
-pkg_shasum=2df42eae46743e3f91201bf5c100041540a7704e8b9abfd57c972b2d544de41b
+pkg_shasum=eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_bin_dirs=(bin)
 
 do_check() {
   make check


### PR DESCRIPTION
### Outstanding Tasks
- [x] Completed Stage 0 build of all base-plans against the refresh/2019q3 branch (after making some minor changes according to this PR).  See also issue https://github.com/gavindidrichsen/core-plans/issues/12
- [ ] Verify this PR on a clean builder installation

### Context

The following changes to the core-plans/base-plans.txt are required to ensure a successful refresh using the refresh/2019q3 branch. 

**PROBLEM:** The glibc build fails with the following

```bash
   glibc: Trying to install 'core/python-minimal' from 'stable'
Ø Enabling feature: IGNORE_LOCAL
» Installing core/python-minimal
☁ Determining latest version of core/python-minimal in the 'stable' channel
✗✗✗
✗✗✗ Package not found.
✗✗✗
   glibc: WARN: Could not find a suitable installed package for 'core/python-minimal'
   glibc: ERROR: Resolving 'core/python-minimal' failed, should this be built first?
   glibc: Build time: 0m24s
   glibc: Exiting on error
Script done, file is /src/results/logs/glibc.2019-08-09-200204.log
[2019-08-09_20:02:28.48] [ERROR]   Exiting /tmp/scripts/setup_builder/04_01_start_the_refresh.sh prematurely with exit code [1]
```

**SOLUTION:** Add core/python-minimal to the base-plans.txt

```diff
diff --git a/base-plans.txt b/base-plans.txt
index 3c85b8d..7ff1d09 100644
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -1,4 +1,5 @@
 core-plans/linux-headers
+core-plans/python-minimal
 core-plans/glibc
root@myvm:/hab/builder/
```

and rebuild.  core/python-minimal now installs fine:

```bash
Ø Enabling feature: IGNORE_LOCAL
   hab-studio: Building 'core-plans/python-minimal' in Studio at /hab/studios/hab--builder--refresh-setup (default)
   ...
   python-minimal: Preparing to build
   python-minimal: Building
```

**PROBLEM:** The core/patchelf build fails with a misalignment of glibc versions

```bash
Install of core/gcc-libs/8.2.0/20190115011926 complete with 0 new packages installed.
   patchelf: Resolved dependency 'core/gcc-libs' to /hab/pkgs/core/gcc-libs/8.2.0/20190115011926
   patchelf: WARN:
   patchelf: WARN: The following runtime dependencies have more than one version
   patchelf: WARN: release in the full dependency chain:
   patchelf: WARN:
   patchelf: WARN:   * core/glibc ( core/glibc/2.29/20190809202925 core/glibc/2.27/20190115002733 )
   patchelf: WARN:   * core/linux-headers ( core/linux-headers/4.17.12/20190809200039 core/linux-headers/4.17.12/20190115002705 )
   patchelf: WARN:
   patchelf: WARN: The current situation usually arises when a Plan has a direct
   patchelf: WARN: dependency on one version of a package (`acme/A/7.0/20160101200001`)
   patchelf: WARN: and has a direct dependency on another package which itself depends
   patchelf: WARN: on another version of the same package (`acme/A/2.0/20151201060001`).
   patchelf: WARN: If this package (`acme/A`) contains shared libraries which are
   patchelf: WARN: loaded at runtime by the current Plan, then both versions of
   patchelf: WARN: `acme/A` could be loaded into the same process in a potentially
   patchelf: WARN: surprising order. Worse, if both versions of `acme/A` are
   patchelf: WARN: ABI-incompatible, runtime segmentation faults are more than likely.
   patchelf: WARN:
   patchelf: WARN: In order to preserve reliability at runtime the duplicate dependency
   patchelf: WARN: entries will need to be resolved before this Plan can be built.
   patchelf: WARN: Below is an expanded graph of all `$pkg_deps` and their dependencies
   patchelf: WARN: with the problematic lines noted.
   patchelf: WARN:
   patchelf: WARN: Computed dependency graph (Lines with '*' denote a problematic entry):

core/patchelf/0.10/20190809220650
    core/glibc/2.29/20190809202925 (*)
        core/linux-headers/4.17.12/20190809200039 (*)
    core/gcc-libs/8.2.0/20190115011926
        core/glibc/2.27/20190115002733 (*)
            core/linux-headers/4.17.12/20190115002705 (*)

   patchelf: ERROR: Computed runtime dependency check failed, aborting
   patchelf: Build time: 0m27s
   patchelf: Exiting on error
Script done, file is /src/results/logs/patchelf.2019-08-09-220650.log
[2019-08-09_22:07:18.10] [ERROR]   Exiting /tmp/scripts/setup_builder/04_01_start_the_refresh.sh prematurely with exit code [1]
```

**SOLUTION:** Move the core-plans/gcc-libs before the core-plans/patchelf

```diff
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -8,8 +9,8 @@ core-plans/gmp
 core-plans/mpfr
 core-plans/libmpc
 core-plans/gcc
-core-plans/patchelf FIRST_PASS=true
 core-plans/gcc-libs
+core-plans/patchelf FIRST_PASS=true
 core-plans/patchelf
 core-plans/bzip2
 core-plans/pkg-config
```
