### PR TITLE
[nss-myhostname] add a new plan!

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1022,6 +1022,12 @@ plan_path = "npth"
 plan_path = "nspr"
 [nss]
 plan_path = "nss"
+[nss-myhostname]
+plan_path = "nss-myhostname"
+build_targets = [
+  "x86_64-linux",
+  "x86_64-linux-kernel2"
+]
 [numactl]
 plan_path = "numactl"
 [ocaml]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -165,6 +165,7 @@ metricbeat @echohack
 mssql @mwrock
 nano @predominant
 nmap @defilan
+nss-myhostname @robbkidd
 nuget @mwrock
 openjdk11 @irvingpop
 optipng @predominant

--- a/nss-myhostname/README.md
+++ b/nss-myhostname/README.md
@@ -1,0 +1,18 @@
+# nss-myhostname
+
+[nss-myhostname](http://0pointer.de/lennart/projects/nss-myhostname/) is a plugin for the GNU Name Service Switch (NSS) functionality of the GNU C Library (glibc) providing host name resolution for the locally configured system hostname as returned by gethostname(2). This plugin is commonly enabled in the default `/etc/nsswitch.conf` NSS configuration of RHEL and RHEL-like Linux distributions. glibc has `/etc/nsswitch.conf` hard-coded as the file location for configuration. So long as core/glibc ships with that setting, this plugin is necessary for some software to perform name resolution with expected behavior.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/nss-myhostname)

--- a/nss-myhostname/plan.sh
+++ b/nss-myhostname/plan.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+pkg_name=nss-myhostname
+pkg_origin=core
+pkg_version=0.3
+pkg_license=("LGPL-2.1-or-later")
+pkg_description="nss-myhostname is a plugin for the GNU Name Service Switch (NSS) \
+  functionality of the GNU C Library (glibc) providing host name resolution for \
+  the locally configured system hostname as returned by gethostname(2). It is \
+  commonly enabled in the default NSS configuration of RHEL and RHEL-like Linux \
+  distributions."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_upstream_url="http://0pointer.de/lennart/projects/nss-myhostname/"
+pkg_source="http://0pointer.de/lennart/projects/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="2ba744ea8d578d1c57c85884e94a3042ee17843a5294434d3a7f6c4d67e7caf2"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_lib_dirs=(lib)


### PR DESCRIPTION
[nss-myhostname](http://0pointer.de/lennart/projects/nss-myhostname/) is a plugin for the GNU Name Service Switch (NSS) functionality of the GNU C Library (glibc) providing host name resolution for the locally configured system hostname as returned by gethostname(2). This plugin is commonly enabled in the default `/etc/nsswitch.conf` NSS configuration of RHEL and RHEL-like Linux distributions, with a hosts entry like:

    hosts:      files dns myhostname

`glibc` has `/etc/nsswitch.conf` hard-coded as the file location for configuration.  So long as `core/glibc` ships with that setting, this plugin is necessary for some software to perform name resolution with expected behavior.

### An example of unexpected behavior: Ruby.

It is common in the Ruby ecosystem to check if a domain name is resolvable by using the Ruby stdlib `Socket` class to attempt to open a network socket to a domain and port. ([44,402 results](https://github.com/search?l=Ruby&q=%22rescue+Socket%22&type=Code) searching for "rescue Socket" in Ruby code at the time of this writing.) With `core/ruby*` as built today, performing on any RHEL-flavored host a minimal name resolution check on a domain expected to fail returns `Errno::EBUSY`.

    $ hab pkg exec core/ruby ruby -r socket -e "p Socket.pack_sockaddr_in(80, 'nope.example')"
    Traceback (most recent call last):
            1: from -e:1:in `<main>'
    -e:1:in `pack_sockaddr_in': Device or resource busy - getaddrinfo (Errno::EBUSY)

`getaddrinfo` finds itself in [an else-branch returning `Errno::EBUSY`](https://github.com/bminor/glibc/blob/glibc-2.27/sysdeps/posix/getaddrinfo.c#L926-L939) because it was unable to find lookup functions whose names match the plugins listed in `/etc/nsswitch.conf`.

I was unable to find any examples of Ruby code handling `Errno::EBUSY` exceptions when a `Socket` or `SocketError` was expected.

A Ruby built with a `core/nss-myhostname` as a runtime dependency succeeds (or rather, fails in the expected manner).

    $ hab pkg exec core/ruby ruby -r socket -e "p Socket.pack_sockaddr_in(80, 'nope.example')"
    Traceback (most recent call last):
            1: from -e:1:in `<main>'
    -e:1:in `pack_sockaddr_in': getaddrinfo: No address associated with hostname (SocketError)

### Why kernel2 builds?

My specific interest in expected name resolution failures in Ruby is in service to packaging Ruby projects (e.g. Chef Infra Client and Chef InSpec) in Habitat for use on a wide variety of platforms and platform versions. For those projects to work on RHEL-flavored hosts still running Linux v2, they need a kernel2 build of this plugin.

This project is not expected to itself generate much churn in publishing new packages. This current version was released on May 9, 2011.