### PR TITLE
[helm] Upgrade helm to 3.2.4

### DIFF
--- a/helm/.shellcheckrc
+++ b/helm/.shellcheckrc
@@ -1,0 +1,2 @@
+shell=bash
+disable=SC2034,SC2154

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,10 +1,19 @@
-Helm
-====
+# Helm
 
-This is a Habitat plan for the Kubernetes Helm client CLI application, called `helm`.
+Builds the `helm` binary for a specific GitHub release.
 
-Usage
-=====
+## Maintainers
 
-Please consult the [official documentation](https://docs.helm.sh/using_helm/) for information on how
-to use `helm`.
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+This package is meant to be installed and optionally bin-linked using `hab pkg install core/helm --binlink`.
+
+You can also use it as a `pkg_dep` if your application requires helm in lifecycle hooks.
+
+For information on how to use `helm` itself, please consult the [official documentation](https://docs.helm.sh/using_helm/).

--- a/helm/plan.sh
+++ b/helm/plan.sh
@@ -1,29 +1,18 @@
 go_pkg="k8s.io/helm"
-
 pkg_name=helm
 pkg_origin=core
-pkg_version="2.7.2"
-pkg_description="Helm is a tool for managing Kubernetes charts"
+pkg_version="3.2.4"
+pkg_description="The Kubernetes Package Manager"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://$go_pkg"
-pkg_upstream_url=$pkg_source
+pkg_upstream_url="https://helm.sh"
 pkg_scaffolding="core/scaffolding-go"
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
-  core/which
   core/coreutils
-  core/mercurial
+  core/git
 )
-scaffolding_go_build_deps=()
-# note: helm uses github.com/Masterminds/glide but `make bootstrap` we launch as
-# part of the build below, takes care of that for use.
-
-do_prepare() {
-  build_line "mkdir -p \$GOPATH/bin; export PATH=\$GOPATH/bin:\$PATH"
-  mkdir -p "$GOPATH/bin"
-  export PATH=$GOPATH/bin:$PATH
-}
 
 do_download() {
   # `-d`: don't let go build it, we'll have to build this ourselves
@@ -32,24 +21,23 @@ do_download() {
 
   go get -d $go_pkg 2>&1 | grep -q "no Go files"
 
-  pushd "$scaffolding_go_pkg_path"
-    git reset --hard v$pkg_version
-  popd
+  pushd "$scaffolding_go_pkg_path" || exit 1
+  git reset --hard v$pkg_version
+  popd || exit 1
 }
 
 do_build() {
   # For some reason one of the commands in the Makefile launches env with an
   # absolute path so we need to ensure it can find it there.
-  build_line "ln -fs \"$(which env)\" /usr/bin/env"
-  ln -fs "$(which env)" /usr/bin/env
+  env_path="$(command -v env)"
+  build_line "ln -fs $env_path /usr/bin/env"
+  ln -fs "$env_path" /usr/bin/env
 
-  pushd "$scaffolding_go_pkg_path"
-    build_line "make bootstrap build"
-    make bootstrap build
-  popd
+  pushd "$scaffolding_go_pkg_path" || exit 1
+  do_default_build
+  popd || exit 1
 }
 
 do_install() {
-  build_line "copying Helm binary"
-  cp -f "${scaffolding_go_pkg_path:?}/bin/helm" "$pkg_prefix/bin"
+  install -m0755 "$scaffolding_go_pkg_path/bin/helm" "$pkg_prefix/bin"
 }


### PR DESCRIPTION
This PR upgrades helm to version 3.2.4. 

I also tried to align the `plan.sh` and `README` to some of the better maintained plans (like prometheus).

A couple notes:

- `core/mercurial` was removed because I couldn't see anywhere that required it as a dependency.
- `core/which` was removed in favour of `command`
- go get is used instead of a github archive tarball. Not exactly why this was done but when I build it from the github tarball source the `helm version` shows "unreleased" so I left `do_download` as is.