### PR TITLE
[inotify-tools] Update inotify-tools to 3.20.2.2, add tests, update upstream URL

### DIFF
--- a/inotify-tools/plan.sh
+++ b/inotify-tools/plan.sh
@@ -1,12 +1,15 @@
 pkg_origin=core
 pkg_name=inotify-tools
-pkg_version=3.14
+pkg_version=3.20.2.2
 pkg_description="inotify-tools is a C library and a set of command-line programs for Linux providing a simple interface to inotify. These programs can be used to monitor and act upon filesystem events."
-pkg_upstream_url=https://github.com/rvoicilas/inotify-tools/wiki
+pkg_upstream_url=https://github.com/inotify-tools/inotify-tools/wiki
 pkg_license=("GPL-2.0")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="http://github.com/downloads/rvoicilas/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=222bcca8893d7bf8a1ce207fb39ceead5233b5015623d099392e95197676c92f
+pkg_source="https://github.com/inotify-tools/inotify-tools/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=c5b018567814ea555d716f518b6e3ae243c733f7bd3e8585d81748a6da286f3c
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/gcc core/make)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
 pkg_bin_dirs=(bin)

--- a/inotify-tools/tests/test.bats
+++ b/inotify-tools/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} inotifywait --help | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/inotify-tools/tests/test.sh
+++ b/inotify-tools/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build inotify-tools
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches

1 test, 0 failures
```
