### PR TITLE
Adding plan for network benchmark tool iperf.

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -593,6 +593,8 @@ plan_path = "inotify-tools"
 plan_path = "inputproto"
 [intltool]
 plan_path = "intltool"
+[iperf]
+plan_path = "iperf"
 [iproute2]
 plan_path = "iproute2"
 [iptables]

--- a/iperf/README.md
+++ b/iperf/README.md
@@ -1,0 +1,69 @@
+# iperf
+
+iPerf3 is a tool for active measurements of the maximum achievable bandwidth on IP networks.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Usage: iperf [-s|-c host] [options]
+       iperf [-h|--help] [-v|--version]
+
+Server or Client:
+  -p, --port      #         server port to listen on/connect to
+  -f, --format    [kmgKMG]  format to report: Kbits, Mbits, KBytes, MBytes
+  -i, --interval  #         seconds between periodic bandwidth reports
+  -F, --file name           xmit/recv the specified file
+  -A, --affinity n/n,m      set CPU affinity
+  -B, --bind      <host>    bind to a specific interface
+  -V, --verbose             more detailed output
+  -J, --json                output in JSON format
+  --logfile f               send output to a log file
+  -d, --debug               emit debugging output
+  -v, --version             show version information and quit
+  -h, --help                show this message and quit
+Server specific:
+  -s, --server              run in server mode
+  -D, --daemon              run the server as a daemon
+  -I, --pidfile file        write PID file
+  -1, --one-off             handle one client connection then exit
+Client specific:
+  -c, --client    <host>    run in client mode, connecting to <host>
+  -u, --udp                 use UDP rather than TCP
+  -b, --bandwidth #[KMG][/#] target bandwidth in bits/sec (0 for unlimited)
+                            (default 1 Mbit/sec for UDP, unlimited for TCP)
+                            (optional slash and packet count for burst mode)
+  -t, --time      #         time in seconds to transmit for (default 10 secs)
+  -n, --bytes     #[KMG]    number of bytes to transmit (instead of -t)
+  -k, --blockcount #[KMG]   number of blocks (packets) to transmit (instead of -t or -n)
+  -l, --len       #[KMG]    length of buffer to read or write
+                            (default 128 KB for TCP, 8 KB for UDP)
+  --cport         <port>    bind to a specific client port (TCP and UDP, default: ephemeral port)
+  -P, --parallel  #         number of parallel client streams to run
+  -R, --reverse             run in reverse mode (server sends, client receives)
+  -w, --window    #[KMG]    set window size / socket buffer size
+  -C, --congestion <algo>   set TCP congestion control algorithm (Linux and FreeBSD only)
+  -M, --set-mss   #         set TCP/SCTP maximum segment size (MTU - 40 bytes)
+  -N, --no-delay            set TCP/SCTP no delay, disabling Nagle's Algorithm
+  -4, --version4            only use IPv4
+  -6, --version6            only use IPv6
+  -S, --tos N               set the IP 'type of service'
+  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)
+  -Z, --zerocopy            use a 'zero copy' method of sending data
+  -O, --omit N              omit the first n seconds
+  -T, --title str           prefix every output line with this string
+  --get-server-output       get results from server
+  --udp-counters-64bit      use 64-bit counters in UDP test packets
+  --no-fq-socket-pacing     disable fair-queuing based socket pacing
+                            (Linux only)
+
+[KMG] indicates options that support a K/M/G suffix for kilo-, mega-, or giga-
+
+iperf3 homepage at: http://software.es.net/iperf/
+Report bugs to:     https://github.com/esnet/iperf

--- a/iperf/plan.sh
+++ b/iperf/plan.sh
@@ -1,0 +1,35 @@
+pkg_name=iperf
+pkg_origin=core
+pkg_version=3.1.3
+pkg_description="iPerf3 is a tool for active measurements of the maximum achievable bandwidth on IP networks."
+pkg_upstream_url="https://iperf.fr/"
+pkg_license=('BSD')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://iperf.fr/download/source/iperf-${pkg_version}-source.tar.gz"
+pkg_shasum=e34cf60cffc80aa1322d2c3a9b81e662c2576d2b03e53ddf1079615634e6f553
+# core/coreutils isn't /really/ needed at runtime, but fix_interpreter
+# only works if the dep is listed in pkg_deps
+pkg_deps=(
+  core/coreutils
+  core/glibc
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}"
+  make -j "$(nproc)"
+}
+
+do_check() {
+  fix_interpreter "tests/TESTonce" core/coreutils bin/env
+  make check
+}
+
+do_install() {
+  do_default_install
+  ln -s "${pkg_prefix}/bin/iperf3" "${pkg_prefix}/bin/iperf"
+}

--- a/iperf/tests/test.bats
+++ b/iperf/tests/test.bats
@@ -1,0 +1,12 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} iperf3 --version 2>&1 | head -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+# Running --help always exits 1
+@test "Execution success" {
+  run hab pkg exec ${TEST_PKG_IDENT} iperf3 --version
+  [ $status -eq 0 ]
+}

--- a/iperf/tests/test.sh
+++ b/iperf/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This is a fairly useful tool normally found in the epel repos for rhel. Making this available in core plans would be useful for load testing and troubleshooting.

Signed-off-by: Thomas Cate <tcate@chef.io>