### PR TITLE
Fix habitat-core-maintainers team name in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -93,7 +93,7 @@ xz-musl @fnichol @smacfarlane
 libsodium-musl @fnichol @reset @smacfarlane
 openssl-musl @fnichol @smacfarlane
 libarchive-musl @fnichol @reset @smacfarlane
-rust @fnichol @reset @habitat-core-team
+rust @fnichol @reset @habitat-core-maintainers
 vim @fnichol @smacfarlane
 libbsd @fnichol @smacfarlane
 clens @fnichol @smacfarlane


### PR DESCRIPTION
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>