### PR TITLE
[php] Update PHP to 7.3.10

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=php
 pkg_origin=core
-pkg_version=7.3.9
+pkg_version=7.3.10
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("PHP-3.01")
 pkg_upstream_url=http://php.net/
@@ -8,7 +8,7 @@ pkg_description="PHP is a popular general-purpose scripting language that is esp
 pkg_source="https://php.net/get/${pkg_name}-${pkg_version}.tar.xz/from/this/mirror"
 pkg_filename="${pkg_name}-${pkg_version}.tar.xz"
 pkg_dirname="${pkg_name}-${pkg_version}"
-pkg_shasum=4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd
+pkg_shasum=42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906
 pkg_deps=(
   core/bzip2
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build php
source results/last_build.env
hab studio run "./php/tests/test.sh ${pkg_ident}"
```

### Sample output

```
★ Install of rakops/php/7.3.10/20191001010231 complete with 11 new packages installed.
 ✓ Libzip is supported.
```

![tenor-267538582](https://user-images.githubusercontent.com/24568/65926999-f0be1e80-e432-11e9-9e22-b337ac8e991a.gif)
