### PR TITLE
[kafka2] Update pkg_name

### DIFF
--- a/kafka2/plan.sh
+++ b/kafka2/plan.sh
@@ -1,5 +1,5 @@
+pkg_name=kafka2
 pkg_root_name="kafka"
-pkg_name=${pkg_root_name}2
 pkg_origin=core
 pkg_version=2.5.0
 pkg_source="https://downloads.apache.org/${pkg_root_name}/${pkg_version}/${pkg_root_name}_2.13-${pkg_version}.tgz"


### PR DESCRIPTION
Builder reads the file without evaluating it to assert that the pkg_name is a valid set of characters. Since this isn't being evaluated in a bash context, it is read as a string literal and doesn't support variable interpolation in pkg_name.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>