### PR TITLE
[ruby] Update ruby24, ruby25, and ruby26

### DIFF
--- a/ruby24/plan.sh
+++ b/ruby24/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby24
 pkg_origin=core
-pkg_version=2.4.5
+pkg_version=2.4.7
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,5 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198
+pkg_shasum=cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89
 pkg_dirname="ruby-$pkg_version"

--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby25
 pkg_origin=core
-pkg_version=2.5.5
+pkg_version=2.5.6
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c
+pkg_shasum=1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby26
 pkg_origin=core
-pkg_version=2.6.3
+pkg_version=2.6.4
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=577fd3795f22b8d91c1d4e6733637b0394d4082db659fccf224c774a2b1c82fb
+pkg_shasum=4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
There are a large number of CVEs and bugs in these releases of Ruby. Bump to the latest 2.4, 2.5, and 2.6 release. I've left the ruby plan alone because I'm going to bump that to 2.6 where it should be.

Signed-off-by: Tim Smith <tsmith@chef.io>