### PR TITLE
[ruby] new point releases for Ruby for CVEs

### DIFF
--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby
 pkg_origin=core
-pkg_version=2.5.5
+pkg_version=2.5.7
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c
+pkg_shasum=0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby24/plan.sh
+++ b/ruby24/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby24
 pkg_origin=core
-pkg_version=2.4.7
+pkg_version=2.4.9
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,5 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89
+pkg_shasum=f99b6b5e3aa53d579a49eb719dd0d3834d59124159a6d4351d1e039156b1c6ae
 pkg_dirname="ruby-$pkg_version"

--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby25
 pkg_origin=core
-pkg_version=2.5.6
+pkg_version=2.5.7
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7
+pkg_shasum=0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby26
 pkg_origin=core
-pkg_version=2.6.4
+pkg_version=2.6.5
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937
+pkg_shasum=66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
[2.5.7](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/) and [2.6.5](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/) have CVE fixes:

- [CVE-2019-16255](https://www.ruby-lang.org/en/news/2019/10/01/code-injection-shell-test-cve-2019-16255/): A code injection vulnerability of Shell#[] and Shell#test
- [CVE-2019-16254](https://www.ruby-lang.org/en/news/2019/10/01/http-response-splitting-in-webrick-cve-2019-16254/): HTTP response splitting in WEBrick (Additional fix)
- [CVE-2019-15845](https://www.ruby-lang.org/en/news/2019/10/01/nul-injection-file-fnmatch-cve-2019-15845/): A NUL injection vulnerability of File.fnmatch and File.fnmatch?
- [CVE-2019-16201](https://www.ruby-lang.org/en/news/2019/10/01/webrick-regexp-digestauth-dos-cve-2019-16201/): Regular Expression Denial of Service vulnerability of WEBrick’s Digest access authentication

[2.4.9](https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/) is "a re-package of 2.4.8 because the previous Ruby 2.4.8 release tarball does not install. (See [Bug #16197](https://bugs.ruby-lang.org/issues/16197) in detail.) There are no essential change except their version numbers between 2.4.8 and 2.4.9."

![rubies](https://user-images.githubusercontent.com/517302/66160693-ab4b4e00-e5f8-11e9-9489-9f9bc7021971.gif)
