### PR TITLE
[memcached] Update memcached to 1.5.17, update tests

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.14
+pkg_version=1.5.17
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url="https://memcached.org/"
 pkg_license=('BSD')
 pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=9c5bdf29a780fb6c6f7c9eaaeeda0583efdf663193758c3e316c969a510af2a9
+pkg_shasum=ac7c5af6e8b1acf5d5c644d162e046d8acf9302174af9f24c3f18e5481ce3a0d
 pkg_deps=(
   core/glibc
   core/cyrus-sasl

--- a/memcached/tests/test.bats
+++ b/memcached/tests/test.bats
@@ -1,16 +1,12 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v memcached)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(memcached --version 2>&1 | awk '{print $2}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} memcached --version 2>&1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run memcached --help
+  run hab pkg exec ${TEST_PKG_IDENT} memcached --help
   [ $status -eq 0 ]
 }
 
@@ -24,6 +20,6 @@ source "${BATS_TEST_DIRNAME}/../plan.sh"
 }
 
 @test "Contains SASL support" {
-  memcached --help | grep "enable-sasl"
+  hab pkg exec ${TEST_PKG_IDENT} memcached --help | grep "enable-sasl"
   [ $? -eq 0 ]
 }

--- a/memcached/tests/test.sh
+++ b/memcached/tests/test.sh
@@ -1,34 +1,30 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
 
 hab pkg install core/bats --binlink
-
 hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static ps
 hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static wc
 hab pkg binlink core/busybox-static uniq
 
-source "${PLANDIR}/plan.sh"
+hab pkg install "${TEST_PKG_IDENT}"
 
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  # Unload the service if its already loaded.
-  hab svc unload "${HAB_ORIGIN}/${pkg_name}"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
 
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  hab svc load "${pkg_ident}"
-  popd > /dev/null
-  set +e
-
-  # Give some time for the service to start up
-  sleep 10
-fi
-
-bats "${TESTDIR}/test.bats"
+bats "$(dirname "${0}")/test.bats"
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build memcached
source results/last_build.env
hab studio run "./memcached/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

5 tests, 0 failures
```