### PR TITLE
[sccache] Update sccache to 0.2.13

### DIFF
--- a/sccache/plan.sh
+++ b/sccache/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=sccache
 pkg_origin=core
-pkg_version=0.2.12
+pkg_version=0.2.13
 pkg_license=('Apache-2.0')
 pkg_upstream_url="https://github.com/mozilla/sccache"
 pkg_description="sccache is ccache with cloud storage"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/mozilla/sccache/archive/${pkg_version}.tar.gz"
-pkg_shasum=591a82ddbc2e970630a9426c78c25cbc52c3261b06d57cb4e1f11ab8008629fa
+pkg_shasum=81c973cf9a89e77f02a6b5710298531ba2e50d2555e8a931e505fbf570522e2a
 pkg_bin_dirs=(bin)
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build sccache
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 4226

4 tests, 0 failures
```