### PR TITLE
[curl] bump 7.68.0 -> 7.70.0

### DIFF
--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -3,7 +3,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../curl/plan.sh"
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.68.0
+pkg_version=7.70.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/

--- a/curl-static-musl/tests/test.bats
+++ b/curl-static-musl/tests/test.bats
@@ -9,3 +9,8 @@ TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
   run hab pkg exec ${TEST_PKG_IDENT} curl -s -o /dev/null -w "%{http_code}" "https://www.example.org/"
   [ "$output" -eq 200 ]
 }
+
+@test "JSON output" {
+  run hab pkg exec ${TEST_PKG_IDENT} curl -s -o /dev/null -w "%{json}" "https://www.example.org/"
+  jq -ne --argjson output "$output" '$output.http_code == 200'
+}

--- a/curl-static-musl/tests/test.sh
+++ b/curl-static-musl/tests/test.sh
@@ -1,18 +1,1 @@
-#!/bin/sh
-#/ Usage: test.sh <pkg_ident>
-#/
-#/ Example: test.sh core/php/7.2.8/20181108151533
-#/
-
-set -euo pipefail
-
-if [[ -z "${1:-}" ]]; then
-  grep '^#/' < "${0}" | cut -c4-
-	exit 1
-fi
-
-TEST_PKG_IDENT="${1}"
-export TEST_PKG_IDENT
-hab pkg install core/bats --binlink
-hab pkg install "${TEST_PKG_IDENT}"
-bats "$(dirname "${0}")/test.bats"
+source "$(dirname "${BASH_SOURCE[0]}")/../../curl/tests/test.sh"

--- a/curl/plan.sh
+++ b/curl/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=curl
 pkg_origin=core
-pkg_version=7.68.0
+pkg_version=7.70.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source="https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358
+pkg_shasum=ca2feeb8ef13368ce5d5e5849a5fd5e2dd4755fecf7d8f0cc94000a4206fb8e7
 pkg_deps=(
   core/cacerts
   core/glibc

--- a/curl/tests/test.bats
+++ b/curl/tests/test.bats
@@ -9,3 +9,8 @@ expected_version=$(cut -d/ -f3 <<< $TEST_PKG_IDENT)
   run hab pkg exec $TEST_PKG_IDENT curl -s -o /dev/null -w "%{http_code}" "https://www.example.org/"
   [ "$output" -eq 200 ]
 }
+
+@test "JSON output" {
+  run hab pkg exec ${TEST_PKG_IDENT} curl -s -o /dev/null -w "%{json}" "https://www.example.org/"
+  jq -ne --argjson output "$output" '$output.http_code == 200'
+}

--- a/curl/tests/test.sh
+++ b/curl/tests/test.sh
@@ -13,6 +13,6 @@ fi
 
 TEST_PKG_IDENT="${1}"
 export TEST_PKG_IDENT
-hab pkg install core/bats --binlink
+hab pkg install core/bats core/jq-static --binlink
 hab pkg install "${TEST_PKG_IDENT}"
 bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Also tried to deduplicate the test scripts. Haven't found a simple way
to do the same to test.bats.
