### PR TITLE
[libatomic_ops] Upgrade to version 7.6.10

### DIFF
--- a/libatomic_ops/plan.sh
+++ b/libatomic_ops/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libatomic_ops
 pkg_origin=core
-pkg_version=7.4.4
+pkg_version=7.6.10
 pkg_description="Atomic memory update operations"
 pkg_upstream_url="https://github.com/ivmai/libatomic_ops"
 pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://www.ivmaisoft.com/_bin/atomic_ops/libatomic_ops-${pkg_version}.tar.gz"
-pkg_shasum=bf210a600dd1becbf7936dd2914cf5f5d3356046904848dcfd27d0c8b12b6f8f
+pkg_shasum=587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
It appears that the author is still releasing 7.4 versions
here:

http://www.ivmaisoft.com/_bin/atomic_ops/

but I've tested a build of bdwgc against this 7.6 version
and all of the tests pass.

Signed-off-by: Steven Danna <steve@chef.io>