### PR TITLE
[gifsicle] Update gifsicle to 1.92, and modernize tests

### DIFF
--- a/gifsicle/plan.sh
+++ b/gifsicle/plan.sh
@@ -1,13 +1,24 @@
 pkg_name=gifsicle
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_origin=core
-pkg_version=1.91
-pkg_license=('GPLv2')
+pkg_version=1.92
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://www.lcdf.org/gifsicle/gifsicle-${pkg_version}.tar.gz
-pkg_shasum=0a4ee602aa244cdcdd86a250a6b39c94d8343cf526b8fae862d8a0efc337a800
-pkg_bin_dirs=(bin)
-pkg_deps=(core/zlib core/glibc)
-pkg_build_deps=(core/zlib core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/glibc)
+pkg_license=('GPL-2.0-only')
 pkg_description="Gifsicle is a command-line tool for creating, editing, and getting information about GIF images and animations."
 pkg_upstream_url="https://www.lcdf.org/gifsicle/"
+pkg_source="https://www.lcdf.org/gifsicle/gifsicle-${pkg_version}.tar.gz"
+pkg_shasum=5ab556c01d65fddf980749e3ccf50b7fd40de738b6df679999294cc5fabfce65
+pkg_bin_dirs=(bin)
+pkg_deps=(
+  core/zlib
+  core/glibc
+)
+pkg_build_deps=(
+  core/zlib
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/glibc
+)

--- a/gifsicle/tests/test.bats
+++ b/gifsicle/tests/test.bats
@@ -1,15 +1,11 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Command is on path" {
-  [ "$(command -v gifsicle)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(gifsicle --version | head -1 | awk '{print $3}')"
-  [ "$result" = "${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} gifsicle --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help Command Check" {
-  run gifsicle --help
+  run hab pkg exec ${TEST_PKG_IDENT} gifsicle --help
   [ $status -eq 0 ]
 }

--- a/gifsicle/tests/test.sh
+++ b/gifsicle/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build gifsicle
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help Command Check

2 tests, 0 failures
```
