### PR TITLE
[protobuf, protobuf-cpp] Upgrade to 3.12.3

### DIFF
--- a/protobuf-cpp/plan.sh
+++ b/protobuf-cpp/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=protobuf-cpp
 pkg_distname=protobuf
 pkg_origin=core
-pkg_version=3.9.2
+pkg_version=3.12.3
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data."
 pkg_upstream_url="https://github.com/google/${pkg_distname}"
 pkg_source="https://github.com/google/${pkg_distname}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=1891110cce323fe56b509da3589f03756c7eaf462a60971cb1c4af4efb154f69
+pkg_shasum=4ef97ec6a8e0570d22ad8c57c99d2055a61ea2643b8e1a0998d2c844916c4968
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(core/gcc-libs core/zlib)
 pkg_build_deps=(core/make core/gcc)

--- a/protobuf/plan.ps1
+++ b/protobuf/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="protobuf"
 $pkg_origin="core"
-$pkg_version="3.9.2"
+$pkg_version="3.12.3"
 $pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
 $pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 $pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 $pkg_license=("BSD")
 $pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.zip"
-$pkg_shasum="c18c03b2beb14c8813e1ca4601bfef07755eccaf202c3d6a1187186fc30bb8a1"
+$pkg_shasum="808cf33bc8b490e6ff707a1f6658c4d1fea8a8e3eed4c0273cecbb95c04ca4ec"
 $pkg_deps=@(
     "core/zlib"
 )

--- a/protobuf/plan.sh
+++ b/protobuf/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=protobuf
 pkg_origin=core
-pkg_version=3.9.2
+pkg_version=3.12.3
 pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz"
-pkg_shasum=7c99ddfe0227cbf6a75d1e75b194e0db2f672d2d2ea88fb06bdc83fe0af4c06d
+pkg_shasum=1a83f0525e5c8096b7b812181865da3c8637de88f9777056cefbf51a1eb0b83f
 pkg_deps=(
   core/gcc
   core/zlib


### PR DESCRIPTION
This brings us up to date with the latest upstream version.  The
changelog is a bit too long to include here:

https://github.com/protocolbuffers/protobuf/releases

Signed-off-by: Steven Danna <steve@chef.io>