### PR TITLE
[ruby] add quick tests for Ruby plans

### DIFF
--- a/ruby/tests/test.bats
+++ b/ruby/tests/test.bats
@@ -1,0 +1,21 @@
+expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f3)"
+
+@test "ruby runs" {
+  run hab pkg exec $TEST_PKG_IDENT ruby -v
+  [ $status -eq 0 ]
+}
+
+@test "is expected version ${expected_version}" {
+  actual_version=$(hab pkg exec $TEST_PKG_IDENT ruby -v | grep -o 'ruby .*p')
+  [ "${actual_version}" = "ruby ${expected_version}p" ]
+}
+
+@test "provides a gem command" {
+  run hab pkg exec $TEST_PKG_IDENT gem env
+  [ $status -eq 0 ]
+}
+
+@test "includes bundler" {
+  run hab pkg exec $TEST_PKG_IDENT bundle -v
+  [ $status -eq 0 ]
+}

--- a/ruby/tests/test.sh
+++ b/ruby/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${BASH_SOURCE[0]}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: ${0} FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"

--- a/ruby24/tests/test.sh
+++ b/ruby24/tests/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+THIS_TEST_DIR="$(dirname "${0}")"
+
+source "${THIS_TEST_DIR}/../../ruby/tests/test.sh" "$1"

--- a/ruby25/tests/test.sh
+++ b/ruby25/tests/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+THIS_TEST_DIR="$(dirname "${0}")"
+
+source "${THIS_TEST_DIR}/../../ruby/tests/test.sh" "$1"

--- a/ruby26/tests/test.sh
+++ b/ruby26/tests/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+THIS_TEST_DIR="$(dirname "${0}")"
+
+source "${THIS_TEST_DIR}/../../ruby/tests/test.sh" "$1"


### PR DESCRIPTION
Quick smoke check to make sure Ruby built and is the expected version.

One test definition for `core/ruby` and the others symlink the `tests/` directory because _they're the same tests_.