### PR TITLE
[nginx] Update Nginx to 1.17.6

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.17.4"
+$pkg_version="1.17.6"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="4101197c88ea11f609a665bffbed3ee13ced345f51b711a61a30328b66381c44"
+$pkg_shasum="f4805fe1b1114c1a3a5087d13e4317f39741d6f9fc2fab0ce0ea3ec4206d7549"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.17.4
+pkg_version=1.17.6
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=62854b365e66670ef4f1f8cc79124f914551444da974207cd5fe22d85710e555
+pkg_shasum=3cb4a5314dc0ab0a4e8a7b51ae17c027133417a45cc6c5a96e3dd80141c237b6
 pkg_deps=(
   core/glibc
   core/libedit

--- a/nginx/tests/test.sh
+++ b/nginx/tests/test.sh
@@ -25,7 +25,7 @@ ci_ensure_supervisor_running
 ci_load_service "${TEST_PKG_IDENT}"
 
 # Allow service start
-WAIT_SECONDS=5
+WAIT_SECONDS=10
 echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
 sleep "${WAIT_SECONDS}"
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build nginx
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

6 tests, 0 failures
```