### PR TITLE
[memcached] Update memcached to 1.5.22

### DIFF
--- a/memcached/plan.sh
+++ b/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=memcached
-pkg_version=1.5.21
+pkg_version=1.5.22
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
-pkg_upstream_url="https://memcached.org/"
+pkg_upstream_url=https://memcached.org/
 pkg_license=('BSD-3-Clause')
 pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=e3d10c06db755b220f43d26d3b68d15ebf737a69c7663529b504ab047efe92f4
+pkg_shasum=c2b47e9d20575a2367087c229636ffc3fb699a6c3a7f3a22f44402f25f5f1f93
 pkg_deps=(
   core/glibc
   core/cyrus-sasl


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build memcached
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 11211
 ✓ Contains SASL support

5 tests, 0 failures
```

