### PR TITLE
[libtiff] Update libtiff to 4.1.0

### DIFF
--- a/libtiff/plan.sh
+++ b/libtiff/plan.sh
@@ -1,14 +1,25 @@
 pkg_name=libtiff
 pkg_origin=core
-pkg_version=4.0.6
+pkg_version=4.1.0
 pkg_description="Library for reading and writting files in the Tag Image File Format (TIFF)"
 pkg_upstream_url="http://www.remotesensing.org/libtiff/"
 pkg_license=('libtiff')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.osgeo.org/libtiff/tiff-${pkg_version}.tar.gz"
-pkg_shasum=4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c
-pkg_deps=(core/glibc core/zlib core/libjpeg-turbo core/xz core/jbigkit)
-pkg_build_deps=(core/gcc core/make core/diffutils core/file)
+pkg_shasum=5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634
+pkg_deps=(
+  core/glibc
+  core/zlib
+  core/libjpeg-turbo
+  core/xz
+  core/jbigkit
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/diffutils
+  core/file
+)
 pkg_dirname="tiff-${pkg_version}"
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

Addresses [CVE-2019-14973](https://nvd.nist.gov/vuln/detail/CVE-2019-14973)

### Testing

```
hab pkg build libtiff
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```