### PR TITLE
[go] Upgrade go to 1.13.5

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=go
 pkg_origin=core
-pkg_version=1.13.1
+pkg_version=1.13.5
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://storage.googleapis.com/golang/go${pkg_version}.src.tar.gz"
-pkg_shasum=81f154e69544b9fa92b1475ff5f11e64270260d46e7e36c34aafc8bc96209358
+pkg_shasum=27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff
 pkg_dirname=go
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
Minor bug fixes:

https://golang.org/doc/devel/release.html#go1.13.minor

Signed-off-by: Steven Danna <steve@chef.io>