### PR TITLE
[googletest] Update googletest to 1.10.0

### DIFF
--- a/googletest/plan.sh
+++ b/googletest/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=googletest
 pkg_origin=core
-pkg_version="1.8.1"
+pkg_version=1.10.0
 pkg_description="$(cat << EOF
 Google C++ Testing Framework helps you write better C++ tests.
 EOF
@@ -8,10 +8,9 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd-3-clause')
 pkg_source="https://github.com/google/${pkg_name}/archive/release-${pkg_version}.tar.gz"
-pkg_shasum="9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
+pkg_shasum=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
 pkg_upstream_url="https://github.com/google/googletest"
 pkg_dirname="${pkg_name}-release-${pkg_version}"
-
 pkg_deps=(
   core/gcc-libs
   core/glibc
@@ -22,7 +21,6 @@ pkg_build_deps=(
   core/make
   core/python2
 )
-
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib64)
 pkg_pconfig_dirs=(lib64/pkgconfig)
@@ -41,10 +39,6 @@ do_setup_environment() {
 
 do_prepare() {
   mkdir -p "${BUILD_DIR}"
-
-  # patch version as it is suppose to be 1.8.1
-  # ref: https://github.com/google/googletest/issues/1816
-  sed -e "s/GOOGLETEST_VERSION 1.9.0/GOOGLETEST_VERSION ${pkg_version}/" -i CMakeLists.txt
 }
 
 do_build() {
@@ -59,16 +53,16 @@ do_build() {
   popd || exit 1
 }
 
-do_check() {
-  pushd "${BUILD_DIR}" || exit 1
-  CTEST_OUTPUT_ON_FAILURE=1 make test -j"$(nproc --ignore=1)"
-  popd || exit 1
-}
-
 do_install() {
   pushd "${BUILD_DIR}" || exit 1
   make install
   popd || exit 1
 
   install -Dm644 LICENSE "${pkg_prefix}/share/licenses/license.txt"
+}
+
+do_check() {
+  pushd "${BUILD_DIR}" || exit 1
+  CTEST_OUTPUT_ON_FAILURE=1 make test -j"$(nproc --ignore=1)"
+  popd || exit 1
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab studio enter
DO_CHECK=1 build googletest
```

### Sample output

```
Test project /hab/cache/src/googletest-release-1.10.0/build
      Start  1: gmock-actions_test
 1/61 Test  #1: gmock-actions_test .........................   Passed    0.03 sec
      Start  2: gmock-cardinalities_test
 2/61 Test  #2: gmock-cardinalities_test ...................   Passed    0.01 sec
      Start  3: gmock_ex_test
 3/61 Test  #3: gmock_ex_test ..............................   Passed    0.01 sec
      Start  4: gmock-function-mocker_test
 4/61 Test  #4: gmock-function-mocker_test .................   Passed    0.01 sec
      Start  5: gmock-generated-actions_test
 5/61 Test  #5: gmock-generated-actions_test ...............   Passed    0.01 sec
      Start  6: gmock-generated-function-mockers_test
 6/61 Test  #6: gmock-generated-function-mockers_test ......   Passed    0.01 sec
      Start  7: gmock-generated-matchers_test
 7/61 Test  #7: gmock-generated-matchers_test ..............   Passed    0.01 sec
      Start  8: gmock-internal-utils_test
 8/61 Test  #8: gmock-internal-utils_test ..................   Passed    0.02 sec
      Start  9: gmock-matchers_test
 9/61 Test  #9: gmock-matchers_test ........................   Passed    1.11 sec
      Start 10: gmock-more-actions_test
10/61 Test #10: gmock-more-actions_test ....................   Passed    0.00 sec
      Start 11: gmock-nice-strict_test
11/61 Test #11: gmock-nice-strict_test .....................   Passed    0.01 sec
      Start 12: gmock-port_test
12/61 Test #12: gmock-port_test ............................   Passed    0.00 sec
      Start 13: gmock-spec-builders_test
13/61 Test #13: gmock-spec-builders_test ...................   Passed    0.02 sec
      Start 14: gmock_link_test
14/61 Test #14: gmock_link_test ............................   Passed    0.01 sec
      Start 15: gmock_test
15/61 Test #15: gmock_test .................................   Passed    0.01 sec
      Start 16: gmock_stress_test
16/61 Test #16: gmock_stress_test ..........................   Passed    0.20 sec
      Start 17: gmock-more-actions_no_exception_test
17/61 Test #17: gmock-more-actions_no_exception_test .......   Passed    0.00 sec
      Start 18: gmock_no_rtti_test
18/61 Test #18: gmock_no_rtti_test .........................   Passed    0.02 sec
      Start 19: googletest-death-test-test
19/61 Test #19: googletest-death-test-test .................   Passed    0.11 sec
      Start 20: gtest_environment_test
20/61 Test #20: gtest_environment_test .....................   Passed    0.01 sec
      Start 21: googletest-filepath-test
21/61 Test #21: googletest-filepath-test ...................   Passed    0.01 sec
      Start 22: googletest-listener-test
22/61 Test #22: googletest-listener-test ...................   Passed    0.01 sec
      Start 23: gtest_main_unittest
23/61 Test #23: gtest_main_unittest ........................   Passed    0.01 sec
      Start 24: googletest-message-test
24/61 Test #24: googletest-message-test ....................   Passed    0.01 sec
      Start 25: gtest_no_test_unittest
25/61 Test #25: gtest_no_test_unittest .....................   Passed    0.01 sec
      Start 26: googletest-options-test
26/61 Test #26: googletest-options-test ....................   Passed    0.01 sec
      Start 27: googletest-param-test-test
27/61 Test #27: googletest-param-test-test .................   Passed    0.02 sec
      Start 28: googletest-port-test
28/61 Test #28: googletest-port-test .......................   Passed    2.19 sec
      Start 29: gtest_pred_impl_unittest
29/61 Test #29: gtest_pred_impl_unittest ...................   Passed    0.02 sec
      Start 30: gtest_premature_exit_test
30/61 Test #30: gtest_premature_exit_test ..................   Passed    0.01 sec
      Start 31: googletest-printers-test
31/61 Test #31: googletest-printers-test ...................   Passed    0.02 sec
      Start 32: gtest_prod_test
32/61 Test #32: gtest_prod_test ............................   Passed    0.01 sec
      Start 33: gtest_repeat_test
33/61 Test #33: gtest_repeat_test ..........................   Passed    0.05 sec
      Start 34: gtest_sole_header_test
34/61 Test #34: gtest_sole_header_test .....................   Passed    0.01 sec
      Start 35: gtest_stress_test
35/61 Test #35: gtest_stress_test ..........................   Passed    0.14 sec
      Start 36: googletest-test-part-test
36/61 Test #36: googletest-test-part-test ..................   Passed    0.01 sec
      Start 37: gtest_throw_on_failure_ex_test
37/61 Test #37: gtest_throw_on_failure_ex_test .............   Passed    0.01 sec
      Start 38: gtest-typed-test_test
38/61 Test #38: gtest-typed-test_test ......................   Passed    0.01 sec
      Start 39: gtest_unittest
39/61 Test #39: gtest_unittest .............................   Passed    0.06 sec
      Start 40: gtest-unittest-api_test
40/61 Test #40: gtest-unittest-api_test ....................   Passed    0.01 sec
      Start 41: gtest_skip_in_environment_setup_test
41/61 Test #41: gtest_skip_in_environment_setup_test .......   Passed    0.01 sec
      Start 42: gtest_skip_test
42/61 Test #42: gtest_skip_test ............................   Passed    0.01 sec
      Start 43: gtest-death-test_ex_nocatch_test
43/61 Test #43: gtest-death-test_ex_nocatch_test ...........   Passed    0.01 sec
      Start 44: gtest-death-test_ex_catch_test
44/61 Test #44: gtest-death-test_ex_catch_test .............   Passed    0.01 sec
      Start 45: gtest_no_rtti_unittest
45/61 Test #45: gtest_no_rtti_unittest .....................   Passed    0.06 sec
      Start 46: googletest-break-on-failure-unittest
46/61 Test #46: googletest-break-on-failure-unittest .......   Passed    0.14 sec
      Start 47: gtest_skip_environment_check_output_test
47/61 Test #47: gtest_skip_environment_check_output_test ...   Passed    0.03 sec
      Start 48: googletest-catch-exceptions-test
48/61 Test #48: googletest-catch-exceptions-test ...........   Passed    0.05 sec
      Start 49: googletest-color-test
49/61 Test #49: googletest-color-test ......................   Passed    0.14 sec
      Start 50: googletest-env-var-test
50/61 Test #50: googletest-env-var-test ....................   Passed    0.13 sec
      Start 51: googletest-filter-unittest
51/61 Test #51: googletest-filter-unittest .................   Passed    0.69 sec
      Start 52: gtest_help_test
52/61 Test #52: gtest_help_test ............................   Passed    0.08 sec
      Start 53: googletest-list-tests-unittest
53/61 Test #53: googletest-list-tests-unittest .............   Passed    0.07 sec
      Start 54: googletest-output-test
54/61 Test #54: googletest-output-test .....................   Passed    0.17 sec
      Start 55: googletest-shuffle-test
55/61 Test #55: googletest-shuffle-test ....................   Passed    0.09 sec
      Start 56: googletest-throw-on-failure-test
56/61 Test #56: googletest-throw-on-failure-test ...........   Passed    0.06 sec
      Start 57: googletest-uninitialized-test
57/61 Test #57: googletest-uninitialized-test ..............   Passed    0.04 sec
      Start 58: gtest_xml_outfiles_test
58/61 Test #58: gtest_xml_outfiles_test ....................   Passed    0.07 sec
      Start 59: googletest-json-outfiles-test
59/61 Test #59: googletest-json-outfiles-test ..............   Passed    0.05 sec
      Start 60: gtest_xml_output_unittest
60/61 Test #60: gtest_xml_output_unittest ..................   Passed    0.10 sec
      Start 61: googletest-json-output-unittest
61/61 Test #61: googletest-json-output-unittest ............   Passed    0.07 sec

100% tests passed, 0 tests failed out of 61
```