### PR TITLE
[sbt] Update sbt to 1.3.0

### DIFF
--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=sbt
-pkg_version=1.2.8
+pkg_version=1.3.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A build tool for Scala, Java, and more"
 pkg_upstream_url="https://www.scala-sbt.org"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz"
-pkg_shasum=9bb9212541176d6fcce7bd12e4cf8a9c9649f5b63f88b3aff474e0b02c7cfe58
+pkg_shasum=c9bc6bcbbe7a65773f4526ad5613d93f220ce21bd2456c3cf35363c4cdd52648
 pkg_deps=(
   core/coreutils
   core/openjdk11


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build sbt
source results/last_build.env
hab studio run "./sbt/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ sbt matches version 1.3.0

1 test, 0 failures
```

Note that initial run / test of sbt takes some  time.