### PR TITLE
CODEOWNERS cleanup - fnichol

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,13 +6,13 @@ scaffolding-* @habitat-sh/scaffolding-maintainers
 #
 # All of these plans are critical for Builder's operation and build
 
-libarchive @fnichol
-libsodium @fnichol
-nginx @fnichol @predominant
-postgresql @fnichol @irvingpop
-protobuf @fnichol
-protobuf-rust @fnichol
-zeromq @fnichol
+libarchive @smacfarlane
+libsodium @smacfarlane
+nginx @predominant
+postgresql @irvingpop @habitat-sh/habitat-core-plans-maintainers
+protobuf @smacfarlane @habitat-sh/habitat-core-plans-maintainers
+protobuf-rust @smacfarlane @habitat-sh/habitat-core-plans-maintainers
+zeromq @smacfarlane @habitat-sh/habitat-core-plans-maintainers
 
 # # Base Plans
 #
@@ -20,84 +20,84 @@ zeromq @fnichol
 # nothing and are in build order. Consequently, these need a closer look when
 # accepting changes, updating versions, etc.
 
-linux-headers @fnichol @smacfarlane
-glibc @fnichol @smacfarlane
-zlib @fnichol @smacfarlane
-file @fnichol @smacfarlane
-binutils @fnichol @smacfarlane
-m4 @fnichol @smacfarlane
-gmp @fnichol @smacfarlane
-mpfr @fnichol @smacfarlane
-libmpc @fnichol @smacfarlane
-gcc @fnichol @smacfarlane
-gcc-libs @fnichol @smacfarlane
-patchelf @fnichol @smacfarlane
-bzip2 @fnichol @smacfarlane
-pkg-config @fnichol @smacfarlane
-ncurses @fnichol @smacfarlane
-attr @fnichol @smacfarlane
-acl @fnichol @smacfarlane
-libcap @fnichol @smacfarlane
-sed @fnichol @smacfarlane
-shadow @fnichol @smacfarlane
-psmisc @fnichol @smacfarlane
-procps-ng @fnichol @smacfarlane
-coreutils @fnichol @smacfarlane
-bison @fnichol @smacfarlane
-flex @fnichol @smacfarlane
-pcre @fnichol @smacfarlane
-grep @fnichol @smacfarlane
-readline @fnichol @smacfarlane
-bash @fnichol @smacfarlane
-bc @fnichol @smacfarlane
-tar @fnichol @smacfarlane
-gawk @fnichol @smacfarlane
-libtool @fnichol @smacfarlane
-gdbm @fnichol @smacfarlane
-expat @fnichol @smacfarlane
-db @fnichol @smacfarlane
-inetutils @fnichol @smacfarlane
-iana-etc @fnichol @smacfarlane
-less @fnichol @smacfarlane
-perl @fnichol @smacfarlane
-diffutils @fnichol @smacfarlane
-autoconf @fnichol @smacfarlane
-automake @fnichol @smacfarlane
-findutils @fnichol @smacfarlane
-xz @fnichol @smacfarlane
-gettext @fnichol @smacfarlane
-gzip @fnichol @smacfarlane
-make @fnichol @smacfarlane
-patch @fnichol @smacfarlane
-texinfo @fnichol @smacfarlane
-util-linux @fnichol @smacfarlane
-tcl @fnichol @smacfarlane
-expect @fnichol @smacfarlane
-dejagnu @fnichol @smacfarlane
-check @fnichol @smacfarlane
-libidn @fnichol @smacfarlane
-cacerts @fnichol @smacfarlane
-openssl @fnichol @echohack @smacfarlane
+linux-headers @smacfarlane
+glibc @smacfarlane
+zlib @smacfarlane
+file @smacfarlane
+binutils @smacfarlane
+m4 @smacfarlane
+gmp @smacfarlane
+mpfr @smacfarlane
+libmpc @smacfarlane
+gcc @smacfarlane
+gcc-libs @smacfarlane
+patchelf @smacfarlane
+bzip2 @smacfarlane
+pkg-config @smacfarlane
+ncurses @smacfarlane
+attr @smacfarlane
+acl @smacfarlane
+libcap @smacfarlane
+sed @smacfarlane
+shadow @smacfarlane
+psmisc @smacfarlane
+procps-ng @smacfarlane
+coreutils @smacfarlane
+bison @smacfarlane
+flex @smacfarlane
+pcre @smacfarlane
+grep @smacfarlane
+readline @smacfarlane
+bash @smacfarlane
+bc @smacfarlane
+tar @smacfarlane
+gawk @smacfarlane
+libtool @smacfarlane
+gdbm @smacfarlane
+expat @smacfarlane
+db @smacfarlane
+inetutils @smacfarlane
+iana-etc @smacfarlane
+less @smacfarlane
+perl @smacfarlane
+diffutils @smacfarlane
+autoconf @smacfarlane
+automake @smacfarlane
+findutils @smacfarlane
+xz @smacfarlane
+gettext @smacfarlane
+gzip @smacfarlane
+make @smacfarlane
+patch @smacfarlane
+texinfo @smacfarlane
+util-linux @smacfarlane
+tcl @smacfarlane
+expect @smacfarlane
+dejagnu @smacfarlane
+check @smacfarlane
+libidn @smacfarlane
+cacerts @smacfarlane
+openssl @echohack @smacfarlane
 libiconv @smacfarlane
 libunistring @smacfarlane
 libidn2 @smacfarlane
-wget @fnichol @smacfarlane
-unzip @fnichol @smacfarlane
-rq @fnichol @smacfarlane
-linux-headers-musl @fnichol @smacfarlane
-musl @fnichol @smacfarlane
-busybox-static @fnichol @smacfarlane
-zlib-musl @fnichol @smacfarlane
-bzip2-musl @fnichol @smacfarlane
-xz-musl @fnichol @smacfarlane
-libsodium-musl @fnichol @smacfarlane
-openssl-musl @fnichol @smacfarlane
-libarchive-musl @fnichol @smacfarlane
-rust @fnichol @habitat-sh/habitat-core-maintainers
-vim @fnichol @smacfarlane
-libbsd @fnichol @smacfarlane
-clens @fnichol @smacfarlane
-mg @fnichol @smacfarlane
+wget @smacfarlane
+unzip @smacfarlane
+rq @smacfarlane
+linux-headers-musl @smacfarlane
+musl @smacfarlane
+busybox-static @smacfarlane
+zlib-musl @smacfarlane
+bzip2-musl @smacfarlane
+xz-musl @smacfarlane
+libsodium-musl @smacfarlane
+openssl-musl @smacfarlane
+libarchive-musl @smacfarlane
+rust @habitat-sh/habitat-core-maintainers
+vim @smacfarlane
+libbsd @smacfarlane
+clens @smacfarlane
+mg @smacfarlane
 powershell @mwrock
 7zip @mwrock
 docker-credential-helper @mwrock

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,6 @@ To become a maintainer, open a pull request to this list.
 * [Mike Fiedler](https://github.com/miketheman)
 * [Ian Henry](https://github.com/eeyun)
 * [Scott Macfarlane](https://github.com/smacfarlane)
-* [Fletcher Nichol](https://github.com/fnichol)
 * [Nell Shamrell-Harrington](https://github.com/nellshamrell)
 * [Salim Afiune](https://github.com/afiune)
 * [John Jelinek IV](https://github.com/johnjelinek)
@@ -45,3 +44,4 @@ To become a maintainer, open a pull request to this list.
 * [Joshua Timberman](https://github.com/jtimberman)
 * [Elliott Davis](https://github.com/elliott-davis)
 * [Jamie Winsor](https://github.com/reset)
+* [Fletcher Nichol](https://github.com/fnichol)


### PR DESCRIPTION
 @fnichol ,  thank you for your contributions to the Habitat Core Plans project! It's been a while since you've been active. We understand life gets busy and interests change so we're going to move you to `Alumni` status and remove CODEOWNER entries on the following plans:

```
libarchive
libsodium
nginx
postgresql
protobuf
protobuf-rust
zeromq
linux-headers
glibc
zlib
file
binutils
m4
gmp
mpfr
libmpc
gcc
gcc-libs
patchelf
bzip2
pkg-config
ncurses
attr
acl
libcap
sed
shadow
psmisc
procps-ng
coreutils
bison
flex
pcre
grep
readline
bash
bc
tar
gawk
libtool
gdbm
expat
db
inetutils
iana-etc
less
perl
diffutils
autoconf
automake
findutils
xz
gettext
gzip
make
patch
texinfo
util-linux
tcl
expect
dejagnu
check
libidn
cacerts
openssl
wget
unzip
rq
linux-headers-musl
musl
busybox-static
zlib-musl
bzip2-musl
xz-musl
libsodium-musl
openssl-musl
libarchive-musl
rust
vim
libbsd
clens
mg
```

If you'd like to be a CODEOWNER/maintainer in the future we'd love to have you back. At that time, please open a PR adding yourself back to the appropriate entries.
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>