### PR TITLE
[nginx] bump: 1.17.2 -> 1.17.3

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.17.2"
+$pkg_version="1.17.3"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="cc8460633ffd1879f86897a2acc7d83c0b5d34c7815febb4208167244eb18abd"
+$pkg_shasum="f70a06fcaa0eecee1af3b39836bdf6c750175dc9e0e3380b07b754f19c284707"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.17.2
+pkg_version=1.17.3
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=5e333687464e1d6dfb86fc22d653b99a6798dda40093b33186eeeec5a97e69ec
+pkg_shasum=3b84fe1c2cf9ca22fde370e486a9ab16b6427df1b6ea62cdb61978c9f34d0f3c
 pkg_deps=(
   core/glibc
   core/libedit


### PR DESCRIPTION
Changelog is here: http://nginx.org/en/CHANGES

    Changes with nginx 1.17.3                                        13 Aug 2019

        *) Security: when using HTTP/2 a client might cause excessive memory
           consumption and CPU usage (CVE-2019-9511, CVE-2019-9513,
           CVE-2019-9516).

        *) Bugfix: "zero size buf" alerts might appear in logs when using
           gzipping; the bug had appeared in 1.17.2.

        *) Bugfix: a segmentation fault might occur in a worker process if the
           "resolver" directive was used in SMTP proxy.

---------
⚠️ I've changed the `plan.ps1` without having the slightest idea how to test this. Let's see if CI does 🤔 