### PR TITLE
add TargetFrameworkRootPath variable to all .net dev packs

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -249,6 +249,12 @@ plan_path = "docker-compose"
 plan_path = "docutils"
 [dosfstools]
 plan_path = "dosfstools"
+[dotnet-45-dev-pack]
+path_plan = "dotnet-45-dev-pack"
+[dotnet-462-dev-pack]
+path_plan = "dotnet-462-dev-pack"
+[dotnet-47-dev-pack]
+path_plan = "dotnet-47-dev-pack"
 [dotnet-471-dev-pack]
 path_plan = "dotnet-471-dev-pack"
 [dotnet-472-dev-pack]

--- a/dotnet-45-dev-pack/plan.ps1
+++ b/dotnet-45-dev-pack/plan.ps1
@@ -12,6 +12,10 @@ $pkg_bin_dirs=@("Program Files\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools\
 $pkg_lib_dirs=@("Program Files\Windows Kits\8.0\Lib\Win8\um\x64")
 $pkg_include_dirs=@("Program Files\Windows Kits\8.0\Include\um")
 
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv -IsPath "TargetFrameworkRootPath" "$pkg_prefix\Program Files\Reference Assemblies\Microsoft\Framework"
+}
+
 function Invoke-Unpack {
     Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/features OptionId.NetFxSoftwareDevelopmentKit /layout $HAB_CACHE_SRC_PATH/$pkg_dirname /quiet"
     Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname/Redistributable/4.5.50710"

--- a/dotnet-462-dev-pack/plan.ps1
+++ b/dotnet-462-dev-pack/plan.ps1
@@ -12,6 +12,10 @@ $pkg_bin_dirs=@("Program Files\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Too
 $pkg_lib_dirs=@("Program Files\Windows Kits\NETFXSDK\4.6.2\Lib\um\x64")
 $pkg_include_dirs=@("Program Files\Windows Kits\NETFXSDK\4.6.2\Include\um")
 
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv -IsPath "TargetFrameworkRootPath" "$pkg_prefix\Program Files\Reference Assemblies\Microsoft\Framework"
+}
+
 function Invoke-Unpack {
     dark -x "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$HAB_CACHE_SRC_PATH/$pkg_filename"
     Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/dotnet-47-dev-pack/plan.ps1
+++ b/dotnet-47-dev-pack/plan.ps1
@@ -13,6 +13,10 @@ $pkg_bin_dirs=@("Program Files\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools
 $pkg_lib_dirs=@("Program Files\Windows Kits\NETFXSDK\4.7\Lib\um\x64")
 $pkg_include_dirs=@("Program Files\Windows Kits\NETFXSDK\4.7\Include\um")
 
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv -IsPath "TargetFrameworkRootPath" "$pkg_prefix\Program Files\Reference Assemblies\Microsoft\Framework"
+}
+
 function Invoke-Unpack {
     dark -x "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$HAB_CACHE_SRC_PATH/$pkg_filename"
     Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"


### PR DESCRIPTION
When using the visual studio build tools package's `msbuild` to build .Net projects that use any of our dev pack packages, one needs to know to set `TargetFrameworkRootPath` to the right path in those packages which very few will know to do.

This ensures that when declaring a dependency on these packages, `msbuild`'s ability to find the correct reference assemblies path will "just work."

Signed-off-by: mwrock <matt@mattwrock.com>