### PR TITLE
[Docs] Add guide document for base plans

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,11 +15,10 @@ protobuf-rust @smacfarlane @habitat-sh/habitat-core-plans-maintainers
 zeromq @smacfarlane @habitat-sh/habitat-core-plans-maintainers
 
 # # Base Plans
-#
-# These plans are known as "base" plans which are used to build Habitat from
-# nothing and are in build order. Consequently, these need a closer look when
-# accepting changes, updating versions, etc.
+# The following plans are collectively known as the "base" plans.
+# For more information see `docs/dev/guide_documents/base-plans.md` in this repository.
 
+# These packages should not be updated outside of a base plans refresh.
 linux-headers @smacfarlane
 glibc @smacfarlane
 zlib @smacfarlane
@@ -31,49 +30,56 @@ mpfr @smacfarlane
 libmpc @smacfarlane
 gcc @smacfarlane
 gcc-libs @smacfarlane
+gdbm @smacfarlane
 patchelf @smacfarlane
-bzip2 @smacfarlane
 pkg-config @smacfarlane
 ncurses @smacfarlane
 attr @smacfarlane
 acl @smacfarlane
 libcap @smacfarlane
 sed @smacfarlane
-shadow @smacfarlane
-psmisc @smacfarlane
 procps-ng @smacfarlane
 coreutils @smacfarlane
 bison @smacfarlane
 flex @smacfarlane
 pcre @smacfarlane
 grep @smacfarlane
-readline @smacfarlane
-bash @smacfarlane
-bc @smacfarlane
-tar @smacfarlane
 gawk @smacfarlane
-libtool @smacfarlane
-gdbm @smacfarlane
-expat @smacfarlane
 db @smacfarlane
 inetutils @smacfarlane
-iana-etc @smacfarlane
-less @smacfarlane
-perl @smacfarlane
 diffutils @smacfarlane
 autoconf @smacfarlane
 automake @smacfarlane
 findutils @smacfarlane
 xz @smacfarlane
 gettext @smacfarlane
-gzip @smacfarlane
 make @smacfarlane
 patch @smacfarlane
 texinfo @smacfarlane
 util-linux @smacfarlane
 tcl @smacfarlane
+bzip2 @smacfarlane
 expect @smacfarlane
+less @smacfarlane
+perl @smacfarlane
 dejagnu @smacfarlane
+python-minimal @smacfarlane
+
+# These packages are generally safe to update in a normal builder workflow, but still
+# require additional care when updating. Updates to these plans should be coordinated
+# with the Habitat team when possible. See `docs/dev/guide_documents/base-plans.md` in this repository
+# for more information
+
+shadow @smacfarlane
+psmisc @smacfarlane
+readline @smacfarlane
+bash @smacfarlane
+bc @smacfarlane
+tar @smacfarlane
+libtool @smacfarlane
+expat @smacfarlane
+iana-etc @smacfarlane
+gzip @smacfarlane
 check @smacfarlane
 libidn @smacfarlane
 cacerts @smacfarlane
@@ -98,7 +104,6 @@ vim @smacfarlane
 libbsd @smacfarlane
 clens @smacfarlane
 mg @smacfarlane
-python-minimal @smacfarlane
 powershell @mwrock
 7zip @mwrock
 docker-credential-helper @mwrock

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -2,7 +2,10 @@
 
 This directory contains a collection of design documents relating to contributing and the use of core-plans.
 
-### How-to Guides
+### Guide Documents
+- [Base Plans](./guide_documents/base-plans.md)
+
+### How-to Documents
 - [Verifying Base Plan Updates](./howto_documents/verifying-base-plan-updates.md)
 
 ### Policy Documents

--- a/docs/dev/guide_documents/base-plans.md
+++ b/docs/dev/guide_documents/base-plans.md
@@ -80,6 +80,18 @@ If the dependencies of these plans change, which is rare but does happen, they s
 be checked to see if it moves the plan in to the 'Gang of 4X' cycle. If it does, 
 then that update should be made as part of the next base plans refresh.
 
+Additional things to consider when updating these plans include:
+
+* Number of reverse depenencies
+  * What parts of the ecosystem does it impact? Languages? Databases? etc.
+  * Can affect timing, large numbers of rebuilds could hold up other critical updates if there is overlap
+* Does the changelog indicate any changes that might impact downstream usage?
+* Why is the software being updated?
+  * CVE
+  * New features
+  * Bug fixes
+* Does the plan README contain any additional instructions?
+
 ```
 shadow 
 psmisc 

--- a/docs/dev/guide_documents/base-plans.md
+++ b/docs/dev/guide_documents/base-plans.md
@@ -1,0 +1,140 @@
+# Base Plans 
+The following plans are collectively known as the "base" plans. They are the 
+the minimum set of packages required in order to build the Habitat cli, 
+plan-build and the studio. Habitat is a self-hosting system; The build system, 
+plan-build, is a Habitat package that depends on other Habitat packages to run.
+Those packages were build with plan-build. If a change were to produce a studio 
+or plan-build package that failed at run time, it would require manual 
+intervetion and builds to correct.  As such plans in this list require 
+additional care when merging.
+
+The base plans can be further divided into two groups. 
+
+## The "Gang of 4X" #
+These packages form a dependency cycle amongst themselves.
+Ex: `a -> b -> c -> d -> a` 
+In this example, rebuilding 'a' would rebuild 'b', and so on, until 'd', which 
+would rebuild 'a', so special care must be taken to ensure the correct build order
+and to know when it is safe to break out of the loop.
+
+In addition, one or more of these plans are dependencies of nearly every other plan
+in the 'core' origin, so changing any of them means building the 'core' origin in its
+entirety. 
+
+These packages should not be updated outside of a base plans refresh.
+
+```
+linux-headers
+glibc
+zlib
+xz
+pkg-config
+ncurses
+make
+m4
+gmp
+gdbm
+flex
+findutils
+diffutils
+bzip2
+attr
+file
+binutils
+util-linux
+procps-ng
+bison
+mpfr
+patch
+libcap
+acl
+libmpc
+gawk
+inetutils
+sed
+coreutils
+gcc
+gcc-libs
+tcl
+python-minimal
+pcre
+patchelf
+gettext
+db
+expect
+less
+grep
+perl
+dejagnu
+texinfo
+automake
+autoconf 
+```
+
+## The remainder 
+These packages are generally safe to update in a normal builder workflow, but still
+require additional care when updating. Updates to these plans should be coordinated 
+with the Habitat team when possible.
+
+If the dependencies of these plans change, which is rare but does happen, they should
+be checked to see if it moves the plan in to the 'Gang of 4X' cycle. If it does, 
+then that update should be made as part of the next base plans refresh.
+
+```
+shadow 
+psmisc 
+readline 
+bash 
+bc 
+tar 
+libtool 
+gdbm 
+expat 
+iana-etc 
+perl 
+gzip 
+expect 
+dejagnu 
+check 
+libidn 
+cacerts 
+openssl
+libiconv 
+libunistring 
+libidn2 
+wget 
+qnzip 
+rq 
+linux-headers-musl 
+musl 
+busybox-static 
+zlib-musl 
+bzip2-musl 
+xz-musl 
+libsodium-musl 
+openssl-musl 
+libarchive-musl 
+rust
+vim 
+libbsd 
+clens 
+mg 
+```
+
+# Base plans refresh
+
+The base plans refresh is a process though which updateds to critical packages, such as
+glibc and gcc are made, which causes the entire `core` origin to need rebuilding. 
+
+The process as it exists today is an artifact of Builder being unable to build on changes
+to build dependencies (`pkg_build_deps`), in addition to being unable to handle the cycle
+of the 'Gang of 4X'. Today, to update the base plans involved in a cycle, multiple builds
+must be performed manually, in a specific order defined `base-plans.txt`. Once those builds
+are complete, the remainder of core must be built offline against those packages, in 
+a topologically sorted order base on run time dependencies.
+ 
+In the near future, Builder will be able to handle building updates that will remove the 
+need for the offline builds, allowing us to treat updates to packages such as `gcc` similar
+to how we might update `redis`. However, there will still likely remain some ceremony around
+updates to these packages, due to the scope of rebuilds and impact that they could have 
+on the ecosystem. 

--- a/docs/dev/guide_documents/base-plans.md
+++ b/docs/dev/guide_documents/base-plans.md
@@ -3,9 +3,9 @@ The following plans are collectively known as the "base" plans. They are the
 the minimum set of packages required in order to build the Habitat cli, 
 plan-build and the studio. Habitat is a self-hosting system; The build system, 
 plan-build, is a Habitat package that depends on other Habitat packages to run.
-Those packages were build with plan-build. If a change were to produce a studio 
+Those packages were built with plan-build. If a change were to produce a studio 
 or plan-build package that failed at run time, it would require manual 
-intervetion and builds to correct.  As such plans in this list require 
+intervention and builds to correct.  As such plans in this list require 
 additional care when merging.
 
 The base plans can be further divided into two groups. 


### PR DESCRIPTION
> As a maintainer of core-plans I want to understand why some plans are considered
'base plans', and why only some of those can be updated outside of a refresh,
and why some need to wait.

> As a user of core plans, I want to know what the base plans refresh is, why
it is necessary and what it entails.

This PR attempts to explain at a high level what a base plan is and why they require
extra care when merging. It also breaks apart which plans require a refresh to be
updated, and why, and which can be updated outside of a refresh.

Finally, the process around the refresh, why it exists and how it might change as
Builder is able to handle more complex workloads is covered.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>