### PR TITLE
[shared-mime-info] fix the broken build

### DIFF
--- a/shared-mime-info/plan.sh
+++ b/shared-mime-info/plan.sh
@@ -29,5 +29,11 @@ pkg_bin_dirs=(bin)
 do_prepare() {
   do_default_prepare
 
-  cpanm XML::Parser --configure-args="EXPATLIBPATH=$(pkg_path_for core/expat)/lib export EXPATINCPATH=$(pkg_path_for core/expat)/include"
+  # cpanm requires core/expat in the LD_LIBRARY_PATH when it installs XML::Parser.
+  # Normally it is best to avoid setting the LD_LIBRARY_PATH in the habitat plan. However
+  # since cpanm/perl needs it for building the XML::Parser, then passing it in via
+  # the 'env' limits it to the actual cpanm process.  This workaround is done in similar
+  # fashion to core/ffmpeg.
+  env LD_LIBRARY_PATH="$(pkg_path_for core/expat)/lib:${LD_LIBRARY_PATH}" \
+    cpanm XML::Parser --configure-args="EXPATLIBPATH=$(pkg_path_for core/expat)/lib export EXPATINCPATH=$(pkg_path_for core/expat)/include"
 }


### PR DESCRIPTION
### Outstanding Tasks
- [ ] Scott confirmed that there isn't another LD_LIBRARY_PATH solution as this is normally an anti-pattern?

### Context

During a troubleshooting session with Michal Wronka it was discovered that on building the shared-mime-info it failed as follows:

```bash
...
...
   shared-mime-info: Setting PKG_CONFIG_PATH=/hab/pkgs/core/expat/2.2.5/20190115012836/lib/pkgconfig:/hab/pkgs/core/glib/2.50.3/20190305224252/lib/pkgconfig:/hab/pkgs/core/libxml2/2.9.10/20191119234603/lib/pkgconfig:/hab/pkgs/core/pcre/8.42/20190115012526/lib/pkgconfig:/hab/pkgs/core/zlib/1.2.11/20190115003728/lib/pkgconfig
   shared-mime-info: Preparing to build
--> Working on XML::Parser
Fetching http://www.cpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz ... OK
Configuring XML-Parser-2.46 ... N/A
! Configure failed for XML-Parser-2.46. See /root/.cpanm/work/1574435524.1223/build.log for details.
   shared-mime-info: Build time: 0m48s
   shared-mime-info: Exiting on error
[5][default:/src/shared-mime-info:1]# vim /root/.cpanm/work/1574435524.1223/build.log
```

Viewing the /root/.cpanm/work/1574435524.1223/build.log reveals that the libexpat.so.1 is required and not found.

```bash
Configuring XML-Parser-2.46
Running Makefile.PL
/root/.cpanm/work/1574442575.1218/XML-Parser-2.46/assertlibXnmZtgjh: error while loading shared libraries: libexpat.so.1: cannot open shared object file: No such file or directory

Expat must be installed prior to building XML::Parser and I can't find
it in the standard library directories. Install 'expat-devel' (or
'libexpat1-dev') package with your OS package manager. See 'README'.

...
...
Note that if you build against a shareable library in a non-standard location
you may (on some platforms) also have to set your LD_LIBRARY_PATH environment
variable at run time for perl to find the library.
```

The solution was to pass the required LD_LIBRARY_PATH variable into the build process.