### PR TITLE
[ruby][ruby24][ruby25][ruby26][ruby27] Upgrade all rubies for latest point releases

### DIFF
--- a/ruby/plan.sh
+++ b/ruby/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby
 pkg_origin=core
-pkg_version=2.5.7
+pkg_version=2.5.8
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4
+pkg_shasum=6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby24/plan.sh
+++ b/ruby24/plan.sh
@@ -3,7 +3,7 @@ source ../ruby/plan.sh
 
 pkg_name=ruby24
 pkg_origin=core
-pkg_version=2.4.9
+pkg_version=2.4.10
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -11,5 +11,5 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=f99b6b5e3aa53d579a49eb719dd0d3834d59124159a6d4351d1e039156b1c6ae
+pkg_shasum=93d06711795bfb76dbe7e765e82cdff3ddf9d82eff2a1f24dead9bb506eaf2d0
 pkg_dirname="ruby-$pkg_version"

--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby25
 pkg_origin=core
-pkg_version=2.5.7
+pkg_version=2.5.8
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4
+pkg_shasum=6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby26
 pkg_origin=core
-pkg_version=2.6.5
+pkg_version=2.6.6
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
+pkg_shasum=364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)

--- a/ruby27/plan.sh
+++ b/ruby27/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby27
 pkg_origin=core
-pkg_version=2.7.0
+pkg_version=2.7.1
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.7/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe
+pkg_shasum=d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
* [ruby] Still using ruby 2.5 for major version, but now on latest 2.5.8 point release
* [ruby24] Upgrade to latest 2.4.10
* [ruby25] Upgrade to latest 2.5.8
* [ruby26] Upgrade to latest 2.6.6
* [ruby27] Upgrade to latest 2.7.1

As a note, Ruby 2.4.10 is now [out of support entirely](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/) so won't receive further updates.