### PR TITLE
[cmake] Update cmake to 3.16.0

### DIFF
--- a/cmake/plan.ps1
+++ b/cmake/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="cmake"
 $pkg_origin="core"
-$base_version="3.13"
-$pkg_version="$base_version.2"
+$base_version="3.16"
+$pkg_version="$base_version.0"
 $pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 $pkg_upstream_url="https://cmake.org/"
 $pkg_license=@("BSD-3-Clause")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="http://cmake.org/files/v$base_version/cmake-$pkg_version-win64-x64.msi"
-$pkg_shasum="c680993e59e0547d0161e43587530acdb2e5c3f5dd8a1a17be18b60e1617b5be"
+$pkg_shasum="067b1d3b203e0cb7da3549c2e04986e8eed0bd7002f14731569e3aae3d1f81f0"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/cmake/plan.sh
+++ b/cmake/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cmake
 pkg_origin=core
-_base_version=3.13
-pkg_version=${_base_version}.2
+_base_version=3.16
+pkg_version=${_base_version}.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('BSD-3-Clause')
 pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 pkg_upstream_url="https://cmake.org/"
 pkg_source="https://cmake.org/files/v${_base_version}/cmake-${pkg_version}.tar.gz"
-pkg_shasum=c925e7d2c5ba511a69f43543ed7b4182a7d446c274c7480d0e42cd933076ae25
+pkg_shasum=6da56556c63cab6e9a3e1656e8763ed4a841ac9859fefb63cbe79472e67e8c5f
 pkg_deps=(
   core/glibc
   core/gcc-libs


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build cmake
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches plan

1 test, 0 failures
```