### PR TITLE
[hugo] Update hugo to 0.67.1

### DIFF
--- a/hugo/plan.sh
+++ b/hugo/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hugo
 pkg_origin=core
-pkg_version=0.63.2
+pkg_version=0.67.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Hugo is one of the most popular open-source static site generators."


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build hugo
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output\

```
 ✓ Version matches
 ✓ Help command
 ✓ Generate new site

3 tests, 0 failures
```