### PR TITLE
[composer] Update composer to 1.9.0, add tests

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -1,14 +1,17 @@
 pkg_name=composer
 pkg_origin=core
-pkg_version=1.8.0
+pkg_version=1.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_upstream_url=https://getcomposer.org/
 pkg_description="Dependency Manager for PHP"
-pkg_source=https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar
-pkg_filename=${pkg_name}.phar
-pkg_shasum=0901a84d56f6d6ae8f8b96b0c131d4f51ccaf169d491813d2bcedf2a6e4cefa6
-pkg_deps=(core/php core/git)
+pkg_source="https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar"
+pkg_filename="${pkg_name}.phar"
+pkg_shasum=c9dff69d092bdec14dee64df6677e7430163509798895fbd54891c166c5c0875
+pkg_deps=(
+  core/php
+  core/git
+)
 pkg_bin_dirs=(bin)
 
 do_unpack(){

--- a/composer/tests/test.bats
+++ b/composer/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} composer --no-ansi --version 2>&1 | tail -1 | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} composer --help
+  [ $status -eq 0 ]
+}

--- a/composer/tests/test.sh
+++ b/composer/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build composer
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```