### PR TITLE
[ansible] Update ansible to 2.9.1

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version=2.8.6
+pkg_version=2.9.1
 pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."
 pkg_upstream_url="https://www.ansible.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-only")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=94c96aaf781417c073b340381c83992e4880f2a660b46888530909bc7c57ef71
+pkg_shasum=087a7644890e27c26171b0d24fc5d64024f12201ffb81d222aaa5704987e4c12
 pkg_deps=(
   core/libffi
   core/python2


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build ansible
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command

2 tests, 0 failures
```

![tenor-251975729](https://user-images.githubusercontent.com/24568/69767660-abaf3200-11c0-11ea-9c56-acdcd1aba595.gif)
