### PR TITLE
[tcl] Add version check test

### DIFF
--- a/tcl/tests/test.bats
+++ b/tcl/tests/test.bats
@@ -1,3 +1,9 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "tclsh matches version ${expected_version}" {
+  actual_version="$(echo "puts [info patchlevel]" | hab pkg exec "${TEST_PKG_IDENT}" tclsh)"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}
+
 @test "simple tcl expression" {
   run hab pkg exec $TEST_PKG_IDENT tclsh "$BATS_TEST_DIRNAME"/fixtures/simple.tcl
   [ "$output" == "4" ]


### PR DESCRIPTION
### Outstanding Tasks
- [ ] What diff using for this?  Respond to predominant

### Context
Tests all pass:

```bash
★ Install of core/tcl/8.6.9/20190821164514 complete with 0 new packages installed.
 ✓ tclsh matches version 8.6.9
 ✓ simple tcl expression

2 tests, 0 failures
[50][default:/src/tcl:0]#
```