### PR TITLE
[tcpdump] Update tcpdump to 4.9.3, add simple tests

### DIFF
--- a/tcpdump/plan.sh
+++ b/tcpdump/plan.sh
@@ -1,20 +1,32 @@
 pkg_name=tcpdump
 pkg_origin=core
-pkg_version=4.9.2
+pkg_version=4.9.3
 pkg_description="A powerful command-line packet analyzer."
 pkg_upstream_url="http://www.tcpdump.org/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.tcpdump.org/release/tcpdump-${pkg_version}.tar.gz
-pkg_shasum=798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79
+pkg_source="http://www.tcpdump.org/release/tcpdump-${pkg_version}.tar.gz"
+pkg_shasum=2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410
 # core/coreutils isn't /really/ needed at runtime, but fix_interpreter
 # only works if the dep is listed in pkg_deps
-pkg_deps=(core/glibc core/libpcap core/openssl core/coreutils)
-pkg_build_deps=(core/gcc core/make core/perl core/diffutils)
+pkg_deps=(
+  core/glibc
+  core/libpcap
+  core/openssl
+  core/coreutils
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/perl
+  core/diffutils
+)
 pkg_bin_dirs=(sbin)
 
 do_build() {
-  ./configure --prefix="$pkg_prefix" --with-crypto
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --with-crypto
   make -j "$(nproc)"
 }
 

--- a/tcpdump/tests/test.bats
+++ b/tcpdump/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} tcpdump --version 2>&1 | head -1 | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} tcpdump --help
+  [ $status -eq 0 ]
+}

--- a/tcpdump/tests/test.sh
+++ b/tcpdump/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build tcpdump
source results/last_build.env                                                  
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```

![tenor-64674709](https://user-images.githubusercontent.com/24568/66009328-03009100-e4f5-11e9-98c4-89bd0a68e05e.gif)
