### PR TITLE
[go] Bump version to 1.12.8

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.12.5
+pkg_version=1.12.8
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz"
-pkg_shasum=2aa5f088cbb332e73fc3def546800616b38d3bfe6b8713b8a6404060f22503e8
+pkg_shasum=11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898
 pkg_dirname=go
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
This addresses the following CVEs:

- CVE-2019-9512
- CVE-2019-9514
- CVE-2019-14809

For more information see

https://groups.google.com/forum/#!msg/golang-nuts/fCQWxqxP8aA/DbI5QZnMAAAJ

Signed-off-by: Steven Danna <steve@chef.io>