### PR TITLE
[jenkins] Listen on multiple network interfaces

### DIFF
--- a/jenkins/hooks/run
+++ b/jenkins/hooks/run
@@ -11,19 +11,19 @@ exec java \
   --prefix={{cfg.jenkins.prefix}} \
   {{~#if cfg.jenkins.http.enabled}}
   --httpPort={{cfg.jenkins.http.port}} \
-  --httpListenAddress={{sys.ip}} \
+  --httpListenAddress=0.0.0.0 \
   {{~/if}}
   {{~#if cfg.jenkins.https.enabled}}
   --httpsPort={{cfg.jenkins.https.port}} \
-  --httpsListenAddress={{sys.ip}} \
+  --httpsListenAddress=0.0.0.0 \
   {{~/if}}
   {{~#if cfg.jenkins.http2.enabled}}
   --http2Port={{cfg.jenkins.http2.port}} \
-  --http2ListenAddress={{sys.ip}} \
+  --http2ListenAddress=0.0.0.0 \
   {{~/if}}
   {{~#if cfg.jenkins.ajp13.enabled}}
   --ajp13Port={{cfg.jenkins.ajp13.port}} \
-  --ajp13ListenAddress={{sys.ip}} \
+  --ajp13ListenAddress=0.0.0.0 \
   {{~else}}
   --ajp13Port=-1 \
   {{~/if}}


### PR DESCRIPTION
This forgoes the use of `{{sys.ip}}`, allowing the Jenkins service to listen on _every_ network interface instead of [the first network interface with a route to Google's DNS](https://github.com/habitat-sh/habitat/issues/5079#issuecomment-494119508). This both overcomes the Habitat bug where `sys.ip` will sometimes resolve to the local loopback, as well as allowing this to be more flexible as a whole.

If there is a use-case for restricting the Jenkins server to a specific IP address, this should probably be addressed through the resolution to [this issue](https://github.com/habitat-sh/habitat/issues/6793) when it arrives.