### PR TITLE
[sqlite] Update sqlite to 3.31.1, change version spec, add tests

### DIFF
--- a/sqlite/plan.sh
+++ b/sqlite/plan.sh
@@ -1,16 +1,24 @@
 pkg_name=sqlite
-pkg_version=3130000
+pkg_version=3.31.1
+pkg_dist_version=3310100
 pkg_origin=core
 pkg_license=('Public Domain')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine."
 pkg_upstream_url=https://www.sqlite.org/
-pkg_source=https://www.sqlite.org/2016/${pkg_name}-autoconf-${pkg_version}.tar.gz
-pkg_filename=${pkg_name}-autoconf-${pkg_version}.tar.gz
-pkg_dirname=${pkg_name}-autoconf-${pkg_version}
-pkg_shasum=e2797026b3310c9d08bd472f6d430058c6dd139ff9d4e30289884ccd9744086b
-pkg_deps=(core/glibc core/readline)
-pkg_build_deps=(core/gcc core/make core/coreutils)
+pkg_source="https://www.sqlite.org/2020/${pkg_name}-autoconf-${pkg_dist_version}.tar.gz"
+pkg_filename="${pkg_name}-autoconf-${pkg_dist_version}.tar.gz"
+pkg_dirname="${pkg_name}-autoconf-${pkg_dist_version}"
+pkg_shasum=62284efebc05a76f909c580ffa5c008a7d22a1287285d68b7825a2b6b51949ae
+pkg_deps=(
+  core/glibc
+  core/readline
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/coreutils
+)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)

--- a/sqlite/tests/test.bats
+++ b/sqlite/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} sqlite3 -version | head -1 | awk '{print $1}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/sqlite/tests/test.sh
+++ b/sqlite/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This fixes the version specification in the sqlite plan, adds a dist_version, and adds tests.