### PR TITLE
[base-plans.txt] Update base-plans.txt to ensure full path to habitat plan file

### DIFF
--- a/base-plans.txt
+++ b/base-plans.txt
@@ -74,12 +74,8 @@ core-plans/libsodium-musl
 core-plans/openssl-musl
 core-plans/libarchive-musl
 core-plans/rust
-habitat/components/hab
 core-plans/bats
-habitat/components/plan-build
 core-plans/vim
 core-plans/libbsd
 core-plans/clens
 core-plans/mg
-habitat/components/backline
-habitat/components/studio


### PR DESCRIPTION
### Outstanding Tasks
- [x] Remove the habitat components from the base-plans.txt.  NOTE: The refresh build fails if Builder does not also contain the habitat packages so explicitly add them to the refresh build setup.
- [x] Fix the refresh code (https://github.com/chef-partners/habitat-coreplan-refresher/pull/21) to explicitly load the following into the local Builder instance.
```bash
habitat/components/hab/habitat
habitat/components/plan-build/habitat
habitat/components/backline/habitat
habitat/components/studio/habitat
```
)and verify a refresh build from scratch
- [x] Update the PR removing the habitat components

### Context 

An example of an automated Builder setup is defined [here](https://github.com/chef-partners/habitat-coreplan-refresher).  In order to do baseplan refresh, this Builder must be setup with just-enough packages to enable all the building of the baseplans.  One way to achieve this has been to:  
- source all of the packages in the core-plans/base-plans.txt file to obtain a list of all $pkg_deps **AND** $pkg_build_deps defined for every baseplan.  Using this sorted and de-duped list of dependencies...
- ``hab pkg download`` all necessary artefacts, not only the dependencies for runtime but also for buildtime.  NOTE: the list of both $pkg_build_deps and $pkg_deps is necessary since ``hab pkg download`` only downloads the $pkg_deps for a given plan.  For example ``hab pkg download core/wget`` will only download ``pkg_deps=( core/cacerts  core/glibc  core/openssl  core/pcre  core/zlib )`` not also ``pkg_build_deps=(  core/coreutils  core/diffutils  core/flex  core/gcc  core/gettext  core/grep  ore/make  core/patch  core/perl  core/pkg-config  core/sed )``.  An attempt therefore to build core/wget using a clean Builder instance will fail if its $pkg_build_deps are not also present as well as the $pkg_deps.  

During the process of building up the full list of $pkg_deps and $pkg_build_deps for all plans in the base-plans.txt it was discovered that the paths defined for habitat do not contain a plan.sh as do all the other core-plan paths.  As well multiple plan.sh files lived beneath each habitat directory.

To fix this problem with the habitat baseplan entries and to ensure a successful sourcing of each plan, each of the habitat plans in base-plans.txt were corrected to be the exact directory where the plan.sh lives.

With this change, the automated refresh process works successfully.