### PR TITLE
[cerebro] Update cerebro to 0.8.5

### DIFF
--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cerebro
 pkg_origin=core
-pkg_version=0.8.4
+pkg_version=0.8.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Cerebro: Elasticsearch Administration"
 pkg_upstream_url="https://github.com/lmenezes/cerebro"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum=a36c5d4dd335bbf50fa19fe8efd3cb1c8cb49d7093f0486f06f5fd05c1397cbe
+pkg_shasum=97cdba6c0054f505c6ac72ca5ae010612c86385ac0f7f760cf512e5705a00a27
 pkg_deps=(
 	core/coreutils
 	core/openjdk11

--- a/cerebro/tests/test.sh
+++ b/cerebro/tests/test.sh
@@ -19,10 +19,11 @@ hab pkg install core/bats --binlink
 hab pkg install core/curl --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 
-ci_ensure_supervisor_running
-ci_load_service "${TEST_PKG_IDENT}"
+WAIT_SECONDS=10
 
-WAIT_SECONDS=5
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}" "${WAIT_SECONDS}"
+
 echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
 sleep "${WAIT_SECONDS}"
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build cerebro
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Service is running
 ✓ Version matches

2 tests, 0 failures
```