### PR TITLE
[curl] Update curl to 7.68.0

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../curl/plan.sh"
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.67.0
+pkg_version=7.68.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/

--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.67.0
+pkg_version=7.68.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
-pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=52af3361cf806330b88b4fe6f483b6844209d47ae196ac46da4de59bb361ab02
+pkg_source="https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum=1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358
 pkg_deps=(
   core/cacerts
   core/glibc
@@ -32,21 +32,22 @@ do_prepare() {
 }
 
 do_build() {
-  ./configure --prefix="$pkg_prefix" \
-              --with-ca-bundle="$(pkg_path_for cacerts)/ssl/certs/cacert.pem" \
-              --with-ssl="$(pkg_path_for openssl)" \
-              --with-zlib="$(pkg_path_for zlib)" \
-              --with-nghttp2="$(pkg_path_for nghttp2)" \
-              --disable-manual \
-              --disable-ldap \
-              --disable-ldaps \
-              --disable-rtsp \
-              --enable-proxy \
-              --enable-optimize \
-              --disable-dependency-tracking \
-              --enable-ipv6 \
-              --without-libidn \
-              --without-gnutls \
-              --without-librtmp
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --with-ca-bundle="$(pkg_path_for cacerts)/ssl/certs/cacert.pem" \
+    --with-ssl="$(pkg_path_for openssl)" \
+    --with-zlib="$(pkg_path_for zlib)" \
+    --with-nghttp2="$(pkg_path_for nghttp2)" \
+    --disable-manual \
+    --disable-ldap \
+    --disable-ldaps \
+    --disable-rtsp \
+    --enable-proxy \
+    --enable-optimize \
+    --disable-dependency-tracking \
+    --enable-ipv6 \
+    --without-libidn \
+    --without-gnutls \
+    --without-librtmp
   make
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

This updates curl and curl-static-musl

### Testing

```
hab pkg build curl
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Curl against https sites

2 tests, 0 failures
```
