### PR TITLE
[bind] Update bind to 9.15.6

### DIFF
--- a/bind/plan.sh
+++ b/bind/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=bind
 pkg_origin=core
-pkg_version=9.15.4
+pkg_version=9.15.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Versatile, Classic, Complete Name Server Software"
 pkg_upstream_url="https://www.isc.org/downloads/bind/"
 pkg_license=("MPL-2.0")
 pkg_source="https://ftp.isc.org/isc/bind9/${pkg_version}/bind-${pkg_version}.tar.gz"
-pkg_shasum=679288d6c42dc862afc69afbad53caf64c9565328623e710204e9b4b140eecb8
+pkg_shasum=0b0ebe2b4da531cf1f80be9e205213324968da4ac8ee844dbf0dfce65440c04e
 pkg_deps=(
   core/glibc
   core/libxml2
@@ -15,6 +15,7 @@ pkg_deps=(
   core/libcap
   core/busybox-static
   core/python
+  core/libuv
 )
 pkg_build_deps=(
   core/diffutils


### PR DESCRIPTION
I'm not sure how this compiled before since 9.15 requires libuv, but
I've added that since it fails early if the lib is missing.

```
[32][default:/src/bind/results:0]# bind --help
bind: bind [-lpsvPSVX] [-m keymap] [-f filename] [-q name] [-u name] [-r keyseq] [-x keyseq:shell-command] [keyseq:readline-function or readline-command]
    Set Readline key bindings and variables.

    Bind a key sequence to a Readline function or a macro, or set a
    Readline variable.  The non-option argument syntax is equivalent to
    that found in ~/.inputrc, but must be passed as a single argument:
    e.g., bind '"\C-x\C-r": re-read-init-file'.

    Options:
      -m  keymap         Use KEYMAP as the keymap for the duration of this
                         command.  Acceptable keymap names are emacs,
                         emacs-standard, emacs-meta, emacs-ctlx, vi, vi-move,
                         vi-command, and vi-insert.
      -l                 List names of functions.
      -P                 List function names and bindings.
      -p                 List functions and bindings in a form that can be
                         reused as input.
      -S                 List key sequences that invoke macros and their values
      -s                 List key sequences that invoke macros and their values
                         in a form that can be reused as input.
      -V                 List variable names and values
      -v                 List variable names and values in a form that can
                         be reused as input.
      -q  function-name  Query about which keys invoke the named function.
      -u  function-name  Unbind all keys which are bound to the named function.
      -r  keyseq         Remove the binding for KEYSEQ.
      -f  filename       Read key bindings from FILENAME.
      -x  keyseq:shell-command	Cause SHELL-COMMAND to be executed when
    				KEYSEQ is entered.
      -X                 List key sequences bound with -x and associated commands
                         in a form that can be reused as input.

    Exit Status:
    bind returns 0 unless an unrecognized option is given or an error occurs.
```

Signed-off-by: Tim Smith <tsmith@chef.io>