### PR TITLE
[make] Add tests to core/make

### DIFF
--- a/make/plan.sh
+++ b/make/plan.sh
@@ -1,3 +1,5 @@
+# Stop shellcheck requiring quotes around pkg_name
+# shellcheck disable=SC2209
 pkg_name=make
 pkg_origin=core
 pkg_version=4.2.1

--- a/make/tests/test.bats
+++ b/make/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "make matches version ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" make --version | grep "GNU Make" | awk '{print $3}')"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}

--- a/make/tests/test.sh
+++ b/make/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting for approval and merge
- [x] Fix the shellcheck error in the plan

```bash
In make/plan.sh line 1:
--
  | pkg_name=make
  | ^------^ SC2209: Use var=$(command) to assign output (or quote to assign string).
  |  
  | For more information:
  | https://www.shellcheck.net/wiki/SC2209 -- Use var=$(command) to assign outp...
```

### Context
Tests added:

```bash
★ Install of core/make/4.2.1/20190819155911 complete with 0 new packages installed.
 ✓ make matches version 4.2.1

1 test, 0 failures
```