### PR TITLE
[rust] uplift to 1.38 from 1.36 to align with master

### DIFF
--- a/rust/plan.ps1
+++ b/rust/plan.ps1
@@ -1,12 +1,12 @@
 ﻿$pkg_name="rust"
 $pkg_origin="core"
-$pkg_version="1.36.0"
+$pkg_version="1.38.0"
 $pkg_description="Safe, concurrent, practical language"
 $pkg_upstream_url="https://www.rust-lang.org/"
 $pkg_license=@("Apache-2.0", "MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://static.rust-lang.org/dist/rust-$pkg_version-x86_64-pc-windows-msvc.msi"
-$pkg_shasum="e86148196e71c9c826101d37b66393dfaacef824559d92a9f4e48f030a7aa1e4"
+$pkg_shasum="e6a5e79f60a25df6ec951f6ad63ea20796f18ff67b7b4d1ba65dcab75cb1c311"
 $pkg_deps=@("core/visual-cpp-redist-2015", "core/visual-cpp-build-tools-2015")
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")

--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.36.0
+pkg_version=1.38.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Rust is a systems programming language that runs blazingly fast, prevents \
@@ -10,7 +10,7 @@ pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
 _url_base="https://static.rust-lang.org/dist"
 pkg_source="$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz"
-pkg_shasum="15e592ec52f14a0586dcebc87a957e472c4544e07359314f6354e2b8bd284c55"
+pkg_shasum="adda26b3f0609dbfbdc2019da4a20101879b9db2134fae322a4e863a069ec221"
 pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu"
 pkg_deps=(
   core/glibc
@@ -33,7 +33,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-    4d36e7b52839cff72481b2b1858417f382be36ffa5f084f72f35c1a9117c94ea
+    56b87fdca1f41b634285593cae42fdbd5fe9632ef502336679362b283ed53c22
 )
 
 do_download() {


### PR DESCRIPTION
core/rust a baseplan was uplifted on the master branch to 1.38.0 recently with [this PR](https://github.com/habitat-sh/core-plans/pull/3045) but not also on the refresh branch.  During refresh branch build sanity testing, packages following core/rust were failing and looking for the 1.38.0.

Patching this new version fixed the build process.

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>