### PR TITLE
[windows-10-sdk] set WindowsSdkDir_10 so msbuild uses this package path

### DIFF
--- a/windows-10-sdk/plan.ps1
+++ b/windows-10-sdk/plan.ps1
@@ -24,6 +24,10 @@ $pkg_include_dirs=@(
     "Windows Kits\10\Include\10.0.17763.0\winrt"
 )
 
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv -IsPath "WindowsSdkDir_10" "$pkg_prefix\Windows Kits\10"
+}
+
 function Invoke-Unpack {
     Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/features OptionId.DesktopCPPx64 /quiet /layout $HAB_CACHE_SRC_PATH/$pkg_dirname"
     Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"


### PR DESCRIPTION
Currently plans that consume this package for building native apps need to magically know to set this or go through the pain of debugging msbuild target files which might lead them to this knowledge.

Signed-off-by: mwrock <matt@mattwrock.com>