### PR TITLE
[ci] - Fixing habitat studio version checks in ci

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -50,7 +50,7 @@ echo "--- Installing the studio"
 # This will ensure the correct version of the studio for the `hab` 
 # on our path is installed, and provide some informational output
 # about what version we intend to use. 
-hab studio version
+hab studio run "hab studio version"
 
 # We want to ensure that we build from the project root. This
 # creates a subshell so that the cd will only affect that process

--- a/bin/ci/verify-pr-build.sh
+++ b/bin/ci/verify-pr-build.sh
@@ -49,7 +49,7 @@ echo "--- Installing the studio"
 # This will ensure the correct version of the studio for the `hab` 
 # on our path is installed, and provide some informational output
 # about what version we intend to use. 
-hab studio version
+hab studio run "hab studio version"
 
 echo "--- :construction: Starting build for $plan"
 # Build with DO_CHECK=true.


### PR DESCRIPTION
This adds a change that wraps the habitat studio version check within "hab studio run" to ensure that it works locally on macs.

Signed-off-by: MindNumbing <SMarshall@chef.io>