### PR TITLE
[shared-mime-info] Lock XMLParser to known good version

### DIFF
--- a/shared-mime-info/plan.sh
+++ b/shared-mime-info/plan.sh
@@ -28,6 +28,5 @@ pkg_bin_dirs=(bin)
 
 do_prepare() {
   do_default_prepare
-
-  cpanm XML::Parser --configure-args="EXPATLIBPATH=$(pkg_path_for core/expat)/lib export EXPATINCPATH=$(pkg_path_for core/expat)/include"
+  cpanm TODDR/XML-Parser-2.44.tar.gz --configure-args="EXPATLIBPATH=$(pkg_path_for core/expat)/lib EXPATINCPATH=$(pkg_path_for core/expat)/include"
 }

--- a/shared-mime-info/tests/test.bats
+++ b/shared-mime-info/tests/test.bats
@@ -1,0 +1,43 @@
+# The share-mime-info spec delcares that these files must be present 
+# We should not validate the content, as that should come from upstream 
+# tests and may change over time.
+# We also skip the MEDIA/SUBTYPE.xml checks as that would produce a 
+# extremely large number of checks that also may change over time
+# https://specifications.freedesktop.org/share-mime-info-spec/share-mime-info-spec-0.18.html
+
+@test "globs metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/globs ]
+}
+
+@test "globs2 metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/globs2 ]
+}
+
+@test "magic metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/magic ]
+}
+
+@test "subclasses metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/subclasses ]
+}
+
+@test "aliases metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/aliases ]
+}
+
+@test "icons metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/icons ]
+}
+
+@test "generic-icons metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/generic-icons ]
+}
+
+@test "XMLnamespaces metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/XMLnamespaces ]
+}
+
+@test "mime.cache metadata is generated" {
+  [ -f /hab/pkgs/$TEST_PKG_IDENT/share/mime/mime.cache ]
+}
+

--- a/shared-mime-info/tests/test.sh
+++ b/shared-mime-info/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
shared-mime-info needs XML-Parser as part of its build process. There was a recent update to that project that pulled in an update to Devel::CheckLib that breaks the detection of libexpat, even though we explicitly set the lib and include paths.  

For now, we will lock to a known good version of XML-Parser to unblock the builds of this package.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>
