### PR TITLE
[nghttp2] link against glibc, update to 1.40.0

### DIFF
--- a/nghttp2/plan.sh
+++ b/nghttp2/plan.sh
@@ -1,15 +1,18 @@
 pkg_name=nghttp2
 pkg_origin=core
-pkg_version=1.39.2
+pkg_version=1.40.0
 pkg_description="nghttp2 is an open source HTTP/2 C Library."
 pkg_upstream_url=https://nghttp2.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=fc820a305e2f410fade1a3260f09229f15c0494fc089b0100312cd64a33a38c0
+pkg_shasum=eb9d9046495a49dd40c7ef5d6c9907b51e5a6b320ea6e2add11eb8b52c982c47
 pkg_build_deps=(
   core/make
   core/gcc
+)
+pkg_deps=(
+    core/glibc
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)


### PR DESCRIPTION
The in-development check-bin script found:

```
/hab/pkgs/core/nghttp2/1.39.2/20200310022350/lib/libnghttp2.so.14.18.0:
    core/glibc/2.29/20200305172459 is not listed in TDEPS but is used as a dependency
```

Signed-off-by: Steven Danna <steve@chef.io>