### PR TITLE
[python] Add Python 3.8, Update 3.7, restructure for new builds, add tests

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1235,15 +1235,23 @@ paths = [
 [python35]
 plan_path = "python35"
 paths = [
-  "python/*"
+  "python/*",
+  "python34/*"
 ]
 [python36]
 plan_path = "python36"
 paths = [
-  "python/*"
+  "python/*",
+  "python34/*"
 ]
 [python37]
 plan_path = "python37"
+paths = [
+  "python/*",
+  "python34/*"
+]
+[python38]
+plan_path = "python38"
 paths = [
   "python/*"
 ]

--- a/python/plan.ps1
+++ b/python/plan.ps1
@@ -1,5 +1,5 @@
 $pkg_name="python"
-$pkg_version="3.7.3"
+$pkg_version="3.8.1"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')

--- a/python/plan.sh
+++ b/python/plan.sh
@@ -1,21 +1,23 @@
 pkg_name=python
 pkg_distname=Python
-pkg_version=3.7.0
+pkg_version=3.8.1
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
 pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
-pkg_upstream_url="https://www.python.org"
+pkg_upstream_url=https://www.python.org
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
-
+pkg_shasum=c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-pkg_interpreters=(bin/python bin/python3 bin/python3.7)
-
+pkg_interpreters=(
+  bin/python
+  bin/python3
+  bin/python3.8
+)
 pkg_deps=(
   core/bzip2
   core/expat
@@ -29,7 +31,6 @@ pkg_deps=(
   core/sqlite
   core/zlib
 )
-
 pkg_build_deps=(
   core/coreutils
   core/diffutils
@@ -40,21 +41,21 @@ pkg_build_deps=(
 )
 
 do_prepare() {
-  sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
-  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+  sed -i.bak 's/#zlib/zlib/' Modules/Setup
+  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup
 }
 
 do_build() {
   export LDFLAGS="$LDFLAGS -lgcc_s"
-
   # TODO: We should build with `--enable-optimizations`
-  ./configure --prefix="$pkg_prefix" \
-              --enable-loadable-sqlite-extensions \
-              --enable-shared \
-              --with-threads \
-              --with-system-expat \
-              --with-system-ffi \
-              --with-ensurepip
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-loadable-sqlite-extensions \
+    --enable-shared \
+    --with-threads \
+    --with-system-expat \
+    --with-system-ffi \
+    --with-ensurepip
 
   make
 }

--- a/python/tests/test-hello-world.py
+++ b/python/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python/tests/test.bats
+++ b/python/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python/tests/test.sh
+++ b/python/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -14,19 +14,28 @@ pkg_description="Python is a programming language that lets you work quickly \
 pkg_upstream_url="https://www.python.org"
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db"
+pkg_shasum=18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db
+pkg_interpreters=(
+  bin/python
+  bin/python2
+  bin/python2.7
+)
 
-pkg_interpreters=(bin/python bin/python2 bin/python2.7)
+do_prepare() {
+  sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
+  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+}
 
 do_build() {
     # TODO: We should build with `--enable-optimizations`
-    ./configure --prefix="$pkg_prefix" \
-                --enable-shared \
-                --enable-unicode=ucs4 \
-                --with-threads \
-                --with-system-expat \
-                --with-system-ffi \
-                --with-ensurepip
+    ./configure \
+      --prefix="${pkg_prefix}" \
+      --enable-shared \
+      --enable-unicode=ucs4 \
+      --with-threads \
+      --with-system-expat \
+      --with-system-ffi \
+      --with-ensurepip
 
     make
 }

--- a/python2/tests/test-hello-world.py
+++ b/python2/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python2/tests/test.bats
+++ b/python2/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version 2>&1 | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python2/tests/test.sh
+++ b/python2/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python34/tests/test-hello-world.py
+++ b/python34/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python34/tests/test.bats
+++ b/python34/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python34/tests/test.sh
+++ b/python34/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python35/plan.sh
+++ b/python35/plan.sh
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148,SC1091
-source ../python/plan.sh
+source ../python34/plan.sh
 
 pkg_name=python35
 pkg_distname=Python
@@ -9,9 +9,12 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
 pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
-pkg_upstream_url="https://www.python.org"
+pkg_upstream_url=https://www.python.org
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5"
-
-pkg_interpreters=(bin/python bin/python3 bin/python3.5)
+pkg_shasum=2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5
+pkg_interpreters=(
+  bin/python
+  bin/python3
+  bin/python3.5
+)

--- a/python35/tests/test-hello-world.py
+++ b/python35/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python35/tests/test.bats
+++ b/python35/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python35/tests/test.sh
+++ b/python35/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python36/plan.sh
+++ b/python36/plan.sh
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148,SC1091
-source ../python/plan.sh
+source ../python34/plan.sh
 
 pkg_name=python36
 pkg_distname=Python
@@ -9,9 +9,12 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
 pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
-pkg_upstream_url="https://www.python.org"
+pkg_upstream_url=https://www.python.org
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58"
-
-pkg_interpreters=(bin/python bin/python3 bin/python3.6)
+pkg_shasum=7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58
+pkg_interpreters=(
+  bin/python
+  bin/python3
+  bin/python3.6
+)

--- a/python36/tests/test-hello-world.py
+++ b/python36/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python36/tests/test.bats
+++ b/python36/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python36/tests/test.sh
+++ b/python36/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python37/plan.sh
+++ b/python37/plan.sh
@@ -1,17 +1,20 @@
 # shellcheck disable=SC2148,SC1091
-source ../python/plan.sh
+source ../python34/plan.sh
 
 pkg_name=python37
 pkg_distname=Python
-pkg_version=3.7.0
+pkg_version=3.7.6
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
 pkg_description="Python is a programming language that lets you work quickly \
   and integrate systems more effectively."
-pkg_upstream_url="https://www.python.org"
+pkg_upstream_url=https://www.python.org
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
-
-pkg_interpreters=(bin/python bin/python3 bin/python3.7)
+pkg_shasum=aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114
+pkg_interpreters=(
+  bin/python
+  bin/python3
+  bin/python3.7
+)

--- a/python37/tests/test-hello-world.py
+++ b/python37/tests/test-hello-world.py
@@ -1,0 +1,1 @@
+print('Hello World')

--- a/python37/tests/test.bats
+++ b/python37/tests/test.bats
@@ -1,0 +1,17 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python --version | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} python --help
+  [ "$status" -eq 0 ]
+}
+
+@test "Basic hello world" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} python ${BATS_TEST_DIRNAME}/test-hello-world.py)"
+  [ $? -eq 0 ]
+  [ "$result" = "Hello World" ]
+}

--- a/python37/tests/test.sh
+++ b/python37/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"

--- a/python38/README.md
+++ b/python38/README.md
@@ -1,0 +1,18 @@
+# python38
+
+Python is a programming language that lets you work quickly and integrate systems more effectively.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+```
+hab pkg install core/python38
+hab pkg exec core/python38 python
+```

--- a/python38/plan.ps1
+++ b/python38/plan.ps1
@@ -1,7 +1,7 @@
 . ../python/plan.ps1
 
 $pkg_name="python37"
-$pkg_version="3.7.6"
+$pkg_version="3.8.1"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')

--- a/python38/plan.sh
+++ b/python38/plan.sh
@@ -1,9 +1,9 @@
 # shellcheck disable=SC2148,SC1091
 source ../python/plan.sh
 
-pkg_name=python34
+pkg_name=python38
 pkg_distname=Python
-pkg_version=3.4.8
+pkg_version=3.8.1
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
@@ -12,14 +12,9 @@ pkg_description="Python is a programming language that lets you work quickly \
 pkg_upstream_url=https://www.python.org
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum=8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639
+pkg_shasum=c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb
 pkg_interpreters=(
   bin/python
   bin/python3
-  bin/python3.4
+  bin/python3.8
 )
-
-do_prepare() {
-  sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
-  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
-}


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This consolidates updates and restructuring due to a minor change in the build process of Python 3.8.

New plan build dependency:

* python2 -> python
* python34 -> python
* python35 -> python34 (changed)
* python36 -> python34 (changed)
* python37 -> python34 (changed)
* python38 -> python (new)

This also unifies Windows and linux version for Python 3.7

### Testing

```
build python2; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python34; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python35; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python36; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python37; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python38; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
build python; source results/last_build.env; ./${pkg_name}/tests/test.sh ${pkg_ident}
```

### Sample output (all versions)

```
 ✓ Version matches
 ✓ Help command
 ✓ Basic hello world

3 tests, 0 failures
```