### PR TITLE
Upgrading Consul to 1.6.2 and updated CI tests

### DIFF
--- a/bin/ci/test_helpers.sh
+++ b/bin/ci/test_helpers.sh
@@ -43,7 +43,7 @@ ci_ensure_supervisor_running() {
 # period has passed.
 ci_load_service() {
   service="$1"
-  timeout="${2:-5}"
+  timeout="${2:-10}"
 
   echo "--- :habicat: Loading service $service"
   hab svc load "$service"

--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.6.1
+pkg_version=1.6.2
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=a8568ca7b6797030b2c32615b4786d4cc75ce7aee2ed9025996fe92b07b31f7e
+pkg_shasum=78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Hello all,

This PR updates Consul to version 1.6.2.

To test this, please run

```
hab pkg build consul
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

The results should be:
```
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```

As a side note @predominant , I updated the test_helpers.sh ci_load_service() to a longer timeout. 5 was too fast and the service could not load in that time. I changed it to 10. Let me know what you think :)

Please let me know if there are any questions or comments. Thanks! 