### PR TITLE
[meta] Adding stalebot to core-plans

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,46 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - C-base-plan
+  - R-refresh
+  - T-security
+  - Type: Design Proposal
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: pulls
+
+# Configuration specific to pull requests
+pulls:
+  # Number of days of inactivity before a Pull Request becomes stale
+  daysUntilStale: 90
+  # Number of days of inactivity before a Pull Request with the stale label is closed.
+  daysUntilClose: 14
+  # Comment to post when marking a Pull Request as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Comment to post when closing a stale Pull Request.
+  closeComment: >
+    This pr has not had any activity while marked as stale. It is now being closed.
+    Please reopen this pr if you believe it is still relevant. Thank you for your
+    contributions.


### PR DESCRIPTION
This change will add stale bot to the core-plans repo.
This will mark any pr as stale if it hasn't received any update for a period of 90 days.
After a further 14 days the stale pr will be closed.

Exemptions to this are any pr with the following labels:
 - c-base-plan
 - r-refresh
 - t-security
 - type: Design Proposal

Signed-off-by: MindNumbing <SMarshall@chef.io>