### PR TITLE
[nmap] Upgrading nmap to 7.80 and added tests

### DIFF
--- a/nmap/plan.sh
+++ b/nmap/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nmap
 pkg_origin=core
-pkg_version=7.70
+pkg_version=7.80
 pkg_description="nmap is a free security scanner for network exploration and security audits"
 pkg_upstream_url="https://nmap.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source="https://nmap.org/dist/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="847b068955f792f4cc247593aca6dc3dc4aae12976169873247488de147a6e18"
+pkg_shasum=fcfa5a0e42099e12e4bf7a68ebe6fde05553383a682e816a7ec9256ab4773faa
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/nmap/tests/test.bats
+++ b/nmap/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} nmap --version | grep version | awk '{print $3}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/nmap/tests/test.sh
+++ b/nmap/tests/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -euo pipefail
+
+source bin/ci/test_helpers.sh
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Hello all,

This PR updates nmap to version 7.80.

To test this, please run

```
hab pkg build nmap
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```
The results should be:

```
✓ Version matches

1 test, 0 failures
```

Please let me know if there are any questions or comments. Thanks! 