### PR TITLE
[base-plans.txt] add missing dependencies

### DIFF
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -70,8 +70,10 @@ core-plans/busybox-static
 core-plans/zlib-musl
 core-plans/bzip2-musl
 core-plans/xz-musl
+core-plans/libsodium
 core-plans/libsodium-musl
 core-plans/openssl-musl
+core-plans/libarchive
 core-plans/libarchive-musl
 core-plans/rust
 habitat/components/hab


### PR DESCRIPTION
Fix #3129: add missing dependencies to base-plans.txt:core/libarchive and core/libsodium

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>