### PR TITLE
[boringssl] Adds a test for boringssl

### DIFF
--- a/boringssl/tests/test.bats
+++ b/boringssl/tests/test.bats
@@ -1,0 +1,6 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Encodes successfully" {
+  actual="$(echo "a_byte_character" | hab pkg exec "${TEST_PKG_IDENT}" bssl sha256sum | cut -d' ' -f1)"
+  diff <( echo "$actual" ) <( echo "606ce9d59be5ad79105843d3497122b53bf0b890c1f70776e3be8bc5117e8bb2" )
+}

--- a/boringssl/tests/test.sh
+++ b/boringssl/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/boringssl/3945/20200710133332
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+    exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Adds a test to run sample command for boringssl.

```bash
hab pkg build boringssl; source results/last_build.env; hab studio run "./${pkg_name}/tests/test.sh ${pkg_ident}"
```

> ★ Install of mindnumbing/boringssl/3538/20200710135239 complete with 1 new packages installed.
> ✓ Encodes successfully
>
>1 test, 0 failures

Signed-off-by: MindNumbing <SMarshall@chef.io>