### PR TITLE
[packer] Update packer to 1.5.6

### DIFF
--- a/packer/plan.ps1
+++ b/packer/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="packer"
 $pkg_origin="core"
-$pkg_version="1.4.5"
+$pkg_version="1.5.6"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('MPL2')
 $pkg_bin_dirs=@("bin")
 $pkg_source="https://releases.hashicorp.com/packer/${pkg_version}/packer_${pkg_version}_windows_amd64.zip"
-$pkg_shasum="5da1b38beaad735a8b7390865d33e5f60d830fa93e5485f593aae2254dcc4ad8"
+$pkg_shasum="60c5220bd2617e95949a930625c3276f704ffbb54039312a0a040379786ac49e"
 
 function Invoke-Install {
     Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_name-$pkg_version/$pkg_name.exe" $pkg_prefix\bin

--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.4.5
+pkg_version=1.5.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=30da8dab9c526a6d15b037e2234f6f12cf3accfad77eb2c130738ec1a54cab6d
+pkg_shasum=2abb95dc3a5fcfb9bf10ced8e0dd51d2a9e6582a1de1cab8ccec650101c1f9df
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build packer
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command

2 tests, 0 failures
```
