### PR TITLE
[elasticsearch] Corrects config issues that prevent package from running out of the box

### DIFF
--- a/elasticsearch/default.toml
+++ b/elasticsearch/default.toml
@@ -141,7 +141,7 @@
   #
   # Set the bind address to a specific IP (IPv4 or IPv6):
   #
-  host =  "_site_"
+  host =  "127.0.0.1"
   #
   # Set a custom port for HTTP:
   #
@@ -160,7 +160,7 @@
   # Pass an initial list of hosts to perform discovery when new node is started:
   # The default list of hosts is ["127.0.0.1", "[::1]"]
   #
-  ping_unicast_hosts = "[]"
+  ping_unicast_hosts = ["127.0.0.1"]
   #
   # Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
   #

--- a/elasticsearch/hooks/run
+++ b/elasticsearch/hooks/run
@@ -2,6 +2,10 @@
 
 exec 2>&1
 
+export TMPDIR="{{pkg.svc_var_path}}/tmp"
+export ES_TMPDIR="{{pkg.svc_var_path}}/tmp"
+export ES_PATH_CONF="{{pkg.svc_config_path}}"
+
 {{#if cfg.runtime.es_startup_sleep_time ~}}
 export ES_STARTUP_SLEEP_TIME={{cfg.runtime.es_startup_sleep_time}}
 {{/if ~}}


### PR DESCRIPTION
In testing some other packages we found that the elasticsearch package does not run out of box. These changes to the default value allow the service to start in a standalone state without any extra configuration. They match the default configuration provided by upstream elasticsearch config files.

Signed-off-by: Ian Henry <ianjhenry00@gmail.com>