### PR TITLE
[refresh2020q1][maven][jffi] Add cycle for maven

### DIFF
--- a/.refresh/package_cycles.csv
+++ b/.refresh/package_cycles.csv
@@ -1,0 +1,10 @@
+download,core-plans/maven
+upload,core-plans/maven
+build,core-plans/maven
+build,core-plans/jffi
+build,core-plans/maven
+build,core-plans/jffi
+build,core-plans/maven
+build,core-plans/jffi
+upload,core-plans/maven
+upload,core-plans/jffi

--- a/.refresh/package_cycles.csv
+++ b/.refresh/package_cycles.csv
@@ -1,10 +1,8 @@
 download,core-plans/maven
 upload,core-plans/maven
 build,core-plans/maven
-build,core-plans/jffi
 build,core-plans/maven
-build,core-plans/jffi
 build,core-plans/maven
-build,core-plans/jffi
 upload,core-plans/maven
+build,core-plans/jffi
 upload,core-plans/jffi


### PR DESCRIPTION
This adds another file to the .refresh directory, this file details what should be done to cycle several plans and their dependencies. 

Signed-off-by: MindNumbing <SMarshall@chef.io>