### PR TITLE
[base-plan][ncurses] Link to gcc-libs, upgrade to 6.2

### DIFF
--- a/ncurses/plan.sh
+++ b/ncurses/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ncurses
 pkg_origin=core
-pkg_version=6.1
+pkg_version=6.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 ncurses (new curses) is a programming library providing an application \
@@ -10,9 +10,10 @@ user interfaces in a terminal-independent manner.\
 pkg_upstream_url="https://www.gnu.org/software/ncurses/"
 pkg_license=('ncurses')
 pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17"
+pkg_shasum="30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
 pkg_deps=(
   core/glibc
+  core/gcc-libs
 )
 pkg_build_deps=(
   core/coreutils


### PR DESCRIPTION
The check-bin's script found:

    /hab/pkgs/core/ncurses/6.1/20200305230210/lib/libncurses++w.so.6.1:
          libgcc_s.so.1 missing
          libstdc++.so.6 missing

Signed-off-by: Steven Danna <steve@chef.io>