### PR TITLE
[telegraf] Update telegraf to 1.12.2

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version=1.11.4
+pkg_version=1.12.2
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum=8c7ce7398fe61b349607e05efb37626eb4d5ab018bb219be25781f67bcedb645
+pkg_shasum=dab9ae72b53c99f93e708ab911d556d6906c0691c6858da09b4e74e24e344c8a
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config ${pkg_svc_config_path}/telegraf.conf"
 pkg_build_deps=(


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build telegraf
source results/last_build.env
hab studio run "./telegraf/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running

2 tests, 0 failures
```

![tenor-136787301](https://user-images.githubusercontent.com/24568/65560552-1a320280-df7a-11e9-8f63-a3eb6fb60e0a.gif)
