### PR TITLE
[sbt] Update sbt to 1.3.7

### DIFF
--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=sbt
-pkg_version=1.3.0
+pkg_version=1.3.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A build tool for Scala, Java, and more"
 pkg_upstream_url="https://www.scala-sbt.org"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz"
-pkg_shasum=c9bc6bcbbe7a65773f4526ad5613d93f220ce21bd2456c3cf35363c4cdd52648
+pkg_shasum=813d4a3b7d2f9d8e5585d959fd5bc389c999770d5b6f2b9c313cc009f7729814
 pkg_deps=(
   core/coreutils
   core/openjdk11


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build sbt
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ sbt matches version 1.3.7

1 test, 0 failures
```
