### PR TITLE
[shellcheck] Updated shellcheck to 0.7.0

### DIFF
--- a/shellcheck/plan.ps1
+++ b/shellcheck/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="shellcheck"
 $hkg_name="ShellCheck"
 $pkg_origin="core"
-$pkg_version="0.6.0"
+$pkg_version="0.7.0"
 $pkg_license=@("GPL-3")
 $pkg_upstream_url="http://www.shellcheck.net/"
 $pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-$pkg_shasum="f6e79fb34d076504176761cc8b7c3f996f8d31bed23250fb1570e32283cd7df6"
+$pkg_shasum="3af93f97750fe896b5e9c5247b84f1a99e34293992bb0e9001b0cc725949a8ef"
 $pkg_dirname="${hkg_name}-${pkg_version}"
 
 
@@ -16,7 +16,7 @@ $pkg_bin_dirs=@("bin")
 $pkg_build_deps=@(
   "core/7zip"
   "core/cabal-install"
-  "core/ghc"
+  "core/ghc86"
 )
 
 function Invoke-Unpack {

--- a/shellcheck/plan.sh
+++ b/shellcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=shellcheck
 hkg_name=ShellCheck
 pkg_origin=core
-pkg_version=0.6.0
+pkg_version=0.7.0
 pkg_license=('GPL-3')
 pkg_upstream_url="http://www.shellcheck.net/"
 pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="f6e79fb34d076504176761cc8b7c3f996f8d31bed23250fb1570e32283cd7df6"
+pkg_shasum="3af93f97750fe896b5e9c5247b84f1a99e34293992bb0e9001b0cc725949a8ef"
 pkg_dirname="${hkg_name}-${pkg_version}"
 
 pkg_bin_dirs=(bin)
@@ -21,7 +21,7 @@ pkg_deps=(
 
 pkg_build_deps=(
   core/cabal-install
-  core/ghc
+  core/ghc86
 )
 
 do_clean() {


### PR DESCRIPTION
Updated shellcheck to 0.7.0
Building with ghc 8.6, as shellcheck does not yet support building with ghc 8.8

This is dependent on #3099

Signed-off-by: W. Duncan Fraser <duncan@wduncanfraser.com>