### PR TITLE
CODEOWNERS cleanup - rsertelon 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -113,14 +113,11 @@ wix @mwrock
 # inclusion here is voluntary.
 # This list shall be alphabetical, for sanity purposes.
 
-acbuild @rsertelon
 alex @wduncanfraser
 artifactory-pro @defilan
 asciinema @jasonwbarnett
-atk @rsertelon
 benchmark @bdangit
 cabal-install @wduncanfraser
-cairo @rsertelon
 cerebro @predominant
 clojure @johnjelinek
 concourse @echohack
@@ -142,8 +139,6 @@ dsc-core @mwrock
 elasticsearch @joshbrand @predominant @echohack
 fd @jasonwbarnett
 filebeat @predominant @echohack
-gdk-pixbuf @rsertelon
-glib @rsertelon
 ghc @wduncanfraser
 ghc710 @wduncanfraser
 ghc710-bootstrap @wduncanfraser
@@ -155,17 +150,11 @@ go @afiune @predominant
 gocd-server @predominant
 googletest @bdangit
 grpcurl @afiune
-gtk2 @rsertelon
 happy @wduncanfraser
-harfbuzz @rsertelon
 hugo @tduffield @cnunciato @predominant
 innounp @mwrock
-jdk7 @rsertelon
-jdk8 @rsertelon
 jenkins @predominant
 journalbeat @thomascate @echohack
-jre7 @rsertelon
-jre8 @rsertelon
 json-c @jasonwbarnett
 kibana @joshbrand @predominant
 logstash @joshbrand @predominant
@@ -173,8 +162,6 @@ libimagequant @predominant
 libtalloc @defilan
 mage @predominant
 metricbeat @echohack
-monit @rsertelon
-mosquitto @rsertelon
 mssql @mwrock
 nano @predominant
 nmap @defilan
@@ -182,7 +169,6 @@ nuget @mwrock
 openjdk11 @irvingpop
 optipng @predominant
 p4broker @dbhagen
-pango @rsertelon
 pngquant @predominant
 postgresql-client @joshbrand @irvingpop
 postgresql11 @irvingpop
@@ -190,7 +176,6 @@ postgresql11-client @irvingpop
 prometheus-cpp @bdangit
 protobuf-cpp @afiune
 redis @irvingpop
-shared-mime-info @rsertelon
 shellcheck @wduncanfraser
 sqitch @irvingpop
 sqitch_pg @irvingpop

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,7 +26,6 @@ To become a maintainer, open a pull request to this list.
 * [Paul Mooring](https://github.com/paulmooring)
 * [Josh Brand](https://github.com/joshbrand)
 * [Christopher P. Maher](https://github.com/defilan)
-* [Romain Sertelon](https://github.com/rsertelon)
 * [Tasha Drew](https://github.com/tashimi)
 * [Jon Bauman](https://github.com/baumanj)
 * [Graham Weldon](https://github.com/predominant)
@@ -45,3 +44,4 @@ To become a maintainer, open a pull request to this list.
 * [Elliott Davis](https://github.com/elliott-davis)
 * [Jamie Winsor](https://github.com/reset)
 * [Fletcher Nichol](https://github.com/fnichol)
+* [Romain Sertelon](https://github.com/rsertelon)


### PR DESCRIPTION
 @rsertelon  ,  thank you for your contributions to the Habitat Core Plans project! It's been a while since you've been active. We understand life gets busy and interests change so we're going to move you to `Alumni` status and remove CODEOWNER entries on the following plans:

```
acbuild
atk
cairo
gdk-pixbuf
glib
gtk2
harfbuzz
jdk7
jdk8
jre7
jre8
monit
mosquitto
pango
shared-mime-info
```

If you'd like to be a CODEOWNER/maintainer in the future we'd love to have you back. At that time, please open a PR adding yourself back to the appropriate entries.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>