### PR TITLE
[openresty] Update openresty to 1.15.8.3, update tests

### DIFF
--- a/openresty/plan.sh
+++ b/openresty/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=openresty
 pkg_origin=core
-pkg_version=1.15.8.1
+pkg_version=1.15.8.3
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://openresty.org/download/${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=89a1238ca177692d6903c0adbea5bdf2a0b82c383662a73c03ebf5ef9f570842
+pkg_shasum=b68cf3aa7878db16771c96d9af9887ce11f3e96a1e5e68755637ecaff75134a8
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/openresty/tests/test.sh
+++ b/openresty/tests/test.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
 if [[ -z "${1:-}" ]]; then
   grep '^#/' < "${0}" | cut -c4-
 	exit 1
@@ -18,13 +20,10 @@ hab pkg install core/busybox-static
 hab pkg binlink core/busybox-static netstat
 hab pkg install "${TEST_PKG_IDENT}"
 
-hab sup term
-hab sup run &
-sleep 5
+WAIT_SECONDS=10
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}" "${WAIT_SECONDS}"
 
-hab svc load "${TEST_PKG_IDENT}"
-
-# Allow service start
 WAIT_SECONDS=5
 echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
 sleep "${WAIT_SECONDS}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build openresty
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Service is running
 ✓ Listening on port 80

3 tests, 0 failures
```
