### PR TITLE
[boringssl] Move deps to pkg_build_deps, cleanup unpacking

### DIFF
--- a/boringssl/plan.sh
+++ b/boringssl/plan.sh
@@ -9,20 +9,26 @@ pkg_source="https://boringssl.googlesource.com/boringssl/+archive/${pkg_version}
 pkg_shasum="None"
 pkg_deps=(
   core/glibc
-  core/go
-  core/cmake
-  core/ninja
-  core/perl
-  core/gcc
-)
-pkg_build_deps=(
-  core/glibc
   core/gcc-libs
+)
+
+pkg_build_deps=(
+  core/go
+  core/perl
+  core/ninja
+  core/cmake
+  core/gcc
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 
+do_unpack() {
+  mkdir -p "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
+  tar xf "${HAB_CACHE_SRC_PATH}/${pkg_filename}" \
+    -C "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" \
+    --no-same-owner
+}
 
 # This feels bad but Google doesn't do releases and that branch is a moving target
 do_verify() {
@@ -30,18 +36,15 @@ do_verify() {
 }
 
 do_build() {
-  pushd .. >/dev/null
   mkdir -p "build"
   pushd build >/dev/null
   cmake -GNinja ..
   ninja
   popd >/dev/null
-  pushd .. >/dev/null
-
 }
 
 do_install() {
-  pushd ../build >/dev/null
+  pushd build >/dev/null
   mkdir -p "${pkg_prefix}/bin" "${pkg_prefix}/include" "${pkg_prefix}/lib"
   mv tool/bssl "${pkg_prefix}/bin"
   mv ssl/libssl.a           "${pkg_prefix}/lib"


### PR DESCRIPTION
This moves the build dependencies to pkg_build_deps rather than
pkg_deps. Further, it overrides do_unpack to ensure we don't unpack
directly in the HAB_CACHE_SRC_PATH.

Signed-off-by: Steven Danna <steve@chef.io>