### PR TITLE
[jenkins] Update jenkins to 2.176.3

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.176.2
+pkg_version=2.176.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum="33a6c3161cf8de9c8729fd83914d781319fd1569acf487c7b1121681dba190a5"
+pkg_shasum=9406c7bee2bc473f77191ace951993f89922f927a0cd7efb658a4247d67b9aa3
 pkg_deps=(
   core/openjdk11
   core/curl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build jenkins
source results/last_build.env
hab studio run "./jenkins/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ jenkins binary version matches 2.176.3
 ✓ Service is running
 ✓ Listening on port 80 (HTTP)

3 tests, 0 failures
```