### PR TITLE
[spark] Fix broken service

### DIFF
--- a/spark/hooks/run
+++ b/spark/hooks/run
@@ -9,9 +9,13 @@ export SPARK_WORKER_DIR="{{pkg.svc_var_path}}/work"
 export SPARK_NO_DAEMONIZE=1
 
 {{~#if svc.me.leader}}
+# leader
 exec start-master.sh
-{{else}}
+{{else if svc.me.follower}}
 {{~#with svc.leader}}
 exec start-slave.sh "spark://{{sys.ip}}:{{cfg.port}}"
 {{~/with}}
+{{else}}
+# standalone spark
+exec start-master.sh
 {{~/if}}

--- a/spark/plan.sh
+++ b/spark/plan.sh
@@ -13,6 +13,7 @@ pkg_deps=(
   core/bash
   core/openjdk11
   core/procps-ng
+  core/busybox-static
 )
 pkg_bin_dirs=(bin sbin)
 pkg_lib_dirs=(jars)
@@ -28,4 +29,8 @@ do_build() {
 
 do_install() {
   cp -r sbin bin jars "$pkg_prefix"
+
+  build_line "Fixing bin/env interpreters"
+  fix_interpreter "${pkg_prefix}/bin/*" core/busybox-static bin/env
+  fix_interpreter "${pkg_prefix}/sbin/*" core/busybox-static bin/env
 }

--- a/spark/tests/test.bats
+++ b/spark/tests/test.bats
@@ -1,0 +1,3 @@
+@test "spark service is running" {
+  [ "$(hab svc status | grep "spark\.default" | awk '{print $4}' | grep up)" ]
+}

--- a/spark/tests/test.sh
+++ b/spark/tests/test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "$TEST_PKG_IDENT"
+
+# run the tests
+bats "$(dirname "${0}")/test.bats"
+
+# unload the service
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Fixes issue #2904 

To verify, enter a hab studio and load the service:

```bash
build spark
source results/last_build.env
hab pkg install results/$pkg_artifact
hab svc load $pkg_ident
```

then check the supervisor log.  It should contain something like this:

```bash
40][default:/src:0]# sup-log
--> Tailing the Habitat Supervisor's output (use 'Ctrl+c' to stop)
spark.default(O): 19/09/18 12:36:00 INFO Utils: Successfully started service 'MasterUI' on port 8080.
spark.default(O): 19/09/18 12:36:00 INFO MasterWebUI: Bound MasterWebUI to 0.0.0.0, and started at http://:8080
spark.default(O): 19/09/18 12:36:01 INFO Utils: Successfully started service on port 6066.
spark.default(O): 19/09/18 12:36:01 INFO StandaloneRestServer: Started REST server for submitting applications on port 6066
spark.default(O): 19/09/18 12:36:01 INFO Master: I have been elected leader! New state: ALIVE
```

A simple test has been added as well:

```bash
./spark/tests.test.sh $pkg_ident
```

producing:

```bash
 ✓ spark service is running

1 test, 0 failures
```

**NOTE**: The version check was removed from the test because it kept failing on buildkite even though it passed fine in habitat studio.  To manually check the spark version once the service is loaded:

```bash
hab pkg exec $pkg_ident spark-submit --version
```

