### PR TITLE
[nginx] Update nginx to 1.17.8

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.17.7"
+$pkg_version="1.17.8"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="da3ce8b96fae331e16aef120382d95864ea8f82d86cd1a03dd3d05a426198057"
+$pkg_shasum="de82e682a147da48e0cd8c4c2a905d69ddb8836cdbbe04d630e69c7a410fdfe1"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port="http.listen.port"}
 $pkg_exposes=@('port')

--- a/nginx/plan.sh
+++ b/nginx/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.17.7
+pkg_version=1.17.8
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=b62756842807e5693b794e5d0ae289bd8ae5b098e66538b2a91eb80f25c591ff
+pkg_shasum=97d23ecf6d5150b30e284b40e8a6f7e3bb5be6b601e373a4d013768d5a25965b
 pkg_deps=(
   core/glibc
   core/libedit

--- a/nginx/tests/test.sh
+++ b/nginx/tests/test.sh
@@ -21,11 +21,11 @@ hab pkg binlink core/busybox-static netstat
 hab pkg binlink core/busybox-static ps
 hab pkg install "${TEST_PKG_IDENT}"
 
-ci_ensure_supervisor_running
-ci_load_service "${TEST_PKG_IDENT}" 10
+WAIT_SECONDS=10
 
-# Allow service start
-WAIT_SECONDS=5
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}" "${WAIT_SECONDS}"
+
 echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
 sleep "${WAIT_SECONDS}"
 


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build nginx
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single master process
 ✓ Multiple worker processes
 ✓ Listening on port 80

6 tests, 0 failures
```