### PR TITLE
[nginx-prometheus-exporter] Add new plan: nginx-prometheus-exporter

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -978,6 +978,8 @@ plan_path = "nettle"
 plan_path = "nghttp2"
 [nginx]
 plan_path = "nginx"
+[nginx-prometheus-exporter]
+plan_path = "nginx-prometheus-exporter"
 [ninja]
 plan_path = "ninja"
 [nload]

--- a/nginx-prometheus-exporter/README.md
+++ b/nginx-prometheus-exporter/README.md
@@ -1,0 +1,30 @@
+# nginx-prometheus-exporter
+
+NGINX Prometheus exporter makes it possible to monitor NGINX or NGINX Plus using Prometheus.
+
+## Maintainers
+
+* The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+Service package
+
+## Usage
+
+This package is designed to be run in conjunction with an Nginx server that is using the `stub_status` output.
+
+You can either inject configuration to specify the Nginx endpoint to collect data from (by default, `http://localhost:8080/stub_status`), or bind to an Nginx server that has exported the `stub_status_port` and `stub_status_path` data.
+
+```
+hab svc load my/nginx-with-stub-status
+
+hab svc load core/nginx-prometheus-exporter \
+  --bind nginx:nginx-with-stub-status.default
+```
+
+## Topologies
+
+### Standalone
+
+This is a standalone server, and is run once per Nginx instance you have running. Ideally run this standalone, on each instance.

--- a/nginx-prometheus-exporter/default.toml
+++ b/nginx-prometheus-exporter/default.toml
@@ -1,0 +1,12 @@
+[nginx]
+plus = false
+retries = 5
+retry-interval = "5s"
+scrape-uri = "http://127.0.0.1:8080/stub_status"
+ssl-verify = false
+timeout = "5s"
+
+[web]
+address = "0.0.0.0"
+port = 9113
+telemetry-path = "/metrics"

--- a/nginx-prometheus-exporter/hooks/run
+++ b/nginx-prometheus-exporter/hooks/run
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+exec 2>&1
+exec nginx-prometheus-exporter \
+  -nginx.retries {{cfg.nginx.retries}} \
+  -nginx.retry-interval {{cfg.nginx.retry-interval}} \
+  {{~#if bind.nginx}}{{~#with bind.nginx.first}}
+  -nginx.scrape-uri "http://{{sys.ip}}:{{cfg.stub_status_port}}/{{cfg.stub_status_path}}" \
+  {{~/with}}{{~else}}
+  -nginx.scrape-uri "{{cfg.nginx.scrape-uri}}" \
+  {{~/if}}
+  {{~#if cfg.nginx.ssl-verify}}
+  -nginx.ssl-verify \
+  {{~/if}}
+  -nginx.timeout {{cfg.nginx.timeout}} \
+  -web.listen-address "{{cfg.web.address}}:{{cfg.web.port}}" \
+  -web.telemetry-path "{{cfg.web.telemetry-path}}"

--- a/nginx-prometheus-exporter/plan.sh
+++ b/nginx-prometheus-exporter/plan.sh
@@ -1,0 +1,35 @@
+
+pkg_name=nginx-prometheus-exporter
+pkg_origin=core
+pkg_version="0.4.2"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_description="NGINX Prometheus exporter makes it possible to monitor NGINX or NGINX Plus using Prometheus."
+pkg_upstream_url="https://github.com/nginxinc/nginx-prometheus-exporter"
+pkg_source="https://github.com/nginxinc/nginx-prometheus-exporter/archive/v${pkg_version}.tar.gz"
+pkg_shasum=d8931629a2aac26600f0b7c9a366e6fe2373c30d40e9a7572ad8ecc2aff92777
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/make
+  core/gcc
+  core/git
+  core/go
+)
+pkg_bin_dirs=(bin)
+pkg_exports=(
+  [port]=web.port
+)
+pkg_exposes=(port)
+pkg_binds_optional=(
+  [nginx]="stub_status_port stub_status_path"
+)
+
+do_build() {
+  make
+}
+
+do_install() {
+  install -m 755 nginx-prometheus-exporter "${pkg_prefix}/bin/nginx-prometheus-exporter"
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Adds a new plan for nginx-prometheus-exporter.

This is difficult to test. It requires a running Nginx instance, with stub_status enabled, and configured to listen on a separate port/path for stats. This would require embedding a configuration plan inside this plan path.

For the moment I have done private testing on a service I have on an internal builder that exposes the endpoint. Once that is loaded, I run nginx-prometheus-exporter, and it connects to the local Nginx.

Only once the Nginx connection is available does the exporter start listening. So there is no easy way to test this from a service perspective.

![tenor-215152925](https://user-images.githubusercontent.com/24568/67069123-06637000-f1b7-11e9-9ad4-086dd9474071.gif)
