### PR TITLE
[opa] bump 0.16.2 -> 0.19.2

### DIFF
--- a/opa/plan.sh
+++ b/opa/plan.sh
@@ -1,18 +1,17 @@
-gopkg="github.com/open-policy-agent/opa"
 pkg_name=opa
 pkg_description="Open Policy Agent (OPA) is a lightweight general-purpose policy engine that can be co-located with your service."
 pkg_origin=core
 pkg_version="0.19.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
-pkg_source="https://$gopkg/archive/v${pkg_version}.tar.gz"
+pkg_source="https://github.com/open-policy-agent/opa/archive/v${pkg_version}.tar.gz"
 pkg_upstream_url="https://www.openpolicyagent.org/"
-pkg_build_deps=(core/bash)
 pkg_exports=(
   [address]=service.address
 )
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
+    core/bash
     core/make
     core/git
     core/go

--- a/opa/plan.sh
+++ b/opa/plan.sh
@@ -2,7 +2,7 @@ gopkg="github.com/open-policy-agent/opa"
 pkg_name=opa
 pkg_description="Open Policy Agent (OPA) is a lightweight general-purpose policy engine that can be co-located with your service."
 pkg_origin=core
-pkg_version="0.16.2"
+pkg_version="0.19.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://$gopkg/archive/v${pkg_version}.tar.gz"
@@ -17,7 +17,7 @@ pkg_build_deps=(
     core/git
     core/go
 )
-pkg_shasum="f71b0532790962fb2b19b18acab21f8303c1e25f1a6822f461f006a3f47f0c93"
+pkg_shasum="f8ccdf7ae2a9766654a8466b4287b5d55ad4b3f55673e45bd10340c93d967746"
 
 do_prepare() {
   sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" -i build/*.sh


### PR DESCRIPTION
ℹ️ Release notes are here: https://github.com/open-policy-agent/opa/releases

(We're a few versions behind, so I'm not accumulating all that has changed here.)