### PR TITLE
[libarchive] Update libarchive to 3.4.2

### DIFF
--- a/libarchive/plan.ps1
+++ b/libarchive/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="libarchive"
 $pkg_origin="core"
-$pkg_version="3.4.0"
+$pkg_version="3.4.2"
 $pkg_description="Multi-format archive and compression library"
 $pkg_upstream_url="https://www.libarchive.org"
 $pkg_license=@("BSD")
 $pkg_source="http://www.libarchive.org/downloads/${pkg_name}-${pkg_version}.zip"
-$pkg_shasum="d893507dca992d0ea70c4354f01e385cbf0ee8e544c1611d3d432d6359fd59e0"
+$pkg_shasum="9af28a8e88baa0d25123122ea4661478726f0544cee826a22b1db1feed3c01e2"
 $pkg_deps=@(
     "core/openssl",
     "core/bzip2",

--- a/libarchive/plan.sh
+++ b/libarchive/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libarchive
 _distname=$pkg_name
 pkg_origin=core
-pkg_version=3.4.0
+pkg_version=3.4.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Multi-format archive and compression library"
 pkg_upstream_url="https://www.libarchive.org"
 pkg_license=('BSD')
 pkg_source="http://www.libarchive.org/downloads/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e"
+pkg_shasum="b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
This resolves nearly a dozen security issues and two published CVEs plus
it fixes critical bugs in the archive parsing. This has been updated in Chef Infra Client and we need this updated in core plans so that effortless packages match.

```
   libarchive: hab-plan-build cleanup
   libarchive:
   libarchive: Source Path: /hab/cache/src/libarchive-3.4.2
   libarchive: Installed Path: /hab/pkgs/tas50/libarchive/3.4.2/20200402054048
   libarchive: Artifact: /src/libarchive/results/tas50-libarchive-3.4.2-20200402054048-x86_64-linux.hart
   libarchive: Build Report: /src/libarchive/results/last_build.env
   libarchive: SHA256 Checksum: 0bb8113e002e2d09dcc79b1db19a2bb9fa5752df46df2e8277b7287459d8836e
   libarchive: Blake2b Checksum: 2affe8038489a2484c4f274de8ac5cbd305c4f02bc2d6b434067dabe6149ac0c
   libarchive:
   libarchive: I love it when a plan.sh comes together.
   libarchive:
   libarchive: Build time: 1m5s
```

Signed-off-by: Tim Smith <tsmith@chef.io>