### PR TITLE
[jenkins] Update jenkins to 2.190.2

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.176.3
+pkg_version=2.190.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum=9406c7bee2bc473f77191ace951993f89922f927a0cd7efb658a4247d67b9aa3
+pkg_shasum=47620a00004af5634e45904149897fe4a36b0463ec691bfabc2086779f90f127
 pkg_deps=(
   core/openjdk11
   core/curl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build jenkins
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample Output

```
 ✓ jenkins binary version matches 2.190.2
 ✓ Service is running
 ✓ Listening on port 80 (HTTP)

3 tests, 0 failures
```