### PR TITLE
[refresh2020q1][img] - Fixing go pseudo version issue

### DIFF
--- a/.refresh/remaining_plans_failed.txt
+++ b/.refresh/remaining_plans_failed.txt
@@ -7,7 +7,6 @@ core-plans/buildkite-agent
 core-plans/ansible
 core-plans/shield-agent
 core-plans/rethinkdb
-core-plans/img
 core-plans/cockroach
 core-plans/buildkite-cli
 core-plans/drupal

--- a/.refresh/remaining_plans_passed.txt
+++ b/.refresh/remaining_plans_passed.txt
@@ -319,6 +319,7 @@ core-plans/libpciaccess
 core-plans/kubectl
 core-plans/kibana
 core-plans/intltool
+core-plans/img
 core-plans/imagemagick
 core-plans/renderproto
 core-plans/kbproto

--- a/img/plan.sh
+++ b/img/plan.sh
@@ -1,6 +1,6 @@
 pkg_name="img"
 pkg_origin="core"
-pkg_version=0.5.4
+pkg_version=0.5.7
 pkg_description="Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder."
 pkg_upstream_url="https://github.com/genuinetools/img"
 pkg_license=('MIT')
@@ -39,6 +39,14 @@ do_verify() {
 }
 
 do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  pushd "${pkg_cache_path}" >/dev/null
+    go mod edit -replace github.com/containerd/containerd@3a3f0aac8819=github.com/containerd/containerd@814b795
+    go get github.com/go-bindata/go-bindata/go-bindata
+  popd >/dev/null
   return 0
 }
 

--- a/img/plan.sh
+++ b/img/plan.sh
@@ -43,11 +43,12 @@ do_unpack() {
 }
 
 do_prepare() {
+  # This changes the version of containerd that is added to fix invalid pseudo version caused by version in go.mod file.
+  # This should be fixed with the next release.
   pushd "${pkg_cache_path}" >/dev/null
     go mod edit -replace github.com/containerd/containerd@3a3f0aac8819=github.com/containerd/containerd@814b795
     go get github.com/go-bindata/go-bindata/go-bindata
   popd >/dev/null
-  return 0
 }
 
 do_build() {


### PR DESCRIPTION
Minor version bump from 0.5.4 -> 0.57
Adds steps to replace a module that is causing pseudo version issues and to get a module that wasn't included.

Fixes #3291

Signed-off-by: MindNumbing <SMarshall@chef.io>