### PR TITLE
[corretto] Update corretto to 11.0.8.10.1

### DIFF
--- a/corretto/plan.ps1
+++ b/corretto/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="corretto"
 $pkg_origin="core"
-$pkg_version="11.0.3.7.1"
+$pkg_version="11.0.8.10.1"
 $pkg_description="Corretto is a build of the Open Java Development Kit (OpenJDK) with long-term support from Amazon"
 $pkg_upstream_url="https://aws.amazon.com/corretto/"
-$pkg_license=@("GPLv2+CE")
+$pkg_license=@("GPL-2.0-only WITH Classpath-exception-2.0")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://d3pxv6yz143wms.cloudfront.net/${pkg_version}/amazon-corretto-${pkg_version}-windows-x64.zip"
-$pkg_shasum="bb90da7af62cf8380b533e5d74e8c3300d85657d2d450a461f9d754e9a34c5ba"
+$pkg_source="https://corretto.aws/downloads/resources/${pkg_version}/amazon-corretto-${pkg_version}-windows-x64-jdk.zip"
+$pkg_shasum="2a3646b1c3444c2db713d687c37d14736990c32a5ce809ce2c10c2b1b38c3077"
 $pkg_dirname="amazon-corretto-$pkg_version"
 $pkg_bin_dirs=@("bin")
 $pkg_lib_dirs=@("lib")
@@ -16,5 +16,5 @@ function Invoke-Build {
 }
 
 function Invoke-Check {
-    (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/bin/java.exe" --version).StartsWith("openjdk version $pkg_version")
+    (& "$pkg_prefix/bin/java.exe" --version).StartsWith("openjdk version $pkg_version")
 }

--- a/corretto/plan.sh
+++ b/corretto/plan.sh
@@ -1,13 +1,14 @@
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_name=corretto
-# NOTE: Retrieve download link from here: https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html
-pkg_version=11.0.2.9.3
-pkg_source="https://d3pxv6yz143wms.cloudfront.net/${pkg_version}/amazon-corretto-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=be8452a78baa077e19afbfa64070b26275030267a5ea4e837dec7a30eff85c9c
+# NOTE: Retrieve download link from here: https://github.com/corretto/corretto-11/releases
+# More in-depth changelogs and download page is here: https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html
+pkg_version=11.0.8.10.1
+pkg_source="https://corretto.aws/downloads/resources/${pkg_version}/amazon-corretto-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=dbbf98ca93b44a0c81df5a3a4f2cebf467ec5c30e28c359e26615ffbed0b454f
 pkg_filename="corretto-${pkg_version}_linux-x64_bin.tar.gz"
 pkg_dirname="amazon-corretto-${pkg_version}-linux-x64"
-pkg_license=("GPL-2.0-only")
+pkg_license=("GPL-2.0-only WITH Classpath-exception-2.0")
 pkg_description=('Corretto is a build of the Open Java Development Kit (OpenJDK) with long-term support from Amazon.')
 pkg_upstream_url=https://aws.amazon.com/corretto/
 pkg_deps=(


### PR DESCRIPTION
This provides a minor patch update to the corretto binary package. It also fixes a minor issue with the correct SPDX license, which should be `GPL-2.0-only WITH Classpath-exception-2.0`, since it has a classpath exception in the license. If you are unfamiliar with SPDX, you can find it here: https://spdx.org/licenses/

You can test with:

`hab studio build corretto`

Signed-off-by: echohack <echohack@users.noreply.github.com>