### PR TITLE
[kafka] Update kafka to 2.3.0 and add tests

### DIFF
--- a/kafka/config/server.properties
+++ b/kafka/config/server.properties
@@ -1,87 +1,19 @@
+#
+# Full documentation on the configuration options can be found here:
 # https://kafka.apache.org/documentation/#configuration
-{{#if cfg.server.broker_id ~}}
-broker.id={{cfg.server.broker_id}}
-{{/if ~}}
-delete.topic.enable={{cfg.server.delete_topic_enable}}
+#
 
-{{#with cfg.socket ~}}
-{{#if listeners ~}}
-listeners={{listeners}}
-{{/if ~}}
-{{#if advertised_listeners ~}}
-advertised.listeners={{advertised_listeners}}
-{{/if ~}}
-num.network.threads={{num_network_threads}}
-num.io.threads={{num_io_threads}}
-socket.send.buffer.bytes={{socket_send_buffer_bytes}}
-socket.receive.buffer.bytes={{socket_receive_buffer_bytes}}
-socket.request.max.bytes={{socket_request_max_bytes}}
-{{/with ~}}
-
-{{#with cfg.log ~}}
-log.dirs={{log_dirs}}
-num.partitions={{num_partitions}}
-num.recovery.threads.per.data.dir={{num_recovery_threads_per_data_dir}}
-log.retention.hours={{retention.hours}}
-log.segment.bytes={{retention.segment_bytes}}
-log.retention.check.interval.ms={{retention.check_interval_ms}}
-{{#if interval_messages ~}}
-log.flush.interval.messages={{flush.interval_messages}}
-{{/if ~}}
-{{#if interval_ms ~}}
-log.flush.interval.ms={{flush.interval_ms}}
-{{/if ~}}
-log.retention.hours={{retention.hours}}
-{{#if bytes ~}}
-log.retention.bytes={{retention.bytes}}
-{{/if ~}}
-log.segment.bytes={{retention.segment_bytes}}
-log.retention.check.interval.ms={{retention.check_interval_ms}}
-{{/with ~}}
-
+broker.id={{cfg.broker.id}}
+num.network.threads={{cfg.num.network_threads}}
+num.io.threads={{cfg.num.io_threads}}
+num.partitions={{cfg.num.partitions}}
+num.recovery.threads.per.data.dir={{cfg.num.recovery_threads_per_data_dir}}
+socket.send.buffer.bytes={{cfg.socket.send_buffer_bytes}}
+socket.receive.buffer.bytes={{cfg.socket.receive_buffer_bytes}}
+socket.request.max.bytes={{cfg.socket.request_max_bytes}}
+log.dirs={{pkg.svc_var_path}}/logs
+log.segment.bytes={{cfg.log.segment_bytes}}
+log.retention.hours={{cfg.log.retention.hours}}
+log.retention.check.interval.ms={{cfg.log.retention.check_interval_ms}}
 zookeeper.connection.timeout.ms={{cfg.zookeeper.connection_timeout_ms}}
-zookeeper.connect={{~#each bind.zookeeper.members}}{{sys.ip}}:{{cfg.port}}{{else}}{{cfg.zookeeper.host}}:{{cfg.zookeeper.port}}{{~/each}}
-
-############################# Advanced #############################
-{{#with cfg.advanced ~}}
-auto.create.topics.enable={{auto_create_topics_enable}}
-auto.leader.rebalance.enable={{auto_leader_rebalance_enable}}
-background.threads={{background_threads}}
-compression.type={{compression_type}}
-leader.imbalance.check.interval.seconds={{leader_imbalance_check_interval_seconds}}
-leader.imbalance.per.broker.percentage={{leader_imbalance_per_broker_percentage}}
-
-log.flush.offset.checkpoint.interval.ms={{log_flush_offset_checkpoint_interval_ms}}
-log.flush.scheduler.interval.ms={{log_flush_scheduler_interval_ms}}
-
-{{#if log_retention_minutes ~}}
-log.retention.minutes={{log_retention_minutes}}
-{{/if ~}}
-{{#if log_retention_ms ~}}
-log.retention.ms={{log_retention_ms}}
-{{/if ~}}
-
-log.roll.hours={{log_roll_hours}}
-{{#if log_roll_ms ~}}
-log.roll.ms={{log_roll_ms}}
-{{/if ~}}
-log.jitter.hours={{log_jitter_hours}}
-{{#if log_jitter_ms ~}}
-log.jitter.ms={{log_jitter_ms}}
-{{/if ~}}
-
-log.segment.delete.delay.ms={{log_segment_delete_delay_ms}}
-message.max.bytes={{message_max_bytes}}
-min.insync.replicas={{min_insync_replicas}}
-num.replica.fetchers={{num_replica_fetchers}}
-offset.metadata.max.bytes={{offset_metadata_max_bytes}}
-offsets.commit.required.acks={{offsets_commit_required_acks}}
-offsets.commit.timeout.ms={{offsets_commit_timeout_ms}}
-offsets.load.buffer.size={{offsets_load_buffer_size}}
-offsets.retention.check.interval.ms={{offsets_retention_check_interval_ms}}
-offsets.retention.minutes={{offsets_retention_minutes}}
-offsets.topic.compression.codec={{offsets_topic_compression_codec}}
-offsets.topic.num.partitions={{offsets_topic_num_partitions}}
-offsets.topic.replication.factor={{offsets_topic_replication_factor}}
-offsets.topic.segment.bytes={{offsets_topic_segment_bytes}}
-{{/with ~}}
+zookeeper.connect={{#each bind.zookeeper.members}}{{sys.ip}}:{{cfg.port}}{{else}}{{cfg.zookeeper.host}}:{{cfg.zookeeper.port}}{{/each}}

--- a/kafka/default.toml
+++ b/kafka/default.toml
@@ -1,160 +1,30 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# Full documentation on the configuration options can be found here:
+# https://kafka.apache.org/documentation/#configuration
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-# see server.KafkaConfig for additional details and defaults
+[broker]
+  id = 0
 
-############################# Server Basics #############################
-[server]
-# The id of the broker. This must be set to a unique integer for each broker.
-#broker_id=0
+[num]
+  network_threads = 3
+  io_threads = 8
+  partitions = 1
+  recovery_threads_per_data_dir = 1
 
-# Switch to enable topic deletion or not, default value is false
-delete_topic_enable=false
-
-############################# Socket Server Settings #############################
 [socket]
-# The address the socket server listens on. It will get the value returned from
-# java.net.InetAddress.getCanonicalHostName() if not configured.
-#   FORMAT:
-#     listeners = security_protocol://host_name:port
-#   EXAMPLE:
-#     listeners = PLAINTEXT://your.host.name:9092
-#listeners=PLAINTEXT://:9092
+  send_buffer_bytes = 102400
+  receive_buffer_bytes = 102400
+  request_max_bytes = 104857600
 
-# Hostname and port the broker will advertise to producers and consumers. If not set,
-# it uses the value for "listeners" if configured.  Otherwise, it will use the value
-# returned from java.net.InetAddress.getCanonicalHostName().
-#advertised_listeners=PLAINTEXT://your.host.name:9092
-
-# The number of threads handling network requests
-num_network_threads=3
-
-# The number of threads doing disk I/O
-num_io_threads=8
-
-# The send buffer (SO_SNDBUF) used by the socket server
-socket_send_buffer_bytes=102400
-
-# The receive buffer (SO_RCVBUF) used by the socket server
-socket_receive_buffer_bytes=102400
-
-# The maximum size of a request that the socket server will accept (protection against OOM)
-socket_request_max_bytes=104857600
-
-
-############################# Log Basics #############################
 [log]
-# A comma seperated list of directories under which to store log files
-log_dirs="/hab/svc/kafka/var"
+  segment_bytes = 1073741824
 
-# The default number of log partitions per topic. More partitions allow greater
-# parallelism for consumption, but this will also result in more files across
-# the brokers.
-num_partitions=1
+  [log.retention]
+    hours = 168
+    check_interval_ms = 300000
 
-# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-# This value is recommended to be increased for installations with data dirs located in RAID array.
-num_recovery_threads_per_data_dir=1
-
-############################# Log Flush Policy #############################
-[log.flush]
-# Messages are immediately written to the filesystem but by default we only fsync() to sync
-# the OS cache lazily. The following configurations control the flush of data to disk.
-# There are a few important trade-offs here:
-#    1. Durability: Unflushed data may be lost if you are not using replication.
-#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
-#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
-# The settings below allow one to configure the flush policy to flush data after a period of time or
-# every N messages (or both). This can be done globally and overridden on a per-topic basis.
-
-# The number of messages to accept before forcing a flush of data to disk
-#interval_messages=10000
-
-# The maximum amount of time a message can sit in a log before we force a flush
-#interval_ms=1000
-
-############################# Log Retention Policy #############################
-[log.retention]
-# The following configurations control the disposal of log segments. The policy can
-# be set to delete segments after a period of time, or after a given size has accumulated.
-# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
-# from the end of the log.
-
-# The minimum age of a log file to be eligible for deletion
-hours=168
-
-# A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
-# segments don't drop below log.retention.bytes.
-#bytes=1073741824
-
-# The maximum size of a log segment file. When this size is reached a new log segment will be created.
-segment_bytes=1073741824
-
-# The interval at which log segments are checked to see if they can be deleted according
-# to the retention policies
-check_interval_ms=300000
-
-############################# Zookeeper #############################
 [zookeeper]
-# Zookeeper connection string (see zookeeper docs for details).
-# This is a comma separated host:port pairs, each corresponding to a zk
-# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
-# You can also append an optional chroot string to the urls to specify the
-# root directory for all kafka znodes.
-host="localhost"
-port=2181
-# Timeout in ms for connecting to zookeeper
-connection_timeout_ms=6000
-
-
-############################# Advanced #############################
-
-# Those config are the default from Apache Kafka documentation page
-[advanced]
-auto_create_topics_enable=true
-auto_leader_rebalance_enable=true
-background_threads=10
-compression_type="producer"
-leader_imbalance_check_interval_seconds=300
-leader_imbalance_per_broker_percentage=10
-log_flush_offset_checkpoint_interval_ms=60000
-log_flush_scheduler_interval_ms=9223372036854775807
-
-# Conflicts with log.retention.hours!
-#log_retention_minutes=
-#log_retention_ms=
-
-log_roll_hours=168
-#log_roll_ms=
-log_jitter_hours=0
-#log_jitter_ms=
-
-log_segment_delete_delay_ms=60000
-message_max_bytes=1000012
-min_insync_replicas=1
-num_replica_fetchers=1
-offset_metadata_max_bytes=4096
-offsets_commit_required_acks=-1
-offsets_commit_timeout_ms=5000
-offsets_load_buffer_size=5242880
-offsets_retention_check_interval_ms=600000
-offsets_retention_minutes=1440
-offsets_topic_compression_codec=0
-offsets_topic_num_partitions=50
-offsets_topic_replication_factor=3
-offsets_topic_segment_bytes=104857600
-queued_max_requests=500
-replica_fetch_min_bytes=1
-replica_fetch_wait_max_ms=500
+  host = "localhost"
+  port = 2181
+  connection_timeout_ms = 6000

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -4,8 +4,12 @@ services:
     image: core/zookeeper
     ports:
       - "2181:2181"
+    environment:
+      - HAB_LICENSE=accept-no-persist
   kafka:
     image: core/kafka
     links:
       - zookeeper
-    command: start core/kafka --peer zookeeper --bind zookeeper:zookeeper.default
+    command: --peer zookeeper --bind zookeeper:zookeeper.default
+    environment:
+      - HAB_LICENSE=accept-no-persist

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       - zookeeper
     command: --peer zookeeper --bind zookeeper:zookeeper.default
     environment:
-      - HAB_LICENSE=accept-no-persist
+      - HAB_LICENSE=${HAB_LICENSE}

--- a/kafka/hooks/run
+++ b/kafka/hooks/run
@@ -2,8 +2,8 @@
 
 exec 2>&1
 
-export JAVA_HOME="{{pkgPathFor "core/corretto8"}}"
+export JAVA_HOME="{{pkgPathFor "core/openjdk11"}}"
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:{{pkg.svc_config_path}}/log4j.properties"
 export EXTRA_ARGS="-name kafkaServer"
 
-exec {{pkg.path}}/bin/kafka-server-start.sh "{{pkg.svc_config_path}}/server.properties"
+exec kafka-server-start.sh "{{pkg.svc_config_path}}/server.properties"

--- a/kafka/plan.sh
+++ b/kafka/plan.sh
@@ -1,9 +1,10 @@
 pkg_name=kafka
 pkg_origin=core
-pkg_version=0.10.2.2
-pkg_source="http://archive.apache.org/dist/${pkg_name}/${pkg_version}/${pkg_name}_2.11-${pkg_version}.tgz"
-pkg_shasum="60f587ed8d1ee6e8e8057f13da6eee472f95c8d2ea691f6aab74edb842dc9950"
-pkg_dirname="${pkg_name}_2.11-${pkg_version}"
+pkg_version=2.3.0
+scala_version=2.12
+pkg_source="http://archive.apache.org/dist/${pkg_name}/${pkg_version}/${pkg_name}_${scala_version}-${pkg_version}.tgz"
+pkg_shasum=d86f5121a9f0c44477ae6b6f235daecc3f04ecb7bf98596fd91f402336eee3e7
+pkg_dirname="${pkg_name}_${scala_version}-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A distributed streaming platform"
 pkg_upstream_url="https://kafka.apache.org/"
@@ -12,7 +13,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(
   core/bash-static
   core/coreutils
-  core/corretto8
+  core/openjdk11
 )
 pkg_binds=(
   [zookeeper]="port"

--- a/kafka/tests/test.bats
+++ b/kafka/tests/test.bats
@@ -6,6 +6,6 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 }
 
 @test "Listening on port 9092" {
-  result="$(netstat -peanut | grep java | grep LISTEN | awk '{print $4}' | awk -F':' '{print $2}' | grep 9092 || echo 'Not found')"
+  result="$(netstat -peanut | grep java | grep LISTEN | awk '{print $4}' | awk -F':' '{print $2}' | grep 9092 || echo '-1')"
   [ "${result}" -eq 9092 ]
 }

--- a/kafka/tests/test.bats
+++ b/kafka/tests/test.bats
@@ -1,9 +1,11 @@
-@test "kafka service is running" {
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Service is running" {
+  echo -e "$(hab svc status)"
   [ "$(hab svc status | grep "kafka\.default" | awk '{print $4}' | grep up)" ]
 }
 
-expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
-@test "kafka matches version ${expected_version}" {
-  actual_version_array=($(cat "${SUP_LOG}" | grep --text -m 1 -oP "(?<=INFO Kafka version : )([^ ]*)"))
-  diff <( echo "${actual_version_array[0]}") <(echo "${expected_version}")
+@test "Listening on port 9092" {
+  result="$(netstat -peanut | grep java | grep LISTEN | awk '{print $4}' | awk -F':' '{print $2}' | grep 9092 || echo 'Not found')"
+  [ "${result}" -eq 9092 ]
 }

--- a/kafka/tests/test.bats
+++ b/kafka/tests/test.bats
@@ -6,6 +6,6 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 }
 
 @test "Listening on port 9092" {
-  result="$(netstat -peanut | grep java | grep LISTEN | awk '{print $4}' | awk -F':' '{print $2}' | grep 9092 || echo '-1')"
+  result="$(netstat -at | grep LISTEN | grep -o 9092 || echo '-1')"
   [ "${result}" -eq 9092 ]
 }

--- a/kafka/tests/test.sh
+++ b/kafka/tests/test.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
-set -euo pipefail
-
 #/ Usage: test.sh <pkg_ident>
 #/
 #/ Example: test.sh core/php/7.2.8/20181108151533
 #/
 
-source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+set -euo pipefail
 
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
@@ -16,34 +14,24 @@ fi
 TEST_PKG_IDENT="${1}"
 export TEST_PKG_IDENT
 hab pkg install core/bats --binlink
-hab pkg install core/curl --binlink
 hab pkg install core/busybox-static
-hab pkg binlink core/busybox-static nc
 hab pkg binlink core/busybox-static netstat
-hab pkg binlink core/busybox-static ps
 hab pkg install "${TEST_PKG_IDENT}"
 
-ci_ensure_supervisor_running
+hab sup term
+hab sup run &
+sleep 5
 
-# clear the supervisor output
-export SUP_LOG="/hab/sup/default/sup.log"
-cat /dev/null > "${SUP_LOG}"
+# Start a backend node with Nginx
+hab svc load -f core/zookeeper
+hab svc load "${TEST_PKG_IDENT}" --bind=zookeeper:zookeeper.default
 
-ci_load_service "core/zookeeper"
+# Allow service start
+WAIT_SECONDS=15
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
 
-# wait for the service to start
-countdown=50
-hab svc status "${TEST_PKG_IDENT}" 2>/dev/null || hab svc load "${TEST_PKG_IDENT}" --bind zookeeper:zookeeper.default
-until ( (nc -z localhost 9092) && (grep -q "INFO Kafka version :" "${SUP_LOG}" ) ) \
-  || (( countdown <= 0 )); do
-  echo "Waiting for core/kafka service to start ${countdown}"
-  sleep 2
-  countdown=$((countdown-1))
-done
-
-# run the tests
 bats "$(dirname "${0}")/test.bats"
 
-# unload the services
-hab svc unload "${TEST_PKG_IDENT}" || true
-hab svc unload core/zookeeper || true
+# hab svc unload "${TEST_PKG_IDENT}" || true
+# hab svc unload "core/zookeeper" || true


### PR DESCRIPTION
closes #2606 

Signed-off-by: Steven Marshall SMarshall@chef.io

Testing
```
hab pkg build kafka
source results/last_build.env
hab studio run "./kafka/tests/test.sh ${pkg_ident}"
```
Sample output
```
 ✓ Service is running
 ✓ Listening on port 9092

2 tests, 0 failures
```