### PR TITLE
[subversion] Update subversion to 1.13.0, add tests

### DIFF
--- a/subversion/plan.sh
+++ b/subversion/plan.sh
@@ -1,17 +1,19 @@
 pkg_name=subversion
-pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=1.9.4
+pkg_version=1.13.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Enterprise-class centralized version control for the masses"
 pkg_upstream_url=https://subversion.apache.org/
-pkg_source=https://archive.apache.org/dist/${pkg_distname}/${pkg_distname}-${pkg_version}.tar.bz2
-pkg_shasum=1267f9e2ab983f260623bee841e6c9cc458bf4bf776238ed5f100983f79e9299
+pkg_source="https://archive.apache.org/dist/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=bc50ce2c3faa7b1ae9103c432017df98dfd989c4239f9f8270bb3a314ed9e5bd
 pkg_deps=(
   core/gcc-libs
   core/serf
   core/zlib
+  core/lz4
+  core/utf8proc
+  core/sqlite
 )
 pkg_build_deps=(
   core/apr
@@ -22,14 +24,15 @@ pkg_build_deps=(
   core/make
   core/pkg-config
   core/python2
-  core/sqlite
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" --with-serf="$(pkg_path_for serf)"
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --with-serf="$(pkg_path_for serf)"
   make
 }
 

--- a/subversion/tests/test.bats
+++ b/subversion/tests/test.bats
@@ -1,0 +1,18 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  hab pkg exec ${TEST_PKG_IDENT} svn --version | head -1 | awk '{print $3}'
+  result=$(hab pkg exec ${TEST_PKG_IDENT} svn --version | head -1 | awk '{print $3}')
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} svn --help
+  [ $status -eq 0 ]
+}
+
+@test "Create repository" {
+  run hab pkg exec ${TEST_PKG_IDENT} svnadmin create ./test-repo
+  [ $status -eq 0 ]
+  rm -rf ./test-repo
+}

--- a/subversion/tests/test.sh
+++ b/subversion/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

* Update version
* Add tests
* requires #3218 to be merged and promoted first

### Testing

```
hab pkg build subversion
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Create repository

3 tests, 0 failures
```