### PR TITLE
[postgresql11] Upgraded postgresql 11 to 11.8

### DIFF
--- a/postgresql11-client/plan.ps1
+++ b/postgresql11-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql11-client"
 $pkg_origin="core"
-$pkg_version="11.2"
+$pkg_version="11.8"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="12c361d7a43542e1556f593fe9971463199b73286f5dac6c6bdc83ded45a1ed8"
+$pkg_shasum="68fe81cdaeb8befbfb0b32a4ef6a374e478ec8c1cc2c28dab965e72780b1f4dc"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"

--- a/postgresql11-client/plan.sh
+++ b/postgresql11-client/plan.sh
@@ -2,14 +2,14 @@ source ../postgresql11/plan.sh
 
 pkg_name=postgresql11-client
 # Default to version/shasum from sourced postgresql plan
-pkg_version=${pkg_version:-11.2}
+pkg_version=${pkg_version:-11.8}
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="${pkg_shasum:-2676b9ce09c21978032070b6794696e0aa5a476e3d21d60afc036dc0a9c09405}"
+pkg_shasum="${pkg_shasum:-eaf2f4329ccc349c89e950761b81daf8c99bb8966abcab5665ccd6ee95c77ae2}"
 pkg_dirname="postgresql-${pkg_version}"
 
 # No exports/exposes for client

--- a/postgresql11/plan.sh
+++ b/postgresql11/plan.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=SC2164
 pkg_name=postgresql11
-pkg_version=11.2
+pkg_version=11.8
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="2676b9ce09c21978032070b6794696e0aa5a476e3d21d60afc036dc0a9c09405"
+pkg_shasum="eaf2f4329ccc349c89e950761b81daf8c99bb8966abcab5665ccd6ee95c77ae2"
 pkg_dirname="postgresql-${pkg_version}"
 
 pkg_deps=(


### PR DESCRIPTION
Updated postgresql 11 from 11.2 to 11.8

As a general reminder, PostgreSQL changed versioning after 9.x, and is 11.8 would be equivalent from changing 9.6.2 to 9.6.5.