### PR TITLE
[at-spi2-core] add zlib runtime dependancy

### DIFF
--- a/at-spi2-core/plan.sh
+++ b/at-spi2-core/plan.sh
@@ -14,6 +14,7 @@ pkg_deps=(
   core/libffi
   core/libiconv
   core/pcre
+  core/zlib
 )
 pkg_build_deps=(
   core/diffutils


### PR DESCRIPTION
closes #2207 

Signed-off-by: Steven Marshall <SMarshall@chef.io>