### PR TITLE
[docs] replace the Travis badge with a BuildKite badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Habitat Plans
 
+[![Build status](https://badge.buildkite.com/3ed82c4ec1ea98900a129ea42236fbe9df1724e46ae7440999.svg)](https://buildkite.com/chef-oss/habitat-sh-core-plans-master-verify)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 [![GitHub issues](https://img.shields.io/github/issues/habitat-sh/core-plans.svg)](https://github.com/habitat-sh/core-plans/issues)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Habitat Plans
 
-[![Build Status](https://travis-ci.org/habitat-sh/core-plans.svg?branch=master)](https://travis-ci.org/habitat-sh/core-plans)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 [![GitHub issues](https://img.shields.io/github/issues/habitat-sh/core-plans.svg)](https://github.com/habitat-sh/core-plans/issues)
 


### PR DESCRIPTION
[Testing moved to BuildKite](https://github.com/habitat-sh/core-plans/pull/2767), so we should stop displaying project status from Travis.

Maybe merge in coordination with [the final removal of the Travis webhook](https://github.com/habitat-sh/core-plans/issues/2813)?