### PR TITLE
[devicemapper] Add pkg-config support

### DIFF
--- a/devicemapper/plan.sh
+++ b/devicemapper/plan.sh
@@ -19,3 +19,9 @@ pkg_deps=(
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(sbin)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+    ./configure --prefix="$pkg_prefix" --enable-pkgconfig
+    make
+}

--- a/devicemapper/tests/test.bats
+++ b/devicemapper/tests/test.bats
@@ -1,6 +1,6 @@
 @test "Version matches" {
     version="$(echo ${PKGIDENT} | cut -d/ -f3)"
-    result="$(hab pkg exec "${PKGIDENT}" vgs --version 2> /dev/null | grep -e 'LVM version' | awk '{print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
+    result="$(hab pkg exec "${PKGIDENT}" vgs --version 2> /dev/null | awk '/LVM version/ {print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
     [ "$result" = "${version}" ]
 }
 

--- a/devicemapper/tests/test.bats
+++ b/devicemapper/tests/test.bats
@@ -3,4 +3,9 @@
     result="$(hab pkg exec "${PKGIDENT}" vgs --version 2> /dev/null | grep -e 'LVM version' | awk '{print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
     [ "$result" = "${version}" ]
 }
+
+@test "Compiled with pkg-config support" {
+    # If compiled with `pkg-config` support, we should find a
+    # `pkg-config` metadata file in the package.
+    [ -f "/hab/pkgs/${PKGIDENT}/lib/pkgconfig/devmapper.pc" ]
 }

--- a/devicemapper/tests/test.bats
+++ b/devicemapper/tests/test.bats
@@ -1,6 +1,6 @@
-source "${BATS_TEST_DIRNAME}/../plan.sh"
-
 @test "Version matches" {
-  result="$(vgs --version 2> /dev/null | grep -e 'LVM version' | awk '{print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
-  [ "$result" = "${pkg_version}" ]
+    version="$(echo ${PKGIDENT} | cut -d/ -f3)"
+    result="$(hab pkg exec "${PKGIDENT}" vgs --version 2> /dev/null | grep -e 'LVM version' | awk '{print $3}' | awk '{gsub("[(][^)]*[)]","")}1')"
+    [ "$result" = "${version}" ]
+}
 }

--- a/devicemapper/tests/test.sh
+++ b/devicemapper/tests/test.sh
@@ -1,21 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Usage: test.sh <pkg_ident>
+#
+# Example: test.sh core/devicemapper/2.03.00/20200507192941
 
-TESTDIR="$(dirname "${0}")"
-PLANDIR="$(dirname "${TESTDIR}")"
-SKIPBUILD=${SKIPBUILD:-0}
+set -euo pipefail
+
+PKGIDENT="${1}"
+export PKGIDENT
 
 hab pkg install core/bats --binlink
-
-source "${PLANDIR}/plan.sh"
-
-if [ "${SKIPBUILD}" -eq 0 ]; then
-  set -e
-  pushd "${PLANDIR}" > /dev/null
-  build
-  source results/last_build.env
-  hab pkg install "results/${pkg_artifact}" --binlink --force
-  popd > /dev/null
-  set +e
-fi
-
-bats "${TESTDIR}/test.bats"
+hab pkg install "${PKGIDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This allows packages that depend on `core/devicemapper` to configure themselves properly during build.