### PR TITLE
[caddy] Update caddy to 1.0.4

### DIFF
--- a/caddy/plan.sh
+++ b/caddy/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=caddy
 pkg_origin=core
-pkg_version=1.0.1
+pkg_version=1.0.4
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/caddyserver/caddy/releases/download/v${pkg_version}/caddy_v${pkg_version}_linux_amd64.tar.gz"
-pkg_shasum=4fd3ad67078c6b16e01ed2443bc8d7abf784a757de4177607e3cad2595db3caf
+pkg_shasum=9e7f37466cbfad53188f038b84ed4469645d3d0fc91f9206f7a54b36eee4b432
 pkg_description="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 pkg_upstream_url=https://caddyserver.com
 pkg_svc_run="caddy -conf ${pkg_svc_config_path}/Caddyfile"

--- a/caddy/tests/test.sh
+++ b/caddy/tests/test.sh
@@ -22,7 +22,7 @@ hab pkg install core/curl --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
 ci_ensure_supervisor_running
-ci_load_service "${TEST_PKG_IDENT}"
+ci_load_service "${TEST_PKG_IDENT}" 10
 
 bats "$(dirname "${0}")/test.bats"
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build caddy
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Basic config validation
 ✓ Service is running
 ✓ Listening on port 8080
 ✓ Simple cURL request

6 tests, 0 failures
```