### PR TITLE
Add workaround to studio ssl issue

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -45,6 +45,13 @@ echo "--- :key: Generating fake origin key"
 # we won't have access to any valid signing keys.
 hab origin key generate "$HAB_ORIGIN"
 
+echo "--- Installing the studio" 
+# Work around https://github.com/habitat-sh/habitat/issues/7219
+# This will ensure the correct version of the studio for the `hab` 
+# on our path is installed, and provide some informational output
+# about what version we intend to use. 
+hab studio version
+
 # We want to ensure that we build from the project root. This
 # creates a subshell so that the cd will only affect that process
 project_root="$(git rev-parse --show-toplevel)"

--- a/bin/ci/verify-pr-build.sh
+++ b/bin/ci/verify-pr-build.sh
@@ -44,6 +44,12 @@ echo "--- :key: Generating fake origin key"
 # we won't have access to any valid signing keys. j
 hab origin key generate "$HAB_ORIGIN"
 
+echo "--- Installing the studio" 
+# Work around https://github.com/habitat-sh/habitat/issues/7219
+# This will ensure the correct version of the studio for the `hab` 
+# on our path is installed, and provide some informational output
+# about what version we intend to use. 
+hab studio version
 
 echo "--- :construction: Starting build for $plan"
 # Build with DO_CHECK=true.


### PR DESCRIPTION
@gavindidrichsen @predominant  This provides a workaround to the studio ssl issue caused by https://github.com/habitat-sh/habitat/issues/7219 until https://github.com/habitat-sh/habitat/pull/7259 lands. 

I've added a whitespace commit to a plan known to trigger the issue (ansible) to verify the workaround is functioning. That commit can be removed 