### PR TITLE
[mage] Update mage to 1.9.0, update tests

### DIFF
--- a/mage/plan.sh
+++ b/mage/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=mage
 pkg_origin=core
-pkg_version="1.7.1"
+pkg_version=1.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets."
 pkg_source="https://github.com/magefile/mage"
-pkg_upstream_url="https://magefile.org/"
+pkg_upstream_url=https://magefile.org/
 pkg_scaffolding="core/scaffolding-go"
 pkg_bin_dirs=(bin)
 

--- a/mage/tests/test.bats
+++ b/mage/tests/test.bats
@@ -1,30 +1,18 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
-@test "Binlink dependencies" {
-  run hab pkg binlink core/go
-  [ $status -eq 0 ]
-
-  run hab pkg binlink core/git
-  [ $status -eq 0 ]
-}
-
-@test "Command is on path" {
-  [ "$(command -v mage)" ]
-}
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(mage --version 2>&1 | head -1)"
-  [ "${result}" = "Mage Build Tool v${pkg_version}" ]
+  result="$(hab pkg exec ${TEST_PKG_IDENT} mage --version 2>&1 | head -1)"
+  [ "${result}" = "Mage Build Tool v${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run mage --help
+  run hab pkg exec ${TEST_PKG_IDENT} mage --help
   [ $status -eq 0 ]
 }
 
 @test "Mage init works" {
   [ ! -f magefile.go ]
-  mage -init
+  hab pkg exec ${TEST_PKG_IDENT} mage -init
   [ -f magefile.go ]
   rm -f magefile.go
 }

--- a/mage/tests/test.sh
+++ b/mage/tests/test.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
 
-hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
 fi
 
-bats "${TESTDIR}/test.bats"
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build mage
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Mage init works

3 tests, 0 failures
```
