### PR TITLE
[consul] Update consul to 1.7.1

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.6.2
+pkg_version=1.7.1
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=78d127e5b8edd310c3f9f89487fb833a5c7bcb4e09cb731a4d39100fc53b38be
+pkg_shasum=09f3583c6cd7b1f748c0c012ce9b3d96de95a6c0d2334327b74f7d72b1fa5054
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build consul
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Port Listen TCP/8300
 ✓ Port Listen TCP/8301
 ✓ Port Listen TCP/8302
 ✓ Port Listen TCP/8500
 ✓ Port Listen TCP/8600
 ✓ Port Listen UDP/8301
 ✓ Port Listen UDP/8302
 ✓ Port Listen UDP/8600

8 tests, 0 failures
```