### PR TITLE
[visual-build-tools-2017] add sql database project build capabilities to visual-build-tools-2017

### DIFF
--- a/visual-build-tools-2017/plan.ps1
+++ b/visual-build-tools-2017/plan.ps1
@@ -23,7 +23,17 @@ $pkg_include_dirs=@(
 )
 
 function Invoke-Unpack {
-  Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "--quiet --layout $HAB_CACHE_SRC_PATH/$pkg_dirname --lang en-US --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.NuGet.BuildTools"
+  $installArgs = "--quiet --layout $HAB_CACHE_SRC_PATH/$pkg_dirname --lang en-US"
+  @(
+    "Microsoft.VisualStudio.Workload.MSBuildTools",
+    "Microsoft.VisualStudio.Workload.VCTools",
+    "Microsoft.VisualStudio.Component.SQL.SSDTBuildSku",
+    "Microsoft.VisualStudio.Component.VC.ATLMFC",
+    "Microsoft.VisualStudio.Component.NuGet.BuildTools"
+  ) | % {
+    $installArgs += " --add $_"
+  }
+  Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList $installArgs
   Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
   try {
     Get-ChildItem "$HAB_CACHE_SRC_PATH/$pkg_dirname" -Include *.vsix -Exclude @('*x86*', '*.arm.*') -Recurse | % {


### PR DESCRIPTION
This accommodates a customer that is packaging database migrations using Visual Studio database projects by adding the `Microsoft.VisualStudio.Component.SQL.SSDTBuildSku` component.

This also attempts to make the installer command a little less cray cray.

Signed-off-by: mwrock <matt@mattwrock.com>