### PR TITLE
[alex] Fix alex builds for ghc 8.8

### DIFF
--- a/alex/plan.sh
+++ b/alex/plan.sh
@@ -18,7 +18,8 @@ pkg_deps=(
 
 pkg_build_deps=(
   core/cabal-install
-  core/ghc
+  # tests fail if we try and build with ghc 8.8
+  core/ghc86
   core/make
   core/which
 )


### PR DESCRIPTION
Tests for alex fail if built with ghc 8.8
Pinning to ghc 8.6 for now

Signed-off-by: W. Duncan Fraser <duncan@wduncanfraser.com>