### PR TITLE
[opa] Refactor tests to use ./bin/ci/test_helpers.sh

### DIFF
--- a/opa/tests/test.sh
+++ b/opa/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
   exit 1
@@ -20,16 +22,8 @@ hab pkg binlink core/busybox-static nc
 hab pkg install core/bats core/curl core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab sup term
-while hab sup status 2>/dev/null; do
-  echo "Waiting for supervisor to terminate"
-  sleep 1
-done
-hab sup run &
-
-echo "Waiting for supervisor to start (30s)"
-wait_listen tcp 9632 30
-hab svc load "${TEST_PKG_IDENT}"
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
 
 # Wait for 5 seconds on first check, to ensure service is up.
 echo "Waiting for opa to start (5s)"


### PR DESCRIPTION
### Outstanding Tasks
- [x] Waiting on approval and merge

### Context

```bash
hab pkg build opa
source results/last_build.env
hab studio run "opa/tests/test.sh ${pkg_ident}"
```

produces test results:

```bash
★ Install of core/opa/0.14.0/20190913140038 complete with 1 new packages installed.
--- :habicat: Starting the supervisor
Waiting for Supervisor to start: 1
Waiting for Supervisor to start: 2
--- :habicat: Loading service core/opa/0.14.0/20190913140038
The core/opa/0.14.0/20190913140038 service was successfully loaded
Waiting for core/opa/0.14.0/20190913140038 to start: 1
Waiting for core/opa/0.14.0/20190913140038 to start: 2
Waiting for core/opa/0.14.0/20190913140038 to start: 3
Waiting for opa to start (5s)
1..3
ok 1 Port Listen TCP/8181
ok 2 /v1/data/system/version endpoint returns version
ok 3 /v1/query endpoint returns an answer
Unloading core/opa/0.14.0/20190913140038
(travis_ci_version_2) ➜  core-plans git:(gavindidrichsen/master/pr/opa_refactor_tests) ✗
```