### PR TITLE
Static grpcurl build

### DIFF
--- a/grpcurl/plan.sh
+++ b/grpcurl/plan.sh
@@ -1,31 +1,26 @@
 gopkg="github.com/fullstorydev/grpcurl"
 pkg_name=grpcurl
 pkg_origin=core
+pkg_version="1.5.1"
 pkg_description="Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://$gopkg/cmd/grpcurl"
+pkg_source="https://github.com/fullstorydev/grpcurl/archive/v${pkg_version}.tar.gz"
 pkg_upstream_url="https://$gopkg"
-pkg_version="1.3.0"
 pkg_license=('MIT')
 pkg_bin_dirs=(bin)
-pkg_scaffolding=core/scaffolding-go
-scaffolding_go_base_path=github.com/fullstorydev
-
-do_download() {
-  # `-d`: don't let go build it, we'll have to build this ourselves
-  go get -d $gopkg
-
-  pushd "${scaffolding_go_gopath:?}/src/$gopkg"
-    git reset --hard "v$pkg_version"
-  popd
-}
+pkg_build_deps=(
+    core/git
+    core/go
+)
+pkg_shasum="0e046500122cb533f9565574a5b06fb74f5c97fe01c93b7550edd5e2edc953ce"
 
 do_build() {
-  pushd "${scaffolding_go_gopath:?}/src/$gopkg"
-    make install
-  popd
+    return 0
 }
 
 do_install() {
-  cp "${scaffolding_go_gopath:?}/bin/grpcurl" "${pkg_prefix}/bin/"
+    GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build \
+      -ldflags "-X 'main.version=v${pkg_version}'" \
+      -o "${pkg_prefix}/bin" \
+      ./cmd/grpcurl
 }

--- a/grpcurl/tests/test.bats
+++ b/grpcurl/tests/test.bats
@@ -1,7 +1,7 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} grpcurl -version 2>&1 | awk '{print $4}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} grpcurl -version 2>&1 | awk '{print $2}')"
   [ "$result" = "v${TEST_PKG_VERSION}" ]
 }
 


### PR DESCRIPTION
The plans that rely on the go scaffolding are producing broken builds
as they rely on glibc implicitly. We can easily build static binaries
with go.
