### PR TITLE
[strace] Update strace to 5.3

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=5.2
+pkg_version=5.3
 pkg_license=("LGPL-2.1-or-later")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url="https://strace.io/"
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=d513bc085609a9afd64faf2ce71deb95b96faf46cd7bc86048bc655e4e4c24d2
+pkg_shasum=6c131198749656401fe3efd6b4b16a07ea867e8f530867ceae8930bbc937a047
 pkg_deps=(
   core/glibc
   core/libunwind


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build strace
source results/last_build.env
hab studio run "./strace/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```

![tenor-240468395](https://user-images.githubusercontent.com/24568/65926519-8a380100-e430-11e9-9faa-f1a5110acca1.gif)
