### PR TITLE
[lz4] Update lz4 to 1.9.2, add tests

### DIFF
--- a/lz4/plan.sh
+++ b/lz4/plan.sh
@@ -1,10 +1,12 @@
 pkg_origin=core
 pkg_name=lz4
-pkg_version=1.9.1
+pkg_version=1.9.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2 Clause' 'GPL-2.0')
+pkg_upstream_url=http://lz4.github.io/lz4/
+pkg_description="Extremely Fast Compression algorithm http://www.lz4.org"
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=f8377c89dad5c9f266edc0be9b73595296ecafd5bfa1000de148096c50052dc4
+pkg_shasum=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/gcc
@@ -15,8 +17,6 @@ pkg_build_deps=(
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
-pkg_upstream_url=http://lz4.github.io/lz4/
-pkg_description="Extremely Fast Compression algorithm http://www.lz4.org"
 
 do_build () {
   make PREFIX="${pkg_prefix}"

--- a/lz4/tests/test.bats
+++ b/lz4/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result=$(hab pkg exec ${TEST_PKG_IDENT} lz4 --version | grep "v${TEST_PKG_VERSION}")
+  [ $? -eq 0 ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} lz4 --help
+  [ $status -eq 0 ]
+}

--- a/lz4/tests/test.sh
+++ b/lz4/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build lz4
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```
