### PR TITLE
[dnsmasq] Update dnsmasq to 2.81

### DIFF
--- a/dnsmasq/plan.sh
+++ b/dnsmasq/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dnsmasq
 pkg_origin=core
-pkg_version=2.80
+pkg_version=2.81
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Provides network infrastructure for small networks"
 pkg_upstream_url="http://www.thekelleys.org.uk/dnsmasq/doc.html"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${pkg_version}.tar.gz"
-pkg_shasum="9e4a58f816ce0033ce383c549b7d4058ad9b823968d352d2b76614f83ea39adc"
+pkg_shasum=3c28c68c6c2967c3a96e9b432c0c046a5df17a426d3a43cffe9e693cf05804d0
 pkg_deps=(
   core/glibc
 )
@@ -17,7 +17,7 @@ pkg_build_deps=(
 pkg_bin_dirs=(
   bin
 )
-pkg_svc_run="dnsmasq -x $pkg_svc_path/dnsmasq.pid -C $pkg_svc_config_path/dnsmasq.conf --no-daemon"
+pkg_svc_run="dnsmasq -x ${pkg_svc_path}/dnsmasq.pid -C ${pkg_svc_config_path}/dnsmasq.conf --no-daemon"
 pkg_svc_user="root"
 pkg_svc_group="root"
 
@@ -26,5 +26,5 @@ do_build() {
 }
 
 do_install() {
-  mv ./src/dnsmasq "$pkg_prefix/bin/"
+  mv ./src/dnsmasq "${pkg_prefix}/bin/"
 }


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Addresses [CVE-2019-14834](https://nvd.nist.gov/vuln/detail/CVE-2019-14834)

### Testing

```
hab pkg build dnsmasq
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ dnsmasq service is running
 ✓ dnsmasq successfully finds debian.org
 ✓ dnsmasq binary matches version 2.81
 ✓ dnsmasq binary test returns success

4 tests, 0 failures
```
