### PR TITLE
[Vault] Upgrading Vault to 1.3.2

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=1.2.1
+pkg_version=1.3.2
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_upstream_url=https://www.vaultproject.io/
 pkg_source="https://releases.hashicorp.com/vault/${pkg_version}/vault_${pkg_version}_linux_amd64.zip"
-pkg_shasum=df14077600df745adf2450f9ea489cf6935352919b27b0367361379460e3b43e
+pkg_shasum=6e72132de0421b74d909f50be1823fe57182694c4268ba9a38c31213d9497ec9
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Hello all,

This PR updates vault to version 1.3.2.

To test this, please run
```
hab pkg build vault
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```
The results should be:
```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ A single process
 ✓ Listening on ports 8200, 8201
 ✓ Good response from /sys/health endpoint

6 tests, 0 failures
```

Please let me know if there are any questions or comments. Thanks! 