### PR TITLE
[base-plans.txt] Add busybox to core plans

### DIFF
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -65,6 +65,7 @@ core-plans/unzip
 core-plans/rq
 core-plans/linux-headers-musl
 core-plans/musl
+core-plans/busybox
 core-plans/busybox-static
 core-plans/zlib-musl
 core-plans/bzip2-musl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

`busybox-static/plan.sh` sources `busybox/plan.sh` so i've added it to base plans.