### PR TITLE
[elasticsearch] update to 6.8.3

### DIFF
--- a/elasticsearch/config/jvm.options
+++ b/elasticsearch/config/jvm.options
@@ -17,9 +17,9 @@
 ################################################################
 
 # Xms represents the initial size of total heap space
-# Xmx represents the maximum size of total heap space
-
 -Xms{{cfg.runtime.heapsize}}
+
+# Xmx represents the maximum size of total heap space
 -Xmx{{cfg.runtime.heapsize}}
 
 ################################################################
@@ -32,23 +32,64 @@
 ##
 ################################################################
 
+## CMS Configuration (tentatively scheduled for removal in JDK 14)
 -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
 -XX:+DisableExplicitGC
+
+## G1GC Configuration (not currently recommended by Elastic)
+#-XX:-UseCMSInitiatingOccupancyOnly
+#-XX:+UseG1GC
+#-XX:InitiatingHeapOccupancyPercent=75
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+# pre-touch memory pages used by the JVM during initialization
 -XX:+AlwaysPreTouch
 -server
+
+# explicitly set the stack size
 -Xss1m
+
+# set to headless, just in case
 -Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
 -Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
 -Djna.nosys=true
 -Djdk.io.permissionsUseCanonicalPath=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
 -Dio.netty.noUnsafe=true
 -Dio.netty.noKeySetOptimization=true
 -Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 -Dlog4j.skipJansi=true
+
+# Make sure our tmpdir is set to the service directory
 -Djava.io.tmpdir={{pkg.svc_var_path}}
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
 -XX:+HeapDumpOnOutOfMemoryError
+
+# user specified elasticsearch java opts
 {{cfg.runtime.es_java_opts}}

--- a/elasticsearch/config/log4j2.properties
+++ b/elasticsearch/config/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console

--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=elasticsearch
 pkg_origin=core
-pkg_version=6.7.1
+pkg_version=6.8.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Open Source, Distributed, RESTful Search Engine"
 pkg_upstream_url="https://elastic.co"
 pkg_license=('Revised BSD')
 pkg_source="https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=7be3f94882130c769e5a6b95dbccdc3cab9f101cbc68edfa661f7188c78f06e2
+pkg_shasum=824078e421c9f7e5ab9c875e4019d9ebfe3ada99db286b54dec090f97d1cbe25
 pkg_build_deps=(
   core/patchelf
 )

--- a/elasticsearch/tests/test.bats
+++ b/elasticsearch/tests/test.bats
@@ -1,25 +1,27 @@
 @test "Version matches" {
-  expected_version=$(cut -d/ -f3 $TEST_PKG_IDENT)
-  result="$(hab pkg exec $TEST_PKG_IDENT elasticsearch --version | awk '{print $2}' | tr -d ',')"
-  [ "$result" = "${pkg_version}" ]
+  local expected_version
+  local result
+  expected_version=$(echo "${TEST_PKG_IDENT}" | cut -d '/' -f3)
+  result=$(hab pkg exec "${TEST_PKG_IDENT}" elasticsearch --version 2> /dev/null | awk '{print $2}' | tr -d ',')
+  [ "${result}" = "${expected_version}" ]
 }
 
 @test "Service is running" {
-  [ "$(hab svc status | grep "elasticsearch\.default" | awk '{print $4}' | grep up)" ]
+  hab svc status | grep "elasticsearch\.default" | awk '{print $4}' | grep up
 }
 
 @test "Open port 9200" {
-  result="$(netstat -peanut | grep java | grep 9200)"
-  [ $? -eq 0 ]
+  netstat -peanut | grep java | grep 9200
 }
 
 @test "Open port 9300" {
-  result="$(netstat -peanut | grep java | grep 9300)"
-  [ $? -eq 0 ]
+  netstat -peanut | grep java | grep 9300
 }
 
 @test "Service Healthcheck" {
-  local addr="$(netstat -lnp | grep 9200 | head -1 | awk '{print $4}')"
-  result="$(curl -s http://${addr}/_cluster/health | jq -r '.status')"
+  local addr
+  local result
+  addr="$(netstat -lnp | grep 9200 | head -1 | awk '{print $4}')"
+  result="$(curl -s http://"${addr}"/_cluster/health | jq -r '.status')"
   [ "${result}" = "green" ]
 }


### PR DESCRIPTION
* Update jvm opts to reflect defaults in the 6.8.3 distribution
* Fix deprecated console layout
* Bump to the latest stable 6.x version

Signed-off-by: Ryan Cragun <ryan@chef.io>