### PR TITLE
[libarchive] Update from 3.3.3 to 3.4.0

### DIFF
--- a/libarchive/plan.ps1
+++ b/libarchive/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="libarchive"
 $pkg_origin="core"
-$pkg_version="3.3.3"
+$pkg_version="3.4.0"
 $pkg_description="Multi-format archive and compression library"
 $pkg_upstream_url="https://www.libarchive.org"
 $pkg_license=@("BSD")
 $pkg_source="http://www.libarchive.org/downloads/${pkg_name}-${pkg_version}.zip"
-$pkg_shasum="9b1c4f5f92c527f4767bb4806f083a765affbdbd915e6be0345a0be97d833dca"
+$pkg_shasum="d893507dca992d0ea70c4354f01e385cbf0ee8e544c1611d3d432d6359fd59e0"
 $pkg_deps=@(
     "core/openssl",
     "core/bzip2",

--- a/libarchive/plan.sh
+++ b/libarchive/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libarchive
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=3.3.3
+pkg_version=3.4.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Multi-format archive and compression library"
 pkg_upstream_url="https://www.libarchive.org"
 pkg_license=('BSD')
 pkg_source="http://www.libarchive.org/downloads/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e"
+pkg_shasum="8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
This includes a large number of fixes and support for new archive formats. We already mentioned this in chef-client release notes and this is necessary to make sure we have feature parity with omnnibus and hab builds.

Signed-off-by: Tim Smith <tsmith@chef.io>