### PR TITLE
[terraform] Updating to 0.12.7

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.12.6
+pkg_version=0.12.7
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
 pkg_filename="${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f
+pkg_shasum=a0fa11217325f76bf1b4f53b0f7a6efb1be1826826ef8024f2f45e60187925e7
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Hey all,

This is just a simple version bump to Terraform. To test this build, run the following commands:
```
hab pkg build terraform
source results/last_build.env
hab studio run "./terraform/tests/test.sh ${pkg_ident}"
```

The results should be:
```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```
