### PR TITLE
[libarchive] Update version and add to baseplans

### DIFF
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -69,6 +69,7 @@ core-plans/bzip2-musl
 core-plans/xz-musl
 core-plans/libsodium-musl
 core-plans/openssl-musl
+core-plans/libarchive
 core-plans/libarchive-musl
 core-plans/rust
 habitat/components/hab

--- a/libarchive/plan.ps1
+++ b/libarchive/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="libarchive"
 $pkg_origin="core"
-$pkg_version="3.3.3"
+$pkg_version="3.4.0"
 $pkg_description="Multi-format archive and compression library"
 $pkg_upstream_url="https://www.libarchive.org"
 $pkg_license=@("BSD")
 $pkg_source="http://www.libarchive.org/downloads/${pkg_name}-${pkg_version}.zip"
-$pkg_shasum="9b1c4f5f92c527f4767bb4806f083a765affbdbd915e6be0345a0be97d833dca"
+$pkg_shasum="d893507dca992d0ea70c4354f01e385cbf0ee8e544c1611d3d432d6359fd59e0"
 $pkg_deps=@(
     "core/openssl",
     "core/bzip2",

--- a/libarchive/plan.sh
+++ b/libarchive/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libarchive
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=3.3.3
+pkg_version=3.4.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Multi-format archive and compression library"
 pkg_upstream_url="https://www.libarchive.org"
 pkg_license=('BSD')
 pkg_source="http://www.libarchive.org/downloads/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e"
+pkg_shasum="8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting on Scott to confirm whether #3117 get's merged into master or this one into the refresh/2019q3 branch.

### Context
PR #3117 introduces a required version uplift to the core/libarchive and bases the change off 'master'.  

However, this plans needs to be treated as a baseplan and based not off master but off the 'refresh/2019q3' branch.  The [base-plans.txt](https://github.com/habitat-sh/core-plans/blob/master/base-plans.txt) lists dependencies for hab packages.  Since core/libarchive-musl is on this list and it also sources the core/libarchive, that makes core/libarchive also a baseplan--even though its not currently on the base-plans.txt.

This PR adds the version uplift and also adds core/libarchive to the base-plans.txt.  This will ensure that the baseplan refresh will also rebuild core/libarchive in the process.

### Completed Tasks
- [x] Verify the windows plan.ps1 build
- [x] Test the linux plan.sh change if this PR against the 'refresh/2019q3' refresh process