### PR TITLE
[nghttp2] bump: 1.34.0 -> 1.39.2

### DIFF
--- a/nghttp2/plan.sh
+++ b/nghttp2/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nghttp2
 pkg_origin=core
-pkg_version=1.34.0
+pkg_version=1.39.2
 pkg_description="nghttp2 is an open source HTTP/2 C Library."
 pkg_upstream_url=https://nghttp2.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=8889399ddd38aa0405f6e84f1c050a292286089441686b8a9c5e937de4f5b61d
+pkg_shasum=fc820a305e2f410fade1a3260f09229f15c0494fc089b0100312cd64a33a38c0
 pkg_build_deps=(
   core/make
   core/gcc


### PR DESCRIPTION
We don't currently build the binaries included in this, but let's still
bump for this:

https://github.com/nghttp2/nghttp2/releases/tag/v1.39.2
