### PR TITLE
add example templates for test scripts

### DIFF
--- a/templates/tests/test.bats
+++ b/templates/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "version matches" {
+  # The most basic test checks that the program executes and matches
+  # the expected version. For example:
+  #
+  #     result="$(hab pkg exec ${TEST_PKG_IDENT} PROGRAM --version 2>&1 | head -1)"
+  #     [ "${result}" = "${TEST_PKG_VERSION}" ]
+  #
+  false
+}

--- a/templates/tests/test.sh
+++ b/templates/tests/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+    grep '^#/' < "${0}" | cut -c4-
+    exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Every time we ask a contributor to add tests for a package, they have
to decide which other package to copy/paste the base startup scripts
from. Since many of these scripts remain unmodified from their source,
we can get a sense of how common they are:

```
> shasum */tests/test.sh | awk '{print $2 "  " $1}' | sort -k2 | uniq -f1 -c | sort -r | head -10
  45 ansible/tests/test.sh  bb0f4fa2c77c76a8fbcb3c09b27f6dcd4f85bdc2
  44 buildkite-agent/tests/test.sh  7d9c73d735f91ae1e1ae6d884312d4a88630adc9
   7 R/tests/test.sh  113c3cfe60007d6e48734a0af618b080c7850176
   5 haproxy16/tests/test.sh  b77ba4890f5e93e01e2c2f4275b639aba55cb5a0
   5 crate/tests/test.sh  17419e6fdbb944d4bb67c964fc6f9df33c68a189
   5 7zip/tests/test.sh  bea68addea930ba8ecbdb31b1464ca66ca017f90
   4 grafana-loki/tests/test.sh  aaccd1d9ffd7c8d6086aaf6ee559281a67972c76
   3 ruby24/tests/test.sh  8a637e15c70508cd8db187fcde56448454495760
   3 pester/tests/test.sh  c729b513be381e51c6ad644a88ee7ab57b3a47ee
   3 filebeat/tests/test.sh  824dbbc5d6163a5b7ffcb24ecf8b35b88cf26baa
```

To make this easier going forward, this adds two "templates" that
people can copy when adding test to a package.

The template is based on the second most popular script because that
seems to be the one we are using more recently in the Git history.

Signed-off-by: Steven Danna <steve@chef.io>