### PR TITLE
[make] Add version test for make

### DIFF
--- a/make/tests/test.bats
+++ b/make/tests/test.bats
@@ -1,3 +1,9 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "make matches version ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" make --version | grep "GNU Make" | awk '{print $3}')"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}
+
 @test "Make simple task" {
   run hab pkg exec "$TEST_PKG_IDENT" make --directory "$BATS_TEST_DIRNAME/fixtures/" ci-test
   grep -q "Make in CI" <<< "$output"


### PR DESCRIPTION
Test all pass:

```bash
★ Install of core/make/4.2.1/20190821165656 complete with 0 new packages installed.
 ✓ make matches version 4.2.1
 ✓ Make simple task

2 tests, 0 failures
```