### PR TITLE
[nginx] Update nginx to 1.17.7

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.17.4"
+$pkg_version="1.17.7"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="4101197c88ea11f609a665bffbed3ee13ced345f51b711a61a30328b66381c44"
+$pkg_shasum="da3ce8b96fae331e16aef120382d95864ea8f82d86cd1a03dd3d05a426198057"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.17.4
+pkg_version=1.17.7
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=62854b365e66670ef4f1f8cc79124f914551444da974207cd5fe22d85710e555
+pkg_shasum=b62756842807e5693b794e5d0ae289bd8ae5b098e66538b2a91eb80f25c591ff
 pkg_deps=(
   core/glibc
   core/libedit

--- a/nginx/tests/test.sh
+++ b/nginx/tests/test.sh
@@ -22,7 +22,7 @@ hab pkg binlink core/busybox-static ps
 hab pkg install "${TEST_PKG_IDENT}"
 
 ci_ensure_supervisor_running
-ci_load_service "${TEST_PKG_IDENT}"
+ci_load_service "${TEST_PKG_IDENT}" 10
 
 # Allow service start
 WAIT_SECONDS=5


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This PR addresses [CVE-2019-20372](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20372).

### Testing

```
hab pkg build nginx
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

6 tests, 0 failures
```