### PR TITLE
[visual-build-tools-2017] Ensure msbuild honors environment variables above registry

### DIFF
--- a/visual-build-tools-2017/plan.ps1
+++ b/visual-build-tools-2017/plan.ps1
@@ -22,6 +22,11 @@ $pkg_include_dirs=@(
     "Contents\VC\Tools\MSVC\14.16.27023\include"
 )
 
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv "DisableRegistryUse" "true"
+    Set-RuntimeEnv "UseEnv" "true"
+}
+
 function Invoke-Unpack {
     $installArgs = "--quiet --layout $HAB_CACHE_SRC_PATH/$pkg_dirname --lang en-US"
     @(
@@ -33,14 +38,14 @@ function Invoke-Unpack {
     ) | ForEach-Object {
         $installArgs += " --add $_"
     }
-Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList $installArgs
-Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-try {
-    Get-ChildItem "$HAB_CACHE_SRC_PATH/$pkg_dirname" -Include *.vsix -Exclude @('*x86*', '*.arm.*') -Recurse | ForEach-Object {
-        Rename-Item $_ "$_.zip"
-        Expand-Archive "$_.zip" expanded -force
-    }
-} finally { Pop-Location }
+    Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList $installArgs
+    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    try {
+        Get-ChildItem "$HAB_CACHE_SRC_PATH/$pkg_dirname" -Include *.vsix -Exclude @('*x86*', '*.arm.*') -Recurse | ForEach-Object {
+            Rename-Item $_ "$_.zip"
+            Expand-Archive "$_.zip" expanded -force
+        }
+    } finally { Pop-Location }
 }
 
 function Invoke-Install {

--- a/visual-build-tools-2017/plan.ps1
+++ b/visual-build-tools-2017/plan.ps1
@@ -29,14 +29,15 @@ function Invoke-SetupEnvironment {
 
 function Invoke-Unpack {
     $installArgs = "--quiet --layout $HAB_CACHE_SRC_PATH/$pkg_dirname --lang en-US"
-    @(
+    $components = @(
         "Microsoft.VisualStudio.Workload.MSBuildTools",
         "Microsoft.VisualStudio.Workload.VCTools",
         "Microsoft.VisualStudio.Component.SQL.SSDTBuildSku",
         "Microsoft.VisualStudio.Component.VC.ATLMFC",
         "Microsoft.VisualStudio.Component.NuGet.BuildTools"
-    ) | ForEach-Object {
-        $installArgs += " --add $_"
+    )
+    foreach ($component in $components) {
+        $installArgs += " --add $component"
     }
     Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList $installArgs
     Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"


### PR DESCRIPTION
Setting these variables is ideal in a habitat based build where we provide a visual studio and windows sdk environment not installed via the visual studio installers which populate the registry with lots of base paths that will override many environment variable set paths. This also ensures that PATH, LIB and INCLUDE dirs are all honored.

Many windows native builds will break without these set and few users of msbuild will know to set these without some weeping and gnashing of teeth.

Signed-off-by: mwrock <matt@mattwrock.com>