### PR TITLE
[bash] Update bash to 5.0.16 and add tests

### DIFF
--- a/bash/bash-patches.sh
+++ b/bash/bash-patches.sh
@@ -3,13 +3,22 @@ _patch_url_base="$_url_base/${_distname}-${_base_version}-patches/${_distname}${
 
 # All official patch file URLs
 _patch_files=(
-  "${_patch_url_base}"-001
-  "${_patch_url_base}"-002
-  "${_patch_url_base}"-003
-  "${_patch_url_base}"-004
-  "${_patch_url_base}"-005
-  "${_patch_url_base}"-006
-  "${_patch_url_base}"-007
+  "${_patch_url_base}-001"
+  "${_patch_url_base}-002"
+  "${_patch_url_base}-003"
+  "${_patch_url_base}-004"
+  "${_patch_url_base}-005"
+  "${_patch_url_base}-006"
+  "${_patch_url_base}-007"
+  "${_patch_url_base}-008"
+  "${_patch_url_base}-009"
+  "${_patch_url_base}-010"
+  "${_patch_url_base}-011"
+  "${_patch_url_base}-012"
+  "${_patch_url_base}-013"
+  "${_patch_url_base}-014"
+  "${_patch_url_base}-015"
+  "${_patch_url_base}-016"
 )
 
 # All official patch file shasums
@@ -21,4 +30,13 @@ _patch_shasums=(
   5bf54dd9bd2c211d2bfb34a49e2c741f2ed5e338767e9ce9f4d41254bf9f8276
   d68529a6ff201b6ff5915318ab12fc16b8a0ebb77fda3308303fcc1e13398420
   17b41e7ee3673d8887dd25992417a398677533ab8827938aa41fad70df19af9b
+  eec64588622a82a5029b2776e218a75a3640bef4953f09d6ee1f4199670ad7e3
+  ed3ca21767303fc3de93934aa524c2e920787c506b601cc40a4897d4b094d903
+  d6fbc325f0b5dc54ddbe8ee43020bced8bd589ddffea59d128db14b2e52a8a11
+  2c4de332b91eaf797abbbd6c79709690b5cbd48b12e8dfe748096dbd7bf474ea
+  2943ee19688018296f2a04dbfe30b7138b889700efa8ff1c0524af271e0ee233
+  f5d7178d8da30799e01b83a0802018d913d6aa972dd2ddad3b927f3f3eb7099a
+  5d6eee6514ee6e22a87bba8d22be0a8621a0ae119246f1c5a9a35db1f72af589
+  a517df2dda93b26d5cbf00effefea93e3a4ccd6652f152f4109170544ebfa05e
+  ffd1d7a54a99fa7f5b1825e4f7e95d8c8876bc2ca151f150e751d429c650b06d
 )

--- a/bash/plan.sh
+++ b/bash/plan.sh
@@ -2,7 +2,7 @@ pkg_name=bash
 _distname="$pkg_name"
 pkg_origin=core
 _base_version=5.0
-pkg_version=${_base_version}.7
+pkg_version=${_base_version}.16
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
  Bash is the GNU Project's shell. Bash is the Bourne Again SHell. Bash is an \
@@ -91,9 +91,9 @@ do_check() {
   # those as symlinks before the tests.
   local clean_cmds=()
   for cmd in /bin/rm /bin/cat /bin/touch /bin/chmod /usr/bin/printf /bin/echo; do
-    if [[ ! -r "$cmd" ]]; then
-      ln -sv "$(pkg_path_for coreutils)/bin/$(basename "$cmd")" "$cmd"
-      clean_cmds+=("$cmd")
+    if [[ ! -r "${cmd}" ]]; then
+      ln -sv "$(pkg_path_for coreutils)/bin/$(basename "${cmd}")" "${cmd}"
+      clean_cmds+=("${cmd}")
     fi
   done
 
@@ -101,7 +101,7 @@ do_check() {
 
   # Clean up any symlinks that were added to support the test suite.
   for cmd in "${clean_cmds[@]}"; do
-    rm -fv "$cmd"
+    rm -fv "${cmd}"
   done
 }
 

--- a/bash/tests/test.bats
+++ b/bash/tests/test.bats
@@ -1,3 +1,9 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "bash matches version ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" bash --version | grep -oP '(?<=GNU bash, version )([^(]*)' )"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}
+
 @test "can execute commands" {
   result="$(hab pkg exec ${TEST_PKG_IDENT} bash -c 'echo "$BASH"' )"
   [ "$result" == "/hab/pkgs/$TEST_PKG_IDENT/bin/bash" ]


### PR DESCRIPTION
Updating core/bash to latest patch level.  Still using refresh/2019q3 to manage refresh PRs.