### PR TITLE
[refresh/2020q1] Remove core/bazel because it has been deprecated

### DIFF
--- a/.refresh/remaining_plans_passed.txt
+++ b/.refresh/remaining_plans_passed.txt
@@ -434,7 +434,6 @@ core-plans/clojure
 core-plans/openjdk11
 core-plans/artifactory
 core-plans/corretto8
-core-plans/bazel
 core-plans/ant
 core-plans/zookeeper
 core-plans/tomcat-native


### PR DESCRIPTION
it has been deprecated

Signed-off-by: Gavin Didrichsen <gavin.didrichsen@gmail.com>