### PR TITLE
[memcache] Add TLS support to memcache

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -11,6 +11,7 @@ pkg_deps=(
   core/glibc
   core/cyrus-sasl
   core/libevent
+  core/openssl11
 )
 pkg_build_deps=(
   core/git
@@ -29,7 +30,8 @@ pkg_exposes=(port)
 do_build() {
   ./configure \
     --prefix="${pkg_prefix}" \
-    --enable-sasl
+    --enable-sasl \
+    --enable-tls
   make
 }
 


### PR DESCRIPTION
TLS support was added to memcache in 1.5.13. It requires openssl
1.1.0+, so this depends on #3111

Signed-off-by: Steven Danna <steve@chef.io>