### PR TITLE
[bundler] Upgrade to release 2.1.4

### DIFF
--- a/bundler/plan.sh
+++ b/bundler/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bundler
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.17.3
+pkg_version=2.1.4
 pkg_origin=core
 pkg_license=('bundler')
 pkg_description="The Ruby language dependency manager"


### PR DESCRIPTION
This is a major version number jump from bundler 1.17.3 to bundler 2.1.4.

There are some docs and gotchas listed on the Bundler website <https://bundler.io/guides/bundler_2_upgrade.html> around this upgrade.

In theory bundler 2 switches internal behaviour to run bundler 1.x if the `Gemfile.lock` specifies that version, so this change is backwards compatible. We don't have plans for below ruby 2.3, so we shouldn't be affected by the minimum version change.