### PR TITLE
[netdata] Update netdata to 1.22.1

### DIFF
--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=netdata
 pkg_origin=core
-pkg_version=1.17.0
+pkg_version=1.22.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
 pkg_description="netdata is a system for distributed real-time performance and health monitoring."
 pkg_upstream_url="https://github.com/netdata/netdata"
 pkg_source="https://github.com/netdata/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=2dc0d510a31655bab4c269b78e1619fcdce38bf79335966d61d6bbd7bed736c5
+pkg_shasum=6efd785eab82f98892b4b4017cadfa4ce1688985915499bc75f2f888765a3446
 pkg_build_deps=(
   core/autoconf
   core/autogen
@@ -24,6 +24,7 @@ pkg_deps=(
   core/util-linux
   core/zlib
   core/coreutils
+  core/libuv
 )
 pkg_bin_dirs=(sbin)
 pkg_exports=(
@@ -51,8 +52,6 @@ do_install() {
   do_default_install || return $?
 
   pushd "${pkg_prefix}" > /dev/null
-
-  rm -r "./var"
 
   build_line "Fixing libexec interpreters"
   find ./libexec/netdata -type f -executable \

--- a/netdata/tests/test.sh
+++ b/netdata/tests/test.sh
@@ -31,3 +31,5 @@ sleep "${WAIT_SECONDS}"
 
 bats "$(dirname "${0}")/test.bats"
 hab svc unload "${TEST_PKG_IDENT}" || true
+echo "Waiting ${WAIT_SECONDS} seconds for service to unload..."
+sleep "${WAIT_SECONDS}"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build netdata
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Help command
 ✓ Service is running
 ✓ Listening on port 19999

4 tests, 0 failures
```