### PR TITLE
[rsync] Upgrade rsync to 3.1.3

### DIFF
--- a/rsync/plan.sh
+++ b/rsync/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=rsync
-pkg_version=3.1.2
+pkg_version=3.1.3
 pkg_origin=core
 pkg_license=('GPL-3.0')
 pkg_description="An open source utility that provides fast incremental file transfer"
 pkg_upstream_url="https://rsync.samba.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://download.samba.org/pub/${pkg_name}/src/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=ecfa62a7fa3c4c18b9eccd8c16eaddee4bd308a76ea50b5c02a5840f09c0a1c2
+pkg_shasum=55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0
 pkg_deps=(core/glibc core/perl core/acl core/attr)
 pkg_build_deps=(core/make core/gcc core/perl core/diffutils)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This includes two security fixes in addition to a number of bug fixes:

  - Fixed a buffer overrun in the protocol's handling of xattr names
    and ensure that the received name is null terminated.

  - Fix an issue with --protect-args where the user could specify the
    arg in the protected-arg list and short-circuit some of the
    arg-sanitizing code.

https://download.samba.org/pub/rsync/src/rsync-3.1.3-NEWS

Signed-off-by: Steven Danna <steve@chef.io>