### PR TITLE
[protobuf] Update protobuf to 3.9.2, add tests

### DIFF
--- a/protobuf/plan.ps1
+++ b/protobuf/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="protobuf"
 $pkg_origin="core"
-$pkg_version="3.9.1"
+$pkg_version="3.9.2"
 $pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
 $pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 $pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 $pkg_license=("BSD")
 $pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.zip"
-$pkg_shasum="aed089110977f7cabda19d550b4d503eb93fa0f73c7a470c4695f27b63029544"
+$pkg_shasum="c18c03b2beb14c8813e1ca4601bfef07755eccaf202c3d6a1187186fc30bb8a1"
 $pkg_deps=@(
     "core/zlib"
 )

--- a/protobuf/plan.sh
+++ b/protobuf/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=protobuf
 pkg_origin=core
-pkg_version=3.9.1
+pkg_version=3.9.2
 pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz
-pkg_shasum=3040a5b946d9df7aa89c0bf6981330bf92b7844fd90e71b61da0c721e421a421
+pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz"
+pkg_shasum=7c99ddfe0227cbf6a75d1e75b194e0db2f672d2d2ea88fb06bdc83fe0af4c06d
 pkg_deps=(
   core/gcc
   core/zlib

--- a/protobuf/tests/test.bats
+++ b/protobuf/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} protoc --version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} protoc --help
+  [ $status -eq 0 ]
+}

--- a/protobuf/tests/test.sh
+++ b/protobuf/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build protobuf
source results/last_build.env
hab studio run "./protobuf/tests/test.sh ${pkg_ident}"
```

### Sample Output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

![tenor-44198004](https://user-images.githubusercontent.com/24568/65927815-2ca6b300-e436-11e9-9b43-a59a684ca35a.gif)
