### PR TITLE
Fix missing binaries and update docker@19.03.8

### DIFF
--- a/docker/plan.sh
+++ b/docker/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=docker
 pkg_description="The Docker Engine"
 pkg_origin=core
-pkg_version=19.03.3
+pkg_version=19.03.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2')
 pkg_source="https://download.docker.com/linux/static/stable/x86_64/${pkg_name}-${pkg_version}.tgz"
 pkg_upstream_url=https://docs.docker.com/engine/installation/binaries/
-pkg_shasum=c3c8833e227b61fe6ce0bc5c17f97fa547035bef4ef17cf6601f30b0f20f4ce5
+pkg_shasum=7f4115dc6a3c19c917f8b9664d7b51c904def1c984e082c4600097433323cf6f
 pkg_dirname=docker
 pkg_bin_dirs=(bin)
 
@@ -15,7 +15,7 @@ do_build() {
 }
 
 do_install() {
-  for bin in docker*; do
+  for bin in *; do
     install -v -D "${bin}" "${pkg_prefix}/bin/${bin}"
   done
 }

--- a/docker/tests/test.bats
+++ b/docker/tests/test.bats
@@ -2,7 +2,17 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
   result="$(hab pkg exec ${TEST_PKG_IDENT} docker version | head -5 | grep Version | awk '{print $2}')"
-  [ "$result" = "${TEST_PKG_VERSION}" ]
+  diff <(echo "$result") <(echo "${TEST_PKG_VERSION}")
+}
+
+@test "Expected executables present" {
+  local missing=""
+  for exe in containerd containerd-shim ctr docker docker-init docker-proxy dockerd runc; do
+    if ! [ -x "/hab/pkgs/$TEST_PKG_IDENT/bin/$exe" ]; then
+      missing="${missing} $exe"
+    fi
+  done
+  diff <(echo "$missing") <(echo "")
 }
 
 @test "Help command" {


### PR DESCRIPTION
Docker has renamed some of its binaries so `docker*` won't work anymore
fixes #3355

Signed-off-by: DekusDenial <dekusdenial@hotmail.com>