### PR TITLE
[ansible] Test fix for buildkite failure

### DIFF
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=ansible
 pkg_origin=core
-pkg_version=2.8.6
+pkg_version=2.9.1
 pkg_description="Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy."
 pkg_upstream_url="https://www.ansible.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-only")
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=94c96aaf781417c073b340381c83992e4880f2a660b46888530909bc7c57ef71
+pkg_shasum=087a7644890e27c26171b0d24fc5d64024f12201ffb81d222aaa5704987e4c12
 pkg_deps=(
   core/libffi
   core/python2

--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -16,6 +16,7 @@ pkg_deps=(
 )
 pkg_build_deps=(
   core/gcc
+  core/cacerts
   core/libyaml
   core/make
 )
@@ -26,6 +27,7 @@ do_setup_environment() {
   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
   push_runtime_env ANSIBLE_CONFIG "${pkg_prefix}/etc/ansible.cfg"
   push_buildtime_env LD_LIBRARY_PATH "$(pkg_path_for libffi)/lib"
+  push_buildtime_env SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
 }
 
 do_prepare() {


### PR DESCRIPTION
Hi @predominant.  I'm testing out a possible fix for your core/ansible PR #3134.  Waiting to see if the buildkite build passes on this, and it did...

The hab team made me aware of a recent [issue](https://github.com/habitat-sh/habitat/issues/7219) where the SSL_CERT_FILE gets set to an invalid value.  My workaround was to:

```diff
--- a/ansible/plan.sh
+++ b/ansible/plan.sh
@@ -16,6 +16,7 @@ pkg_deps=(
 )
 pkg_build_deps=(
   core/gcc
+  core/cacerts
   core/libyaml
   core/make
 )
@@ -26,6 +27,7 @@ do_setup_environment() {
   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
   push_runtime_env ANSIBLE_CONFIG "${pkg_prefix}/etc/ansible.cfg"
   push_buildtime_env LD_LIBRARY_PATH "$(pkg_path_for libffi)/lib"
+  push_buildtime_env SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
 }

 do_prepare() {
```