### PR TITLE
[refresh] - Fixing typo in refresh passed  plan list

### DIFF
--- a/.refresh/remaining_plans_passed.txt
+++ b/.refresh/remaining_plans_passed.txt
@@ -73,7 +73,7 @@ core-plans/polipo
 core-plans/pngcrush
 core-plans/packer
 core-plans/optipng
-core-plans/openssl11
+core-plans/openssl
 core-plans/openldap
 core-plans/opa
 core-plans/oniguruma


### PR DESCRIPTION
"core-plans/openssl11" -> "core-plans/openssl"

Signed-off-by: Steven Marshall <SMarshall@chef.io>