### PR TITLE
[ci] Don't send welcome message to maintainers

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,7 +8,10 @@ github:
 subscriptions:
   - workload: pull_request_opened:{{agent_id}}:*
     actions:
-      - post_github_comment:.expeditor/templates/welcome.mustache
+      - post_github_comment:.expeditor/templates/welcome.mustache:
+          ignore_team_members:
+            - habitat-sh/habitat-core-maintainers
+            - habitat-sh/habitat-core-plans-maintainers
 
 pipelines:
   - verify:


### PR DESCRIPTION
This should mute the welcome messages for PRs opened by Habitat and core-plans maintainers. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>