### PR TITLE
[alex] Update alex to 3.2.5, improve testing

### DIFF
--- a/alex/plan.sh
+++ b/alex/plan.sh
@@ -1,21 +1,18 @@
 pkg_name=alex
 pkg_origin=core
-pkg_version=3.2.4
+pkg_version=3.2.5
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="http://www.haskell.org/alex/"
 pkg_description="Alex is a tool for generating lexical analysers in Haskell. It takes a description of tokens based on regular expressions and generates a Haskell module containing code for scanning text efficiently. It is similar to the tool lex or flex for C/C++."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232"
-
+pkg_shasum=b77c8a1270767c64e2adb21a6e91ee7cd904ba17edae17bc20fd03da5256e0e3
 pkg_bin_dirs=(bin)
-
 pkg_deps=(
   core/glibc
   core/gmp
   core/libffi
 )
-
 pkg_build_deps=(
   core/cabal-install
   # tests fail if we try and build with ghc 8.8
@@ -39,15 +36,15 @@ do_build() {
   cabal v1-install --only-dependencies
 
   # Configure and Build
-  cabal v1-configure --prefix="$pkg_prefix"
+  cabal v1-configure --prefix="${pkg_prefix}"
   cabal v1-build
-}
-
-do_check() {
-  export PATH="$PWD/dist/build/alex:$PATH"
-  cabal v1-test
 }
 
 do_install() {
   cabal v1-copy
+}
+
+do_check() {
+  export PATH="${PWD}/dist/build/alex:${PATH}"
+  cabal v1-test
 }

--- a/alex/tests/test.bats
+++ b/alex/tests/test.bats
@@ -1,14 +1,23 @@
-@test "package directory for package ident ${TEST_PKG_IDENT} exists" {
-  [ -d "/hab/pkgs/${TEST_PKG_IDENT}" ]
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "alex runs with exit status 1" {
+  run hab pkg exec "${TEST_PKG_IDENT}" alex
+  [ $status -eq 1 ]
 }
 
-expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
-@test "alex exe runs" {
-  run hab pkg exec $TEST_PKG_IDENT alex -v
+@test "alex --help runs with exit status 0" {
+  run hab pkg exec "${TEST_PKG_IDENT}" alex --help
   [ $status -eq 0 ]
 }
 
-@test "alex -v output mentions expected version $expected_version" {
-  run hab pkg exec $TEST_PKG_IDENT alex -v
-  [[ "$output" =~ $expected_version ]]
+@test "alex -v output mentions expected version" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" alex -v | awk -F',' '{print $1}')"
+  [ "$result" = "Alex version ${TEST_PKG_VERSION}" ]
+}
+
+@test "alex simple token file succeeds" {
+  run hab pkg exec "${TEST_PKG_IDENT}" alex ${BATS_TEST_DIRNAME}/test.x
+  [ $status -eq 0 ]
+  [ -f ${BATS_TEST_DIRNAME}/test.hs ]
+  rm -f ${BATS_TEST_DIRNAME}/test.hs
 }

--- a/alex/tests/test.sh
+++ b/alex/tests/test.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
 set -euo pipefail
 
-TESTDIR="$(dirname "${0}")"
-
-if [ -z "${1:-}" ]; then
-  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
-  exit 1
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-TEST_PKG_IDENT="$1"
-
-hab pkg install --binlink core/bats
-hab pkg install "$TEST_PKG_IDENT"
-
+TEST_PKG_IDENT="${1}"
 export TEST_PKG_IDENT
-bats "${TESTDIR}/test.bats"
+hab pkg install --binlink core/bats
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/alex/tests/test.x
+++ b/alex/tests/test.x
@@ -1,0 +1,35 @@
+{
+module Main (main) where
+}
+
+%wrapper "basic"
+
+$digit = 0-9			-- digits
+$alpha = [a-zA-Z]		-- alphabetic characters
+
+tokens :-
+
+  $white+				;
+  "--".*				;
+  let					{ \s -> Let }
+  in					{ \s -> In }
+  $digit+				{ \s -> Int (read s) }
+  [\=\+\-\*\/\(\)]			{ \s -> Sym (head s) }
+  $alpha [$alpha $digit \_ \']*		{ \s -> Var s }
+
+{
+-- Each action has type :: String -> Token
+
+-- The token type:
+data Token =
+	Let 		|
+	In  		|
+	Sym Char	|
+	Var String	|
+	Int Int
+	deriving (Eq,Show)
+
+main = do
+  s <- getContents
+  print (alexScanTokens s)
+}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build alex
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ alex runs with exit status 1
 ✓ alex --help runs with exit status 0
 ✓ alex -v output mentions expected version
 ✓ alex simple token file succeeds

4 tests, 0 failures
```