### PR TITLE
[file] export MAGIC path to runtime env

### DIFF
--- a/file/plan.sh
+++ b/file/plan.sh
@@ -25,6 +25,10 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+do_setup_environment() {
+  set_runtime_env MAGIC "${pkg_prefix}/share/misc/magic.mgc"
+}
+
 do_prepare() {
   do_default_prepare
 

--- a/file/plan.sh
+++ b/file/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=file
+pkg_name="file"
 pkg_origin=core
 pkg_version=5.34
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"

--- a/file/tests/test.bats
+++ b/file/tests/test.bats
@@ -1,0 +1,22 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+TEST_PKG_MAGIC_PATH="/hab/pkgs/${TEST_PKG_IDENT}/share/misc/magic.mgc"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} file --version | head -1)"
+  [ "$result" = "file-${TEST_PKG_VERSION}" ]
+}
+
+@test "Internal magic file in use" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} file --version | tail -1)"
+  [ "$result" = "magic file from ${TEST_PKG_MAGIC_PATH}" ]
+}
+
+@test "MAGIC env exported" {
+  result="$(bash -c 'source <(hab pkg env ${TEST_PKG_IDENT}) && echo $MAGIC')"
+  [ "$result" = "${TEST_PKG_MAGIC_PATH}" ]
+}
+
+@test "Command detects format of magic file" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} file ${TEST_PKG_MAGIC_PATH})"
+  [ "$result" = "${TEST_PKG_MAGIC_PATH}: magic binary file for file(1) cmd (version 14) (little endian)" ]
+}

--- a/file/tests/test.sh
+++ b/file/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
`core/file` provides the traditionally-named `/usr/share/misc/magic.mgc` file that some tooling relies on to look for magic bytes in content and determine file formats.

`$MAGIC` seems to be the conventional environment variable for overriding where to find this file

With this change, any plan adding `core/file` to its `pkg_deps` will get `MAGIC` pointing to this file in its runtime env