### PR TITLE
[bind] Update bind to 9.15.4

### DIFF
--- a/bind/plan.sh
+++ b/bind/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=bind
 pkg_origin=core
-pkg_version=9.14.2
+pkg_version=9.15.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Versatile, Classic, Complete Name Server Software"
 pkg_upstream_url="https://www.isc.org/downloads/bind/"
 pkg_license=("MPL-2.0")
 pkg_source="https://ftp.isc.org/isc/bind9/${pkg_version}/bind-${pkg_version}.tar.gz"
-pkg_shasum="0e4027573726502ec038db3973a086c02508671723a4845e21da1769a5c27f0c"
+pkg_shasum=679288d6c42dc862afc69afbad53caf64c9565328623e710204e9b4b140eecb8
 pkg_deps=(
   core/glibc
   core/libxml2
@@ -22,6 +22,7 @@ pkg_build_deps=(
   core/gcc
   core/make
   core/perl
+  core/pkg-config
 )
 pkg_bin_dirs=(
   bin
@@ -50,7 +51,6 @@ do_build() {
   export PYTHONPATH
   ./configure \
     --prefix="${pkg_prefix}" \
-    --with-libxml2="$(pkg_path_for "core/libxml2")" \
     --with-openssl="$(pkg_path_for "core/openssl")" \
     --with-python="$(pkg_path_for core/python)/bin/python"
   make


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

`libxml` preferred method is via `pkg-config` now, adjusted build process to reflect that.

### Testing

```
hab pkg build bind
souce results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Dig
 ✓ Host
 ✓ ARPAname
 ✓ DNSSec Keygen

5 tests, 0 failures
```