### PR TITLE
[e2fsprogs]  Update e2fsprogs to 1.45.6

### DIFF
--- a/e2fsprogs/plan.sh
+++ b/e2fsprogs/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=e2fsprogs
 pkg_origin=core
-pkg_version=1.45.5
+pkg_version=1.45.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Ext2/3/4 filesystem userspace utilities"
 pkg_license=('GPL-2.0')
 pkg_upstream_url="http://e2fsprogs.sourceforge.net/"
 pkg_source="https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-${pkg_version}.tar.gz"
-pkg_shasum=0fd76e55c1196c1d97a2c01f2e84f463b8e99484541b43ff4197f5a695159fd3
+pkg_shasum=d785164a2977cd88758cb0cac5c29add3fe491562a60040cfb193abcd0f9609b
 pkg_deps=(
   core/glibc
 )


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build e2fsprogs
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ uuidgen works

1 test, 0 failures
```
