### PR TITLE
[buildah] Add new core/buildah plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -83,6 +83,8 @@ plan_path = "boost159"
 plan_path = "boringssl"
 [btrfs-progs]
 plan_path = "btrfs-progs"
+[buildah]
+plan_path = "buildah"
 [buildkite-agent]
 plan_path = "buildkite-agent"
 [buildkite-cli]

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -1,0 +1,17 @@
+# buildah
+
+[Buildah][1]: A tool that facilitates building OCI container images.
+
+## Maintainers
+
+The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+This is a binary package.
+
+## Usage
+
+Add `core/buildah` to `pkg_deps` in your `plan.sh`.
+
+[1]: https://buildah.io

--- a/buildah/plan.sh
+++ b/buildah/plan.sh
@@ -1,0 +1,59 @@
+pkg_name=buildah
+pkg_origin=core
+pkg_version="1.14.8"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_deps=(
+    core/devicemapper
+    core/gpgme
+    core/libassuan
+    core/libgpg-error
+    core/libseccomp
+    core/runc
+    core/shadow
+    core/util-linux
+)
+pkg_build_deps=(
+    core/btrfs-progs
+    core/bzip2
+    core/coreutils
+    core/gcc
+    core/git
+    core/go
+    core/make
+    core/pkg-config
+)
+pkg_bin_dirs=(bin)
+pkg_description="A tool which facilitates building OCI images"
+pkg_upstream_url="https://github.com/containers/buildah"
+
+do_download() {
+    repo_path="${HAB_CACHED_SRC_PATH}/${pkg_dirname}"
+    rm -Rf "${repo_path}"
+    git clone \
+        --branch "v${pkg_version}" \
+        --single-branch \
+        "${pkg_upstream_url}" \
+        "${repo_path}"
+}
+
+do_prepare() {
+    # Buildah has a few accessory scripts that have `#!/usr/bin/env`
+    # shebang lines, so we have to make them happy
+    if [[ ! -r /usr/bin/env ]]; then
+        ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+    fi
+}
+
+do_build() {
+    (
+        cd "${HAB_CACHED_SRC_PATH}/${pkg_dirname}"
+        export CGO_LDFLAGS="$LDFLAGS"
+        export CGO_CFLAGS="$CFLAGS"
+        make
+    )
+}
+
+do_install() {
+    cp "${HAB_CACHED_SRC_PATH}/${pkg_dirname}/buildah" "${pkg_prefix}/bin"
+}

--- a/buildah/tests/test.bats
+++ b/buildah/tests/test.bats
@@ -1,0 +1,9 @@
+@test "Version matches" {
+    # Ensure that `pkg_version` from the plan (embedded in the package
+    # identifier) matches the output from `buildah --version`.
+    version="$(echo ${PKGIDENT} | cut -d/ -f3)"
+    result="$(hab pkg exec "${PKGIDENT}" buildah --version)"
+    # The full output will look something like this:
+    #     buildah version 1.14.8 (image-spec 1.0.1-dev, runtime-spec 1.0.1-dev)
+    [[ "$result" =~ "buildah version ${version}" ]]
+}

--- a/buildah/tests/test.sh
+++ b/buildah/tests/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Usage: test.sh <pkg_ident>
+#
+# Example: test.sh core/buildah/1.14.8/20200507194711
+
+set -euo pipefail
+
+PKGIDENT="${1}"
+export PKGIDENT
+
+hab pkg install core/bats --binlink
+hab pkg install "${PKGIDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Before this merges, the following PRs will need to be merged, and their packages promoted to `stable` first:

- [x] https://github.com/habitat-sh/core-plans/pull/3360 [runc] Update to runc 1.0.0-rc10
- [x] https://github.com/habitat-sh/core-plans/pull/3361 [devicemapper] Add pkg-config support
- [x] https://github.com/habitat-sh/core-plans/pull/3362 [btrfs-progs] Add new core/btrfs-progs plan

Signed-off-by: Christopher Maier <cmaier@chef.io>