### PR TITLE
[gradle] Update gradle to 5.6.4

### DIFF
--- a/gradle/plan.sh
+++ b/gradle/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=gradle
 pkg_origin=core
-pkg_version=5.4.1
+pkg_version=5.6.4
 pkg_source="https://services.gradle.org/distributions/${pkg_name}-${pkg_version}-bin.zip"
-pkg_shasum=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
+pkg_shasum=1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A powerful build system for the JVM"
 pkg_upstream_url=http://gradle.org
@@ -24,7 +24,7 @@ pkg_deps=(
 )
 
 do_build() {
-  local native_platform_version=0.17
+  local native_platform_version=0.18
   mkdir patching
   pushd patching
   jar xf "../lib/native-platform-linux-amd64-${native_platform_version}.jar"

--- a/gradle5/plan.sh
+++ b/gradle5/plan.sh
@@ -3,10 +3,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/../gradle/plan.sh"
 pkg_name=gradle5
 pkg_distname=gradle
 pkg_origin=core
-pkg_version=5.4.1
-pkg_source=https://services.gradle.org/distributions/${pkg_distname}-${pkg_version}-bin.zip
+pkg_version=5.6.4
+pkg_source="https://services.gradle.org/distributions/${pkg_distname}-${pkg_version}-bin.zip"
 pkg_dirname="${pkg_distname}-${pkg_version}"
-pkg_shasum="7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc"
+pkg_shasum=1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A powerful build system for the JVM"
 pkg_upstream_url=http://gradle.org


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Both gradle and gradle5 updated in this PR.

### Testing

```
hab pkg build gradle
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Run A Scan With Gradle
 ✓ Version matches

2 tests, 0 failures
```
