### PR TITLE
[openssl11] Add new plan for OpenSSL 1.1.0

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1082,6 +1082,8 @@ plan_path = "openssl-musl"
 paths = [
   "openssl/*",
 ]
+[openssl11]
+plan_path = "openssl11"
 [openvpn]
 plan_path = "openvpn"
 [optipng]

--- a/openssl11/README.md
+++ b/openssl11/README.md
@@ -1,0 +1,20 @@
+# openssl
+
+OpenSSL is an open source project that provides a robust,
+commercial-grade, and full-featured toolkit for the Transport Layer
+Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a
+general-purpose cryptography library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Declare as a runtime dependency in your plan:
+
+    pkg_deps=(core/openssl11)

--- a/openssl11/ca-dir.patch
+++ b/openssl11/ca-dir.patch
@@ -1,0 +1,59 @@
+diff --git a/apps/CA.pl.in b/apps/CA.pl.in
+index 7277eeca96..a1504cc53c 100644
+--- a/apps/CA.pl.in
++++ b/apps/CA.pl.in
+@@ -33,7 +33,7 @@ my $X509 = "$openssl x509";
+ my $PKCS12 = "$openssl pkcs12";
+ 
+ # default openssl.cnf file has setup as per the following
+-my $CATOP = "./demoCA";
++my $CATOP = "@prefix@/ssl";
+ my $CAKEY = "cakey.pem";
+ my $CAREQ = "careq.pem";
+ my $CACERT = "cacert.pem";
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index b3e7444e5f..9815655db9 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -15,7 +15,7 @@ oid_section		= new_oids
+ # To use this configuration file with the "-extfile" option of the
+ # "openssl x509" utility, name here the section containing the
+ # X.509v3 extensions to use:
+-# extensions		= 
++# extensions		=
+ # (Alternatively, use a configuration file that has only
+ # X.509v3 extensions in its main [= default] section.)
+ 
+@@ -39,7 +39,7 @@ default_ca	= CA_default		# The default ca section
+ ####################################################################
+ [ CA_default ]
+ 
+-dir		= ./demoCA		# Where everything is kept
++dir             = @prefix@/ssl          # Where everything is kept
+ certs		= $dir/certs		# Where the issued certs are kept
+ crl_dir		= $dir/crl		# Where the issued crl are kept
+ database	= $dir/index.txt	# database index file.
+@@ -113,7 +113,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+ # input_password = secret
+ # output_password = secret
+ 
+-# This sets a mask for permitted string types. There are several options. 
++# This sets a mask for permitted string types. There are several options.
+ # default: PrintableString, T61String, BMPString.
+ # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+ # utf8only: only UTF8Strings (PKIX recommendation after 2004).
+diff --git a/crypto/include/internal/cryptlib.h b/crypto/include/internal/cryptlib.h
+index d42a134bdf..32094e1780 100644
+--- a/crypto/include/internal/cryptlib.h
++++ b/crypto/include/internal/cryptlib.h
+@@ -41,8 +41,8 @@ DEFINE_LHASH_OF(MEM);
+ 
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+-#  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_DIR           "@cacerts_prefix@/ssl/certs"
++#  define X509_CERT_FILE          "@cacerts_prefix@/ssl/cert.pem"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/openssl11/plan.sh
+++ b/openssl11/plan.sh
@@ -1,0 +1,132 @@
+pkg_name=openssl11
+_distname=openssl
+pkg_origin=core
+pkg_version=1.1.0l
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+OpenSSL is an open source project that provides a robust, commercial-grade, \
+and full-featured toolkit for the Transport Layer Security (TLS) and Secure \
+Sockets Layer (SSL) protocols. It is also a general-purpose cryptography \
+library.\
+"
+pkg_upstream_url="https://www.openssl.org"
+pkg_license=('OpenSSL')
+pkg_source="https://www.openssl.org/source/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/cacerts
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/grep
+  core/perl
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+_common_prepare() {
+  do_default_prepare
+
+  # Set CA dir to `$pkg_prefix/ssl` by default and use the cacerts from the
+  # `cacerts` package. Note that `patch(1)` is making backups because
+  # we need an original for the test suite.
+  sed -e "s,@prefix@,$pkg_prefix,g" \
+      -e "s,@cacerts_prefix@,$(pkg_path_for cacerts),g" \
+      "$PLAN_CONTEXT/ca-dir.patch" \
+      | patch -p1 --backup
+
+  # The openssl build process hard codes /bin/rm in many places.
+  if [[ ! -f "/bin/rm" ]]; then
+    hab pkg binlink core/coreutils rm --dest /bin
+    BINLINKED_RM=true
+  fi
+}
+
+do_prepare() {
+  _common_prepare
+
+  export BUILD_CC=gcc
+  build_line "Setting BUILD_CC=$BUILD_CC"
+}
+
+do_build() {
+  # Set PERL var for scripts in `do_check` that use Perl
+  PERL=$(pkg_path_for core/perl)/bin/perl
+  export PERL
+  "$(pkg_path_for core/perl)/bin/perl" ./Configure \
+    no-idea \
+    no-mdc2 \
+    no-rc5 \
+    no-comp \
+    no-zlib \
+    shared \
+    disable-gost \
+    --prefix="${pkg_prefix}" \
+    --openssldir=ssl \
+    linux-x86_64 \
+
+  make CC= depend
+  make --jobs="$(nproc)" CC="$BUILD_CC"
+}
+
+do_check() {
+  # Flip back to the original sources to satisfy the test suite, but keep the
+  # final version for packaging.
+  for f in apps/CA.pl.in apps/openssl.cnf; do
+    cp -fv $f ${f}.final
+    cp -fv ${f}.orig $f
+  done
+
+  make test
+
+  # Finally, restore the final sources to their original locations.
+  for f in apps/CA.pl.in apps/openssl.cnf; do
+    cp -fv ${f}.final $f
+  done
+}
+
+do_install() {
+  do_default_install
+
+  # Remove dependency on Perl at runtime
+  rm -rfv "$pkg_prefix/ssl/misc" "$pkg_prefix/bin/c_rehash"
+}
+
+do_end() {
+  do_default_end
+
+  # Clean up binlinked rm if we made it
+  if [[ $BINLINKED_RM == true ]]; then
+    rm -f /bin/rm
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+# if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+#   pkg_build_deps=(
+#     core/gcc
+#     core/coreutils
+#     core/sed
+#     core/grep
+#     core/perl
+#     core/diffutils
+#     core/make
+#     core/patch
+#   )
+# fi

--- a/openssl11/tests/test.bats
+++ b/openssl11/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" openssl version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/openssl11/tests/test.sh
+++ b/openssl11/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh origin/package/1.2.3/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Some software only works with OpenSSL 1.1.0.

Differences from core/openssl:

- `ca-dir.patch` updated to match source

- FIPS configuration removed as OpenSSL 1.1.0 does not support FIPS.

- Stage 1 configuration commented until we decide to move to openssl
  1.1.0 as our base version.

Signed-off-by: Steven Danna <steve@chef.io>