### PR TITLE
[cmake] Upgrade to 3.17.2

### DIFF
--- a/cmake/plan.ps1
+++ b/cmake/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="cmake"
 $pkg_origin="core"
-$base_version="3.16"
-$pkg_version="$base_version.0"
+$base_version="3.17"
+$pkg_version="$base_version.2"
 $pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 $pkg_upstream_url="https://cmake.org/"
 $pkg_license=@("BSD-3-Clause")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="http://cmake.org/files/v$base_version/cmake-$pkg_version-win64-x64.msi"
-$pkg_shasum="067b1d3b203e0cb7da3549c2e04986e8eed0bd7002f14731569e3aae3d1f81f0"
+$pkg_shasum="06e999be9e50f9d33945aeae698b9b83678c3f98cedb3139a84e19636d2f6433"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/cmake/plan.sh
+++ b/cmake/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cmake
 pkg_origin=core
-_base_version=3.16
-pkg_version=${_base_version}.0
+_base_version=3.17
+pkg_version=${_base_version}.2
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('BSD-3-Clause')
 pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 pkg_upstream_url="https://cmake.org/"
 pkg_source="https://cmake.org/files/v${_base_version}/cmake-${pkg_version}.tar.gz"
-pkg_shasum=6da56556c63cab6e9a3e1656e8763ed4a841ac9859fefb63cbe79472e67e8c5f
+pkg_shasum=fc77324c4f820a09052a7785549b8035ff8d3461ded5bbd80d252ae7d1cd3aa5
 pkg_deps=(
   core/glibc
   core/gcc-libs


### PR DESCRIPTION
The changelog for this release can be found here:

https://cmake.org/cmake/help/v3.17/release/3.17.html

More specifically, this bug

https://gitlab.kitware.com/cmake/cmake/-/issues/20065

is supposedly fixed. I think that bug is the most proximate cause for
the build failures of core/sentinel.

Signed-off-by: Steven Danna <steve@chef.io>