### PR TITLE
[kafka] Update to 2.3.0 and modify test

### DIFF
--- a/kafka/plan.sh
+++ b/kafka/plan.sh
@@ -1,9 +1,10 @@
 pkg_name=kafka
 pkg_origin=core
-pkg_version=0.10.2.2
-pkg_source="http://archive.apache.org/dist/${pkg_name}/${pkg_version}/${pkg_name}_2.11-${pkg_version}.tgz"
-pkg_shasum="60f587ed8d1ee6e8e8057f13da6eee472f95c8d2ea691f6aab74edb842dc9950"
-pkg_dirname="${pkg_name}_2.11-${pkg_version}"
+pkg_version=2.3.0
+scala_version=2.12
+pkg_source="http://archive.apache.org/dist/${pkg_name}/${pkg_version}/${pkg_name}_${scala_version}-${pkg_version}.tgz"
+pkg_shasum=d86f5121a9f0c44477ae6b6f235daecc3f04ecb7bf98596fd91f402336eee3e7
+pkg_dirname="${pkg_name}_${scala_version}-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A distributed streaming platform"
 pkg_upstream_url="https://kafka.apache.org/"

--- a/kafka/tests/test.bats
+++ b/kafka/tests/test.bats
@@ -4,6 +4,6 @@
 
 expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 @test "kafka matches version ${expected_version}" {
-  actual_version_array=($(cat "${SUP_LOG}" | grep --text -m 1 -oP "(?<=INFO Kafka version : )([^ ]*)"))
+  actual_version_array=($(cat "${SUP_LOG}" | grep --text -m 1 -oP "(?<=INFO Kafka version: )([^ ]*)"))
   diff <( echo "${actual_version_array[0]}") <(echo "${expected_version}")
 }


### PR DESCRIPTION
Signed-off-by: Steven Marshall <SMarshall@chef.io>

closes #2606 

Updated PR with more recent changes. 
Updates kafka to 2.3.0
Fixes issue with regex for version selection
Moves teardown into trap to ensure that it runs regardless of whether or not the test script can finish.