### PR TITLE
[kubectl] update to 1.18.5 and add test

### DIFF
--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -4,9 +4,9 @@ pkg_description="kubectl CLI tool"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.1
+pkg_version=1.18.5
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=073b77321812f26df6513c0ad0aef3a8b0c17f6281a186d515f5855ae009ea17
+pkg_shasum=3fd73d1094f3b24f5b94d390b30a0613de272bbdb419f23b5e54185c3060b0e3
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/kubectl/tests/test.bats
+++ b/kubectl/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} kubectl version --client | head -1 | awk '{print $5}')"
+  [ "$result" = "GitVersion:\"v${TEST_PKG_VERSION}\"," ]
+}

--- a/kubectl/tests/test.sh
+++ b/kubectl/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Replaces #2657 because its branch name was tied to a version, this PR bumps to the latest stable release and includes a basic test