### PR TITLE
[ruby27] Add Ruby 2.7

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1337,6 +1337,11 @@ plan_path = "ruby26"
 paths = [
   "ruby/*"
 ]
+[ruby27]
+plan_path = "ruby27"
+paths = [
+  "ruby/*"
+]
 [runc]
 plan_path = "runc"
 [runit]

--- a/ruby27/README.md
+++ b/ruby27/README.md
@@ -12,8 +12,8 @@ Binary package
 
 ## Usage
 
-hab pkg exec core/ruby26 ruby --help
+hab pkg exec core/ruby27 ruby --help
 
 You can add this as a build dependency to your plan with:
 
-pkg_build_deps=(core/ruby26)
+pkg_build_deps=(core/ruby27)

--- a/ruby27/README.md
+++ b/ruby27/README.md
@@ -1,4 +1,4 @@
-# ruby26
+# ruby27
 
 A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.
 

--- a/ruby27/plan.sh
+++ b/ruby27/plan.sh
@@ -1,0 +1,44 @@
+pkg_name=ruby27
+pkg_origin=core
+pkg_version=2.7.0
+pkg_description="A dynamic, open source programming language with a focus on \
+  simplicity and productivity. It has an elegant syntax that is natural to \
+  read and easy to write."
+pkg_license=("Ruby")
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://cache.ruby-lang.org/pub/ruby/2.7/ruby-${pkg_version}.tar.gz
+pkg_upstream_url=https://www.ruby-lang.org/en/
+pkg_shasum=8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe
+pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+pkg_interpreters=(bin/ruby)
+pkg_dirname="ruby-$pkg_version"
+
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O3 -g -pipe"
+  build_line "Setting CFLAGS='$CFLAGS'"
+}
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-shared \
+    --disable-install-doc \
+    --with-openssl-dir="$(pkg_path_for core/openssl)" \
+    --with-libyaml-dir="$(pkg_path_for core/libyaml)"
+
+  make
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  do_default_install
+  gem update --system --no-document
+  gem install rb-readline --no-document
+}

--- a/ruby27/tests/test.sh
+++ b/ruby27/tests/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -euo pipefail
+
+THIS_TEST_DIR="$(dirname "${0}")"
+
+source "${THIS_TEST_DIR}/../../ruby/tests/test.sh" "$1"


### PR DESCRIPTION
This is required for Chef Infra Client 16.0 development and should be considered a blocker for this quarters work.

Signed-off-by: Tim Smith <tsmith@chef.io>