### PR TITLE
[refresh2020q1][buildkite-agent] - Fix buildkite-agent go vendering

### DIFF
--- a/.refresh/remaining_plans_failed.txt
+++ b/.refresh/remaining_plans_failed.txt
@@ -3,13 +3,11 @@ core-plans/gox
 core-plans/libmaxminddb
 core-plans/goaccess
 core-plans/envoy
-core-plans/buildkite-agent
 core-plans/ansible
 core-plans/shield-agent
 core-plans/rethinkdb
 core-plans/img
 core-plans/cockroach
-core-plans/buildkite-cli
 core-plans/happy
 core-plans/ghc88
 core-plans/ghc

--- a/.refresh/remaining_plans_passed.txt
+++ b/.refresh/remaining_plans_passed.txt
@@ -256,6 +256,7 @@ core-plans/libxdmcp
 core-plans/libxau
 core-plans/caddy
 core-plans/busybox
+core-plans/buildkite-agent
 core-plans/libxslt
 core-plans/libuv
 core-plans/bind
@@ -354,6 +355,7 @@ core-plans/libxcb
 core-plans/libice
 core-plans/ruby
 core-plans/bundler
+core-plans/buildkite-cli
 core-plans/ninja
 core-plans/boringssl
 core-plans/boost159

--- a/buildkite-agent/plan.sh
+++ b/buildkite-agent/plan.sh
@@ -38,6 +38,10 @@ do_prepare() {
 do_build() {
   pushd "${parent_go_path}/agent" > /dev/null
   go install --tags extended
+  pushd "${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}" > /dev/null
+    go mod tidy
+    go mod vendor
+  popd > /dev/null
   go build -o buildkite-agent main.go
   local code=$?
   popd > /dev/null


### PR DESCRIPTION
This PR adds steps required to generate the go module list, and vendor file to fix an issue that was occuring with the latest updates to buildkite-agent.

Fixes #3287

Signed-off-by: MindNumbing <SMarshall@chef.io>