### PR TITLE
Bump rust to 1.38.0

### DIFF
--- a/rust/plan.ps1
+++ b/rust/plan.ps1
@@ -1,12 +1,12 @@
 ﻿$pkg_name="rust"
 $pkg_origin="core"
-$pkg_version="1.37.0"
+$pkg_version="1.38.0"
 $pkg_description="Safe, concurrent, practical language"
 $pkg_upstream_url="https://www.rust-lang.org/"
 $pkg_license=@("Apache-2.0", "MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://static.rust-lang.org/dist/rust-$pkg_version-x86_64-pc-windows-msvc.msi"
-$pkg_shasum="1e7d5617b7d49d7dbe406e6b4e820d5ad41e021911d69131227ac554aae9c27f"
+$pkg_shasum="e6a5e79f60a25df6ec951f6ad63ea20796f18ff67b7b4d1ba65dcab75cb1c311"
 $pkg_deps=@("core/visual-cpp-redist-2015", "core/visual-cpp-build-tools-2015")
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")

--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.37.0
+pkg_version=1.38.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Rust is a systems programming language that runs blazingly fast, prevents \
@@ -10,7 +10,7 @@ pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
 _url_base="https://static.rust-lang.org/dist"
 pkg_source="$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz"
-pkg_shasum="cb573229bfd32928177c3835fdeb62d52da64806b844bc1095c6225b0665a1cb"
+pkg_shasum="adda26b3f0609dbfbdc2019da4a20101879b9db2134fae322a4e863a069ec221"
 pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu"
 pkg_deps=(
   core/glibc
@@ -33,7 +33,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-    fa1d98bf18fb49ff58a70d51ff7924e4d1975f7812dc5217ea31652bf8b7bca4
+    56b87fdca1f41b634285593cae42fdbd5fe9632ef502336679362b283ed53c22
 )
 
 do_download() {


### PR DESCRIPTION
https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html

![](https://media.giphy.com/media/toe6vBrtWgKvKW7Ehz/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>