### PR TITLE
[ImageMagick] Update include path to align with major version bump

### DIFF
--- a/imagemagick/plan.sh
+++ b/imagemagick/plan.sh
@@ -26,7 +26,7 @@ pkg_build_deps=(
   core/pkg-config
 )
 pkg_bin_dirs=(bin)
-pkg_include_dirs=(include/ImageMagick-6)
+pkg_include_dirs=(include/ImageMagick-7)
 pkg_lib_dirs=(lib)
 pkg_dirname="ImageMagick-${pkg_version}"
 


### PR DESCRIPTION
ImageMagick uses `ImageMagick-<MAJOR VERSION>` to install its headers. This PR updates the metadata to reflect the major version bump from 6 to 7. 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>