### PR TITLE
[docker] Update docker for linux to 19.03.3, add tests

### DIFF
--- a/docker/plan.sh
+++ b/docker/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=docker
 pkg_description="The Docker Engine"
 pkg_origin=core
-pkg_version=18.03.0
+pkg_version=19.03.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2')
-pkg_source=https://download.docker.com/linux/static/stable/x86_64/${pkg_name}-${pkg_version}-ce.tgz
+pkg_source="https://download.docker.com/linux/static/stable/x86_64/${pkg_name}-${pkg_version}.tgz"
 pkg_upstream_url=https://docs.docker.com/engine/installation/binaries/
-pkg_shasum=e5dff6245172081dbf14285dafe4dede761f8bc1750310156b89928dbf56a9ee
+pkg_shasum=c3c8833e227b61fe6ce0bc5c17f97fa547035bef4ef17cf6601f30b0f20f4ce5
 pkg_dirname=docker
 pkg_bin_dirs=(bin)
 
@@ -16,7 +16,7 @@ do_build() {
 
 do_install() {
   for bin in docker*; do
-    install -v -D "$bin" "$pkg_prefix/bin/$bin"
+    install -v -D "${bin}" "${pkg_prefix}/bin/${bin}"
   done
 }
 

--- a/docker/tests/test.bats
+++ b/docker/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} docker version | head -5 | grep Version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} docker --help
+  [ $status -eq 0 ]
+}

--- a/docker/tests/test.sh
+++ b/docker/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build docker
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```