### PR TITLE
[terraform] Update terraform to 0.12.11

### DIFF
--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.12.10
+pkg_version=0.12.11
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
 pkg_filename="${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=2215208822f1a183fb57e24289de417c9b3157affbe8a5e520b768edbcb420b4
+pkg_shasum=d61f8758a25bc079bb0833b81f998fbc4cf03bb0f41b995e08204cf5978f700e
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build terraform
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Terraform default workspace

2 tests, 0 failures
```