### PR TITLE
[python2] - Updating python2 to 2.7.18

### DIFF
--- a/python2/plan.ps1
+++ b/python2/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="python2"
-$pkg_version="2.7.16"
+$pkg_version="2.7.18"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')
 $pkg_description="Python is a programming language that lets you work quickly and integrate systems more effectively."
 $pkg_upstream_url="https://www.python.org"
 $pkg_source="https://www.python.org/ftp/python/$pkg_version/python-$pkg_version.amd64.msi"
-$pkg_shasum="7c0f45993019152d46041a7db4b947b919558fdb7a8f67bcd0535bc98d42b603"
+$pkg_shasum="b74a3afa1e0bf2a6fc566a7b70d15c9bfabba3756fb077797d16fffa27800c05"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin", "bin/Scripts")
 

--- a/python2/plan.sh
+++ b/python2/plan.sh
@@ -5,7 +5,7 @@ source ../python/plan.sh
 # If so, the python2 namespace would need to be deprecated per RFC 0007
 pkg_name=python2
 pkg_distname=Python
-pkg_version=2.7.15
+pkg_version=2.7.18
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
@@ -14,7 +14,7 @@ pkg_description="Python is a programming language that lets you work quickly \
 pkg_upstream_url="https://www.python.org"
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db"
+pkg_shasum="da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"
 
 pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 


### PR DESCRIPTION
This updates python2 from 2.7.15 to 2.7.18.

This will be the [last release of python2](https://pythoninsider.blogspot.com/2020/04/python-2718-last-release-of-python-2.html). 🎉 

Signed-off-by: MindNumbing <SMarshall@chef.io>