### PR TITLE
[dsc-core] fix concurrency issues

### DIFF
--- a/dsc-core/README.md
+++ b/dsc-core/README.md
@@ -6,6 +6,8 @@ Note that this plan takes a dependency on the `core/ps-lock` plan to ensure that
 
 The plan puts its `psd1` and `psm1` files in the `PSModulePath` so that its function `Start-DscCore` is automatically discoverable.
 
+Calls to `Start-DscCore` will set the LCM's `RefreshMode` to `Push` and `ConfigurationMode` to `ApplyOnly`. These properties are reset to their original values after `Start-DscCore` completes.
+
 ## Maintainers
 
 The Habitat Maintainers humans@habitat.sh
@@ -123,17 +125,6 @@ Enter-PSLock -Name $(Get-DscLock) -Interval 10 -Splay 10 {
 ```
 
 If the `chef-client` only needs to run once, you can ommit the `-Interval` and `-Splay` arguments.
-
-### Problems using in a local Windows Studio
-
-The `PSModulePath` in a local Windows studio (one started with `hab studio enter -w`) will get assigned the wrong package path and thus simply calling `Start-DscCore` will not automatically import this module.
-
-You can work around this by explicitly importing the module before using the command:
-
-```PowerShell
-Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
-Start-DscCore (Join-Path {{pkg.svc_config_path}} firewall.ps1) NewFirewallRule
-```
 
 # Testing
 

--- a/dsc-core/plan.ps1
+++ b/dsc-core/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="dsc-core"
 $pkg_origin="core"
-$pkg_version="0.3.0"
+$pkg_version="0.3.1"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Apache-2.0")
 $pkg_description="Compiles and applies DSC configurations in Powershell Core"
 $pkg_build_deps=@("core/ps-lock")
 
 function Invoke-SetupEnvironment {
-    Push-RuntimeEnv "PSModulePath" "\hab\pkgs\$pkg_origin\$pkg_name\$pkg_version\$pkg_release\Modules"
+    Push-RuntimeEnv -IsPath "PSModulePath" "\hab\pkgs\$pkg_origin\$pkg_name\$pkg_version\$pkg_release\Modules"
 }
 
 function Invoke-Install {

--- a/dsc-core/tests/test.pester.ps1
+++ b/dsc-core/tests/test.pester.ps1
@@ -32,12 +32,12 @@ InModuleScope -ModuleName DSCCore {
                 $? | Should be $true
             }
         }
-        Context 'Set-LcmRefreshMode' {
+        Context 'Set-LcmConfig' {
             Mock Invoke-CimMethod {}
             Mock New-ConfigurationData {}
             Mock Set-LcmMetaConfig {}
             It 'Runs with no errors' {
-                Set-LcmRefreshMode Push
+                Set-LcmConfig -RefreshMode Push -ConfigurationMode ApplyOnly
                 $? | Should be $true
             }
         }
@@ -46,7 +46,7 @@ InModuleScope -ModuleName DSCCore {
         Mock Enter-PSLock {Invoke-Command -ScriptBlock $ScriptBlock}
         Mock Enter-QuietProgress {Invoke-Command -ScriptBlock $block}
         Mock Wait-LCMReady {}
-        Mock Set-LcmRefreshMode {}
+        Mock Set-LcmConfig {}
         Mock Invoke-CimMethod {}
         Context "test_without_resource" {
             Mock New-ConfigurationData {}
@@ -67,7 +67,7 @@ InModuleScope -ModuleName DSCCore {
         Mock Enter-PSLock -ModuleName DSCCore {Invoke-Command -ScriptBlock $ScriptBlock}
         Mock Enter-QuietProgress -ModuleName DSCCore {Invoke-Command -ScriptBlock $block}
         Mock Wait-LCMReady -ModuleName DSCCore {}
-        Mock Set-LcmRefreshMode -ModuleName DSCCore {}
+        Mock Set-LcmConfig -ModuleName DSCCore {}
 
         Context "no mof file generated" {
             Mock Remove-Item {}
@@ -102,7 +102,6 @@ InModuleScope -ModuleName DSCCore {
     Describe "Invoke-DSCCommandFile" -tag Unit {
         Context "no config data passed" {
             Mock ConvertTo-Json {}
-            Mock ConvertFrom-Json {}
             $results = Invoke-DSCCommandFile -config "function test_dsc_function (`$OutputPath){@{FullName  = 'c:\temp\fake.mof';Directory = `$OutputPath}}" -func test_dsc_function
             # Clean up temp folder
             Remove-Item $results.directory -Recurse
@@ -128,15 +127,29 @@ InModuleScope -ModuleName DSCCore {
             It "should have initial configuration data of type ArrayList" {
                 $cd.AllNodes -is [System.Collections.ArrayList] | should be $true
             }
-
-            It "should convert ConfigData to an object array that works with DSC" {
-                $results.ConfigurationData.AllNodes -is [PSObject[]] | should be $true
-            }
         }
     }
 }
 
 Describe "dsc-core" -tag Functional {
+    BeforeAll {
+        Invoke-Command -EnableNetworkAccess -computername localhost {
+            [DSCLocalConfigurationManager()]
+            configuration LCMConfig
+            {
+                Node localhost
+                {
+                    Settings
+                    {
+                        RefreshMode = "Disabled"
+                        ConfigurationMode = "ApplyAndMonitor"
+                    }
+                }
+            }
+            LCMConfig -OutputPath c:\temp\config
+            Set-DscLocalConfigurationManager -Path c:\temp\config
+        }
+    }
     Context "Apply Configuration with file resource" {
         It "creates the directory" {
             Start-DscCore (Join-Path $PSScriptRoot test_config.ps1) test_with_resource
@@ -188,6 +201,14 @@ Describe "dsc-core" -tag Functional {
         It "runs without error" {
             Start-DscCore (Join-Path $PSScriptRoot test_config.ps1) test_cleanup
             $? | Should be $true
+        }
+
+        It "resets LCM settings" {
+            $conf = Invoke-Command -EnableNetworkAccess -computername localhost {
+                Get-DscLocalConfigurationManager
+            }
+            $conf.RefreshMode | Should be "Disabled"
+            $conf.ConfigurationMode | Should be "ApplyAndMonitor"
         }
     }
 }

--- a/dsc-core/tests/test.pester.ps1
+++ b/dsc-core/tests/test.pester.ps1
@@ -125,7 +125,7 @@ InModuleScope -ModuleName DSCCore {
             $results = Invoke-DSCCommandFile -config "function test_dsc_function (`$OutputPath, `$ConfigurationData){@{Directory = `$OutputPath;ConfigurationData = `$ConfigurationData}}" -func test_dsc_function -ConfigData $cd
             Remove-Item $results.directory -Recurse
             It "should have initial configuration data of type ArrayList" {
-                $cd.AllNodes -is [System.Collections.ArrayList] | should be $true
+                $cd.AllNodes -is [System.Collections.ArrayList] | Should be $true
             }
         }
     }
@@ -135,13 +135,10 @@ Describe "dsc-core" -tag Functional {
     BeforeAll {
         Invoke-Command -EnableNetworkAccess -computername localhost {
             [DSCLocalConfigurationManager()]
-            configuration LCMConfig
-            {
-                Node localhost
-                {
-                    Settings
-                    {
-                        RefreshMode = "Disabled"
+            configuration LCMConfig {
+                Node localhost {
+                    Settings {
+                        RefreshMode       = "Disabled"
                         ConfigurationMode = "ApplyAndMonitor"
                     }
                 }


### PR DESCRIPTION
fixes #3364, #2554 

This PR makes the following changes:

* `Set` calls to the LCM are retryable. The LCM, by default, will perform a "consistency check" every 15 minutes and shortly after a restart. Exactly when these are invoked is completely beyond Habitat's or a service hook's control. While we have waited for the LCM to be in an `idle` state before performing a `set` (it is `busy` during a consistency check), we have seen cases where we find it is `idle` but then begins the check before the `set`. So this takes the extra measure of retrying and waiting again for an `idle` state before the next attempt.
* `Get` calls on LCM state are also now retryable. I more rare case is where we check the state of the LCM while another hook might be performing a `set` which results in an error.
* Set the LCM `ConfigurationMode` to `ApplyOnly` while we apply a DSC configuration and then reset it back to its original state. The default mode is `ApplyAndMonitor`. Setting it to `ApplyOnly` makes any consistency check (mentioned above) much shorter because it is not checking the state of previous converges.
* Use `-IsPath` when setting PSModulePath in the plan. `-IsPath` is relatively new and ensures that setting environment variables to a path will work when running the package in a local studio.

While I did add a test to make sre the LCM state was being reset. Testing the concurrency errors is tricky in an automated test. I loaded a supervisor with 3 services that all perform DSC operations. While it was running I manually invoked a consistency check repeatedly with:

```
Invoke-CimMethod -Name PerformRequiredConfigurationChecks -Namespace root/Microsoft/Windows/D
esiredStateConfiguration -Arguments @{Flags=[Uint32]2} -ClassName MSFT_DscLocalConfigurationManager -verbose
```
I was able to see the errors we were seeing while running with the current stable `dsc-core` package. After installing one built from this PR, and rebuilding my 3 services and reloading them, the errors went away and I could see the retry messages in the log.


Signed-off-by: mwrock <matt@mattwrock.com>