### PR TITLE
[artifactory-pro] Update artifactory-pro to 6.15.0

### DIFF
--- a/artifactory-pro/plan.sh
+++ b/artifactory-pro/plan.sh
@@ -1,19 +1,21 @@
 pkg_origin=core
 pkg_name=artifactory-pro
-pkg_version=6.11.3
+pkg_version=6.15.0
 pkg_description="Artifactory is an advanced binary repository manager for use by build tools (like Maven and Gradle), dependency management tools (like Ivy and NuGet) and build servers (like Jenkins, Hudson, TeamCity and Bamboo).
 Repository managers serve two purposes: they act as highly configurable proxies between your organization and external repositories and they also provide build servers with a deployment destination for your internally generated artifacts."
 pkg_upstream_url=https://www.jfrog.com/artifactory/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("JFrog Artifactory EULA")
-pkg_source=https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip
-pkg_shasum=61cc41c177cf34780e643759157971a81ce6c72fe73ea2f182b9a79dfbcfc028
-pkg_deps=(core/bash core/openjdk11)
+pkg_source="https://dl.bintray.com/jfrog/${pkg_name}/org/artifactory/pro/jfrog-${pkg_name}/${pkg_version}/jfrog-${pkg_name}-${pkg_version}.zip"
+pkg_shasum=5192ed68aa030278a50f5b8ca43197a0435469ee4a1b5f382819cd08e387df53
+pkg_deps=(
+  core/bash
+  core/openjdk11
+)
 pkg_exports=(
   [port]=port
 )
 pkg_exposes=(port)
-
 pkg_svc_user=root
 
 do_build() {
@@ -21,6 +23,6 @@ do_build() {
 }
 
 do_install() {
-  build_line "Copying files from $PWD"
-  cp -R ./* "$pkg_prefix/"
+  build_line "Copying files from ${PWD}"
+  cp -R ./* "${pkg_prefix}/"
 }

--- a/artifactory-pro/tests/test.bats
+++ b/artifactory-pro/tests/test.bats
@@ -7,6 +7,6 @@ load helpers
 }
 
 @test "API is functional" {
-  result="$(curl -s http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
+  result="$(curl -s -u admin:password http://0.0.0.0:8081/artifactory/api/repositories | jq -r '.[].key')"
   [ "${result}" = "example-repo-local" ]
 }

--- a/artifactory-pro/tests/test.sh
+++ b/artifactory-pro/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -eou pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -22,10 +24,10 @@ hab pkg binlink core/busybox-static nc
 hab pkg install core/curl --binlink
 hab pkg install core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
-hab sup run &
-sleep 5
-echo "Waiting for supervisor to start"
-hab svc load "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
 echo "Waiting for Artifactory to start"
 sleep 60
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build artifactory-pro
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8081
 ✓ API is functional

2 tests, 0 failures
```

![tenor-176971727](https://user-images.githubusercontent.com/24568/69768586-7b699280-11c4-11ea-9e2e-320c4beb0fa7.gif)
