### PR TITLE
Update node to 12.13.1

### DIFF
--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="12.9.0"
+$pkg_version="12.13.1"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="7e6c6855fc4eb44b95a033f4ad8d73d7823388dd01ceb98a91eb68a7625323f3"
+$pkg_shasum="b0b4fcae7531a0509fc1f29e814ea59487c38787df671e6bc04b17ee355b24f3"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node/plan.sh
+++ b/node/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=node
 pkg_origin=core
-pkg_version=12.9.0
+pkg_version=12.13.1
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_upstream_url=https://nodejs.org/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=88cb425086a87323288c8389e974e8c1001b81fe11c529e64592e8feb2d12f93
+pkg_shasum=4ee710087687c8de142329d95085f5cba66e454a2c9ea7ec11e1f4b476d6d1ac
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/node12/plan.ps1
+++ b/node12/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node12"
 $pkg_origin="core"
-$pkg_version="12.9.0"
+$pkg_version="12.13.1"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="7e6c6855fc4eb44b95a033f4ad8d73d7823388dd01ceb98a91eb68a7625323f3"
+$pkg_shasum="b0b4fcae7531a0509fc1f29e814ea59487c38787df671e6bc04b17ee355b24f3"

--- a/node12/plan.sh
+++ b/node12/plan.sh
@@ -2,11 +2,11 @@ source "../node/plan.sh"
 
 pkg_name=node12
 pkg_origin=core
-pkg_version=12.9.0
+pkg_version=12.13.1
 pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 pkg_license=('MIT')
 pkg_upstream_url=https://nodejs.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://nodejs.org/dist/v${pkg_version}/node-v${pkg_version}.tar.gz"
-pkg_shasum=88cb425086a87323288c8389e974e8c1001b81fe11c529e64592e8feb2d12f93
+pkg_shasum=4ee710087687c8de142329d95085f5cba66e454a2c9ea7ec11e1f4b476d6d1ac
 pkg_dirname="node-v${pkg_version}"


### PR DESCRIPTION
## Description

At the time of this commit, 12.13.x brings node into the "active LTS" phase, so suitable for production use.

SHAs extracted from:
https://nodejs.org/download/release/v12.13.1/SHASUMS256.txt

General Reference:
https://nodejs.org/en/about/releases/


## Testing
```
hab pkg build node
source results/last_build.env
hab studio run "./node/tests/test.sh ${pkg_ident}"
```

## Output
```
ok 1 Version matches
ok 2 Help Command
```