### PR TITLE
[cerebro] Update cerebro to 0.9.0

### DIFF
--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cerebro
 pkg_origin=core
-pkg_version=0.8.5
+pkg_version=0.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Cerebro: Elasticsearch Administration"
 pkg_upstream_url="https://github.com/lmenezes/cerebro"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum=97cdba6c0054f505c6ac72ca5ae010612c86385ac0f7f760cf512e5705a00a27
+pkg_shasum=44f7d1b7c990571b483771ed8056eccbff37b8381aa3d148497e8a12161b4b91
 pkg_deps=(
 	core/coreutils
 	core/openjdk11


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build cerebro
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Service is running
 ✓ Version matches

2 tests, 0 failures
```