### PR TITLE
[ed] Update to 1.16

### DIFF
--- a/ed/plan.sh
+++ b/ed/plan.sh
@@ -1,12 +1,12 @@
-pkg_name=ed
+pkg_name="ed"
 pkg_origin=core
-pkg_version=1.15
+pkg_version=1.16
 pkg_description="The standard text editor."
 pkg_upstream_url="https://www.gnu.org/software/ed/"
 pkg_license=('GPL-3.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ftp.gnu.org/gnu/ed/ed-${pkg_version}.tar.lz"
-pkg_shasum=ad4489c0ad7a108c514262da28e6c2a426946fb408a3977ef1ed34308bdfd174
+pkg_shasum=cfc07a14ab048a758473ce222e784fbf031485bcd54a76f74acfee1f390d8b2c
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/lzip core/diffutils)
 pkg_bin_dirs=(bin)

--- a/ed/tests/test.bats
+++ b/ed/tests/test.bats
@@ -1,0 +1,7 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} ed --version 2>&1 | head -1)"
+  [[ "$?" -eq 0 ]];
+  diff -u <(echo "${result}") <(echo "GNU ed ${TEST_PKG_VERSION}")
+}

--- a/ed/tests/test.sh
+++ b/ed/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
    ed: hab-plan-build cleanup
    ed:
    ed: Source Path: /hab/cache/src/ed-1.16
    ed: Installed Path: /hab/pkgs/ssd/ed/1.16/20200225003545
    ed: Artifact: /src/results/ssd-ed-1.16-20200225003545-x86_64-linux.hart
    ed: Build Report: /src/results/last_build.env
    ed: SHA256 Checksum: 7b178f8eaea3d26b59bace1f3d12aca2656b31aff9b27bd377bc3f28ec485f7d
    ed: Blake2b Checksum: a726f6a587dfee62078b26157ef21a3c2233aafafbca804b6816f574bf7c204f
    ed:
    ed: I love it when a plan.sh comes together.
    ed:
    ed: Build time: 0m24s
    [3][default:/src:0]# # /hab/pkgs/ssd/ed/1.16/20200225003545/bin/ed --version
    GNU ed 1.16
    Copyright (C) 1994 Andrew L. Moore.
    Copyright (C) 2020 Antonio Diaz Diaz.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
    This is free software: you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.

Changes:

* The substitute command no longer complains about an 'Infinite
  substitution loop' with a substitution like 's/^/#/g'. (Reported by
  Bjoern Wibben).
* The length limit of the prompt string has been removed. (Reported by
  Tim Chase).
* It has been documented in the manual that extended regular
  expression operators may be unavailable depending on the particular
  regex implementation installed in the system running ed. (Reported
  by Brian Zwahr).
* Several fixes and improvements have been made to the manual.

Signed-off-by: Steven Danna <steve@chef.io>