### PR TITLE
[dnsmasq] Source test_helper.sh relative to test.sh

### DIFF
--- a/dnsmasq/tests/test.sh
+++ b/dnsmasq/tests/test.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-source bin/ci/test_helpers.sh
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
 
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-


### PR DESCRIPTION
Tests all continue to pass:

```bash
--- :warning: Supervisor LOCK file found, not starting the supervisor
--- :habicat: Loading service core/dnsmasq/2.80/20190821154320
The core/dnsmasq/2.80/20190821154320 service was successfully loaded
Waiting for core/dnsmasq/2.80/20190821154320 to start: 1
Waiting for core/dnsmasq/2.80/20190821154320 to start: 2
Waiting for core/dnsmasq/2.80/20190821154320 to start: 3
 ✓ dnsmasq service is running
 ✓ dnsmasq successfully finds debian.org
 ✓ dnsmasq binary matches version 2.80
 ✓ dnsmasq binary test returns success

4 tests, 0 failures
Unloading core/dnsmasq/2.80/20190821154320
```