### PR TITLE
[openssl] lift core/openssl version to 1.0.2t

### DIFF
--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="openssl"
 $pkg_origin="core"
-$pkg_version="1.0.2s"
+$pkg_version="1.0.2t"
 $_pkg_version_text=($pkg_version).Replace(".", "_")
 $pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
 $pkg_upstream_url="https://www.openssl.org"
 $pkg_license=@("OpenSSL")
 $pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
-$pkg_shasum="cae88e63ba0e478bca36c7a8fdea225138cf0f4be32b1120c45a1765a9bcf539"
+$pkg_shasum="08741e9c71ded84ad54840e611bc86a2272fbbdb72b90556a3ec7e02b11f1dd9"
 $pkg_deps=@("core/visual-cpp-redist-2015")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
 $pkg_bin_dirs=@("bin")

--- a/openssl/plan.sh
+++ b/openssl/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=openssl
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.2s
+pkg_version=1.0.2t
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 OpenSSL is an open source project that provides a robust, commercial-grade, \
@@ -12,7 +12,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://www.openssl.org/source/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96"
+pkg_shasum="14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Waiting on Scott to confirm whether #3120 get's merged into master or this one into the refresh/2019q3 branch.


### Context 
PR #3120 introduces a required version uplift to the core/openssl and bases the change off 'master'.

However, this plans needs to be treated as a baseplan and based not off master but off the 'refresh/2019q3' branch. This PR does the version uplift not only on the linux plan but also on the windows one.  Verification tests are included.

### Completed Tasks
- [x] Build and test both the windows and linux core/openssl.  Also run `'DO_CHECK=true build .`` as final check on the linux build
- [x] Build the new linux core/openssl 1.0.2t in the flow of a complete refresh process to verify that it works as expected.