### PR TITLE
[refresh2020q1][serf]: fix missing zlib header in build

### DIFF
--- a/serf/pass-env-to-scons.patch
+++ b/serf/pass-env-to-scons.patch
@@ -1,12 +1,12 @@
---- SConstruct.orig	2016-07-15 14:13:44.447114953 +0000
-+++ SConstruct	2016-07-15 14:14:54.744356018 +0000
-@@ -149,6 +149,9 @@
+diff --git a/SConstruct b/SConstruct
+index 211a1e3..e2cf623 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -176,6 +176,7 @@ if sys.platform == 'win32':
  env = Environment(variables=opts,
                    tools=('default', 'textfile',),
                    CPPPATH=['.', ],
-+                  ENV=os.environ,
-+                  CFLAGS=os.environ['CFLAGS'],
-+                  LINKFLAGS = os.environ['LDFLAGS'],
++                  ENV=os.environ
                    )
-
- env.Append(BUILDERS = {
+ 
+ gen_def_script = env.File('build/gen_def.py').rstr()

--- a/serf/plan.sh
+++ b/serf/plan.sh
@@ -35,7 +35,10 @@ do_build() {
     PREFIX="$pkg_prefix" \
     APR="$(pkg_path_for apr)" \
     APU="$(pkg_path_for apr-util)" \
-    OPENSSL="$(pkg_path_for openssl)"
+    ZLIB="$(pkg_path_for zlib)" \
+    OPENSSL="$(pkg_path_for openssl)" \
+    CFLAGS="$CFLAGS" \
+    LINKFLAGS="$LDFLAGS"
 }
 
 # Currently errors out on a comment style in a test suite, of all things.


### PR DESCRIPTION
- Set the path to ZLIB via the ZLIB flag

- Set CFLAGS and LINKFLAGS via the command line rather than via a
  patch. This seems to fix a bug where scons was constructing invalid
  arguments to gcc.

Fixes #3294

Signed-off-by: Steven Danna <steve@chef.io>