### PR TITLE
[consul] Update consul to 1.6.0

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.5.3
+pkg_version=1.6.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=b402e1a0db26adb9638a9e85c6c672acd137df233e8c69f26180f2e2fd6f4cbc
+pkg_shasum=06b9993384e5fad901e0a70185b198dc74f3f34e1660a40f194cd6095b5d59d4
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build consul
source results/last_build.env
hab studio run "./consul/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures

```