### PR TITLE
[jenkins] Update jenkins to 2.204.1

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.190.2
+pkg_version=2.204.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum=47620a00004af5634e45904149897fe4a36b0463ec691bfabc2086779f90f127
+pkg_shasum=12b9ebbf9eb1cd1deab0d11512511bcd80a5d3a754dffab54dd6385d788d5284
 pkg_deps=(
   core/openjdk11
   core/curl

--- a/jenkins/tests/test.sh
+++ b/jenkins/tests/test.sh
@@ -28,7 +28,7 @@ hab pkg binlink core/iproute2 ip
 hab pkg install "${TEST_PKG_IDENT}"
 
 ci_ensure_supervisor_running
-ci_load_service "${TEST_PKG_IDENT}"
+ci_load_service "${TEST_PKG_IDENT}" 10
 
 # wait for the service to start
 DEFAULT_INTERFACE="$(ip route list | grep "default"  | awk '{print $5}')"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build jenkins
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ jenkins binary version matches 2.204.1
 ✓ Service is running
 ✓ Listening on port 80 (HTTP)

3 tests, 0 failures
```
