### PR TITLE
[ruby24] Removing ruby24 from bldr.toml

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1322,8 +1322,6 @@ plan_path = "rq"
 plan_path = "rsync"
 [ruby]
 plan_path = "ruby"
-[ruby24]
-plan_path = "ruby24"
 paths = [
   "ruby/*"
 ]


### PR DESCRIPTION
Ruby24 was deprecated by #3309

This will remove it from the .bldr.toml to ensure it isn't linked with builder

Signed-off-by: MindNumbing <SMarshall@chef.io>