### PR TITLE
[runc] Update to runc 1.0.0-rc10

### DIFF
--- a/runc/plan.sh
+++ b/runc/plan.sh
@@ -1,12 +1,44 @@
 pkg_name="runc"
 pkg_origin="core"
-pkg_version=0.1.1
+pkg_version=1.0.0-rc10
 pkg_description="CLI tool for spawning and running containers according to the OCI specification"
 pkg_upstream_url="https://www.opencontainers.org/"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/opencontainers/runc"
-pkg_shasum="73549dc3eb29005dae5248385c6b40310a323b817714853d35d7194abfa357b8"
 pkg_bin_dirs=(bin)
 pkg_scaffolding=core/scaffolding-go
-pkg_build_deps=(core/pkg-config core/libseccomp)
+pkg_build_deps=(core/pkg-config
+                core/libseccomp)
+
+# We have to override a handful of callbacks from the go scaffolding
+# in order for things to work properly.
+
+# Overridden in order to be able to target a specific release of runc;
+# absent this, we build based on whatever is on the master branch at
+# the time of the build. Additionally, without this, the defined
+# `pkg_version` has no connection at all to the code that is
+# ultimately built.
+do_download() {
+    mkdir -p "$scaffolding_go_pkg_path"
+    git clone \
+        --branch "v${pkg_version}" \
+        --single-branch \
+        "${pkg_source}" \
+        "${scaffolding_go_pkg_path}"
+}
+
+# Overridden to provide a static binary.
+do_build() {
+  (
+      cd "${scaffolding_go_pkg_path}"
+      make static
+  )
+}
+
+# The go scaffolding uses `go install` in this callback, which appears
+# to build the binary a second time, but with a different
+# configuration as used in `do_build`. This simply copies the binary.
+do_install() {
+    cp "${scaffolding_go_pkg_path}/runc" "${pkg_prefix}/bin"
+}

--- a/runc/tests/test.bats
+++ b/runc/tests/test.bats
@@ -1,0 +1,25 @@
+@test "Version matches" {
+    # Ensure that `pkg_version` from the plan (embedded in the package
+    # identifier) matches the output from `runc --version`.
+    version="$(echo ${PKGIDENT} | cut -d/ -f3)"
+    result="$(hab pkg exec "${PKGIDENT}" runc --version | head -n1)"
+    [ "$result" = "runc version ${version}" ]
+}
+
+@test "Binary is statically compiled" {
+    # The output of `file` will contain (among other data) the
+    # string "statically linked" or "dynamically linked"; we want the former.
+    result="$(hab pkg exec core/file file /hab/pkgs/"${PKGIDENT}"/bin/runc)"
+    [[ "$result" =~ "statically linked" ]]
+}
+
+@test "Compiled with libseccomp support" {
+    # There may be better ways of determining this, but a version with
+    # libseccomp support will include numerous strings pointing to the
+    # Go seccomp library; one that hasn't been so compiled will *not*
+    # include these, but will instead include references to indicate
+    # seccomp is not supported.
+    result="$(hab pkg exec core/binutils strings /hab/pkgs/${PKGIDENT}/bin/runc)"
+    [[ "$result" =~ "github.com/opencontainers/runc/vendor/github.com/seccomp/libseccomp-golang" ]]
+    ! [[ "$result" =~ "github.com/opencontainers/runc/libcontainer/seccomp/seccomp_unsupported.go" ]]
+}

--- a/runc/tests/test.sh
+++ b/runc/tests/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Usage: test.sh <pkg_ident>
+#
+# Example: test.sh core/runc/1.0.0-rc10/20200507191843
+
+set -euo pipefail
+
+PKGIDENT="${1}"
+export PKGIDENT
+
+hab pkg install core/bats --binlink
+hab pkg install core/binutils # for strings
+hab pkg install core/file # for file
+hab pkg install "${PKGIDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
In addition to updating to the current version of `runc`, this commit
addresses a handful of problems with the `runc` plan.

First, despite a `pkg_version` being specified in the plan, the build
logic from the Go scaffolding resulted in unspecified code being
built. You would end up building whatever happened to be on the master
branch of https://github.com/opencontainers/runc at the time of your
build.

Now, the download logic has been overridden to grab the code on the
branch specified by `pkg_version` so we can a) reliably build the same
thing over and over, and b) have `pkg_version` correspond to the
contents of the resulting package.

Second, we now create a static binary.

Third, the installation logic of the Go scaffolding has been
overridden. Previously, despite running `make` in the `do_build`
callback, we would run `go install` in the `do_install` callback. This
ended up running `go build` and then installing *that* binary in our
package. Since there is considerably more logic in `runc`'s Makefile,
this actually resulted in a binary *without* compiled support for
`libseccomp`, despite it being a build dependency! Now, we simply copy
the binary created from the `do_build` callback, and everything works.

(The `pkg_shasum` line was removed because it wasn't being used by
anything.)

Tests for all these conditions are included in `tests/test.bats`.

Signed-off-by: Christopher Maier <cmaier@chef.io>