### PR TITLE
[composer] Update composer to 1.10.5

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=composer
 pkg_origin=core
-pkg_version=1.9.0
+pkg_version=1.10.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_upstream_url=https://getcomposer.org/
 pkg_description="Dependency Manager for PHP"
 pkg_source="https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar"
 pkg_filename="${pkg_name}.phar"
-pkg_shasum=c9dff69d092bdec14dee64df6677e7430163509798895fbd54891c166c5c0875
+pkg_shasum=d5f3fddd0be28a5fc9bf2634a06f51bc9bd581fabda93fee7ca8ca781ae43129
 pkg_deps=(
   core/php
   core/git


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build composer
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```