### PR TITLE
[strace] Update strace to 5.7

### DIFF
--- a/strace/plan.sh
+++ b/strace/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=strace
 pkg_origin=core
-pkg_version=5.4
+pkg_version=5.7
 pkg_license=("LGPL-2.1-or-later")
 pkg_description="strace is a system call tracer for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_upstream_url="https://strace.io/"
+pkg_upstream_url=https://strace.io/
 pkg_source="https://github.com/strace/strace/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=f7d00514d51290b6db78ad7a9de709baf93caa5981498924cbc9a744cfd2a741
+pkg_shasum=b284b59f9bcd95b9728cea5bd5c0edc5ebe360af73dc76fbf6334f11c777ccd8
 pkg_deps=(
   core/glibc
   core/libunwind


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Testing

```
hab pkg build strace
source results/last_build.env
hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

### Sample output

```
 ✓ Version matches
 ✓ Can strace

2 tests, 0 failures
```