### PR TITLE
[go] Revert latest dependency update so that core/go depends on core/go17

### DIFF
--- a/go/plan.sh
+++ b/go/plan.sh
@@ -2,11 +2,10 @@
 pkg_name=go
 pkg_origin=core
 pkg_version=1.14
-# Use the most recent previous release of go to build the new release. In a
-# theoretical catastrophe where core/go doesn't exist on bldr we can change this
-# to core/go17
-pkg_bootstrap_pkg="core/go"
-pkg_bootstrap_version=1.13.7
+# Rolled back recent change to core/go17 to facillitate a from-scratch
+# base-plan refresh.
+pkg_bootstrap_pkg="core/go17"
+pkg_bootstrap_version=1.7.5
 pkg_description="Go is an open source programming language that makes it easy to
   build simple, reliable, and efficient software."
 pkg_upstream_url=https://golang.org/


### PR DESCRIPTION
Creating this to fix refresh build for core/go according to issue https://github.com/habitat-sh/core-plans/issues/3266

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>