### PR TITLE
[hugo] 0.57 + extended version fixes

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version=0.56.3
+pkg_version=0.57.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."

--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -5,11 +5,12 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."
 pkg_build_deps=(
-  core/go
-  core/git
   core/gcc
+  core/git
+  core/go
 )
 pkg_deps=(
+  core/gcc-libs
   core/glibc
 )
 pkg_bin_dirs=(bin)
@@ -24,12 +25,15 @@ do_build() {
     --config advice.detachedHead=false \
     "${pkg_repository}" \
     "${hugo_dir}"
+
   pushd "${hugo_dir}" > /dev/null
-  go install --tags extended
-  go build -o hugo main.go
+  go install -tags extended
+  local build_date
+  build_date=$(date -Iseconds -u)
+  go build -o hugo -ldflags "-X github.com/gohugoio/hugo/common/hugo.buildDate=${build_date}" -tags extended main.go
   popd > /dev/null
 }
 
 do_install() {
-  cp "${HAB_CACHE_SRC_PATH}/hugo-${pkg_version}/hugo" "${pkg_prefix}/bin/"
+  install -D "${HAB_CACHE_SRC_PATH}/hugo-${pkg_version}/${pkg_name}" "${pkg_prefix}/bin/${pkg_name}"
 }

--- a/hugo/tests/test.bats
+++ b/hugo/tests/test.bats
@@ -2,7 +2,7 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
   result="$(hab pkg exec "${TEST_PKG_IDENT}" hugo version | awk '{print $5}')"
-  [ "$result" = "v${TEST_PKG_VERSION}" ]
+  [ "$result" = "v${TEST_PKG_VERSION}/extended" ]
 }
 
 @test "Help command" {


### PR DESCRIPTION
Update the hugo plan.sh to properly build the extended version of the hugo binary. Update the tests to reflect this.