### PR TITLE
[refresh][pax-utils] - Upgrade pax utils to version 1.2.5

### DIFF
--- a/.refresh/remaining_plans_failed.txt
+++ b/.refresh/remaining_plans_failed.txt
@@ -1,4 +1,3 @@
-core-plans/pax-utils
 core-plans/libnsl
 core-plans/grpcurl
 core-plans/libgpg-error

--- a/.refresh/remaining_plans_passed.txt
+++ b/.refresh/remaining_plans_passed.txt
@@ -71,6 +71,7 @@ core-plans/postgresql-client
 core-plans/ponysay
 core-plans/polipo
 core-plans/pngcrush
+core-plans/pax-utils
 core-plans/packer
 core-plans/optipng
 core-plans/openssl11

--- a/pax-utils/plan.sh
+++ b/pax-utils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=pax-utils
-pkg_version=1.2.3
+pkg_version=1.2.5
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL')
@@ -7,7 +7,7 @@ pkg_description="ELF related utils for ELF 32/64 binaries that can check files
   for security relevant properties"
 pkg_upstream_url='http://hardened.gentoo.org/pax-utils.xml'
 pkg_source="http://distfiles.gentoo.org/distfiles/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="d231b1a34aea2b9205c24fada79a8251d4c3fbcce49367fc055fe43e4c9783b2"
+pkg_shasum="7ce7170ceed255bb47cac03b88bcbc636b0e412cac974e213e8017a1dae292ec"
 pkg_deps=(
   core/bash
   core/glibc


### PR DESCRIPTION
Changes pax-utils to 1.2.5 to avoid dist location issue.

Signed-off-by: Steven Marshall <SMarshall@chef.io>