### PR TITLE
[yarn] Update yarn to 1.22.4

### DIFF
--- a/yarn/plan.ps1
+++ b/yarn/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="yarn"
 $pkg_origin="core"
-$pkg_version="1.22.0"
+$pkg_version="1.22.4"
 $pkg_description="Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don't ever have to worry."
 $pkg_maintainer="The Habitat Maintainers humans@habitat.sh"
 $pkg_upstream_url="https://yarnpkg.com/"
 $pkg_license=@("BSD-2-Clause")
 $pkg_filename="$pkg_name-$pkg_version.msi"
 $pkg_source="https://github.com/yarnpkg/yarn/releases/download/v${pkg_version}/${pkg_filename}"
-$pkg_shasum="591d8c2c2b7f367f17cc23742bb1a532b2405c5e307b1339b7bff083343bf7a2"
+$pkg_shasum="6243f09fef4aa4e873f74133f94dc7dc715463dc14f9f8fe99e2627d99357bfb"
 $pkg_bin_dirs=@("bin")
 $pkg_deps=@("core/node")
 $pkg_build_deps=@("core/lessmsi")

--- a/yarn/plan.sh
+++ b/yarn/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=yarn
 pkg_origin=core
-pkg_version=1.22.0
+pkg_version=1.22.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don’t ever have to worry."
 pkg_upstream_url=https://yarnpkg.com/
 pkg_license=('BSD-2-Clause')
 pkg_source="https://github.com/yarnpkg/yarn/releases/download/v${pkg_version}/yarn-v${pkg_version}.tar.gz"
-pkg_shasum=de8871c4e2822cba80d58c2e72366fb78567ec56e873493c9ca0cca76c60f9a5
+pkg_shasum=bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58
 pkg_bin_dirs=(bin)
 pkg_build_deps=()
 pkg_deps=(


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build yarn
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```