### PR TITLE
[caddy] Fix the broken core/caddy tests

### DIFF
--- a/caddy/tests/test.sh
+++ b/caddy/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -15,23 +17,12 @@ TEST_PKG_IDENT="${1}"
 export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
 hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static wc
-hab pkg binlink core/busybox-static uniq
 hab pkg install core/curl --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab sup term
-hab sup run &
-sleep 5
-
-hab svc load "${TEST_PKG_IDENT}"
-
-# Allow service start
-WAIT_SECONDS=10
-echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
-sleep "${WAIT_SECONDS}"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
 
 bats "$(dirname "${0}")/test.bats"
 


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting for approval and merge
- [x] Fix the shellcheck error in the plan

### Context
Updated the test.sh so that the service testing is now successful

```bash
★ Install of core/caddy/1.0.1/20190703150822 complete with 1 new packages installed.
--- :warning: Supervisor LOCK file found, not starting the supervisor
--- :habicat: Loading service core/caddy
The core/caddy service was successfully loaded
Waiting for core/caddy to start: 1
Waiting for core/caddy to start: 2
Waiting for core/caddy to start: 3
 ✓ Version matches
 ✓ Help command
 ✓ Basic config validation
 ✓ Service is running
 ✓ Listening on port 8080
 ✓ Simple cURL request

6 tests, 0 failures
Unloading core/caddy
```