### PR TITLE
[envconsul] Update envconsul to 0.9.1

### DIFF
--- a/envconsul/plan.sh
+++ b/envconsul/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=envconsul
 pkg_origin=core
-pkg_version=0.8.0
+pkg_version=0.9.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MPL-2.0")
 pkg_description="Launch a subprocess with environment variables using data from @HashiCorp Consul and Vault."
 pkg_upstream_url=https://github.com/hashicorp/envconsul
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum="d8b07773407e45480ce1b4e440d87c0d776afa49099a5f43a88510ef0c20c523"
+pkg_shasum=bb9e9b786870dd19ef1ac9afebb37695da2f6d192a5320a351d6d398a29417a2
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_build_deps=(core/unzip)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build envconsul
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```
