### PR TITLE
[artifactory] Update artifactory to 6.15.0, update tests for lack of anonymous access

### DIFF
--- a/artifactory/plan.sh
+++ b/artifactory/plan.sh
@@ -1,19 +1,21 @@
 pkg_origin=core
 pkg_name=artifactory
-pkg_version=6.11.3
+pkg_version=6.15.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
 pkg_source="https://bintray.com/jfrog/${pkg_name}/download_file?file_path=jfrog-artifactory-oss-${pkg_version}.zip"
-pkg_shasum=fc2277fa4da9cfd83ca3af9ca94b2b03717e3df60573ab19f0281c9954117eda
-pkg_deps=(core/bash core/openjdk11)
+pkg_shasum=c623a423a4434d183846470c6522eb5e544eeaba80226feed99b6f07fa917121
+pkg_deps=(
+  core/bash
+  core/openjdk11
+)
 pkg_exports=(
   [port]=port
 )
 pkg_exposes=(port)
-
 pkg_svc_user=root
 
 do_build() {

--- a/artifactory/tests/test.bats
+++ b/artifactory/tests/test.bats
@@ -7,6 +7,6 @@ load helpers
 }
 
 @test "API is functional" {
-  result="$(curl -s http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
+  result="$(curl -s -u admin:password http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
   [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory/tests/test.sh
+++ b/artifactory/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -eou pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
   exit 1
@@ -23,10 +25,10 @@ hab pkg binlink core/busybox-static netstat
 hab pkg install core/curl --binlink
 hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
-hab sup run &
-sleep 5
-echo "Waiting for supervisor to start"
-hab svc load "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
 echo "Waiting for Artifactory to start"
 sleep 90
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Anonymous access is now disabled by default. Tests updated to reflect changes.

### Testing

```
hab pkg build artifactory
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8081
 ✓ API is functional

2 tests, 0 failures
```
