### PR TITLE
[php] Correct pkg_deps

### DIFF
--- a/php/plan.sh
+++ b/php/plan.sh
@@ -24,7 +24,7 @@ pkg_deps=(
   core/zip
   core/zlib
   core/gcc-libs
-  rakops/oniguruma
+  core/oniguruma
   core/sqlite
 )
 pkg_build_deps=(


### PR DESCRIPTION
This corrects php's deps to only depend on core packages.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>