### PR TITLE
[erlang22] Added plan for erlang22.3

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -315,6 +315,8 @@ plan_path = "erlang19"
 plan_path = "erlang20"
 [erlang21]
 plan_path = "erlang21"
+[erlang22]
+plan_path = "erlang22"
 [etcd]
 plan_path = "etcd"
 [eudev]

--- a/erlang22/README.md
+++ b/erlang22/README.md
@@ -15,6 +15,6 @@ Binary package
 Simple example of invoking `erl`:
 
 ```
-hab pkg install core/erlang20
-hab pkg exec core/erlang20 erl
+hab pkg install core/erlang22
+hab pkg exec core/erlang22 erl
 ```

--- a/erlang22/README.md
+++ b/erlang22/README.md
@@ -1,0 +1,20 @@
+# erlang22
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Simple example of invoking `erl`:
+
+```
+hab pkg install core/erlang20
+hab pkg exec core/erlang20 erl
+```

--- a/erlang22/plan.sh
+++ b/erlang22/plan.sh
@@ -1,0 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../erlang/plan.sh"
+
+pkg_name=erlang22
+pkg_origin=core
+pkg_version=22.3
+pkg_description="A programming language for massively scalable soft real-time systems."
+pkg_upstream_url="http://www.erlang.org/"
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
+pkg_filename="otp_src_${pkg_version}.tar.gz"
+pkg_shasum=5c35b952808fa933ca95a9d259818aee27cb17ca96067da0fda2f035259ee612
+pkg_dirname="otp_src_${pkg_version}"

--- a/erlang22/tests/test.bats
+++ b/erlang22/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/erlang22/tests/test.sh
+++ b/erlang22/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install core/bats --binlink
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install "results/${pkg_artifact}" --binlink --force
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
This adds a core-plan for the latest version of erlang 22 to help with work around shipping a more modern Chef Server within Automate.

Signed-off-by: Thomas Cate <tcate@chef.io>