### PR TITLE
[opa] bump 0.22.0 -> 0.23.1

### DIFF
--- a/opa/plan.sh
+++ b/opa/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=opa
 pkg_description="Open Policy Agent (OPA) is a lightweight general-purpose policy engine that can be co-located with your service."
 pkg_origin=core
-pkg_version="0.22.0"
+pkg_version="0.23.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/open-policy-agent/opa/archive/v${pkg_version}.tar.gz"
@@ -16,7 +16,7 @@ pkg_build_deps=(
     core/git
     core/go
 )
-pkg_shasum="5347fc727fc0485a221582a41c7aabd1a541fc399a65b5b7b36e7db6b7563193"
+pkg_shasum="db84bcf9040623a5f7977e7b4d2fa7f15ac61efdbd2e6c13cafe1bf67bdac07a"
 
 do_prepare() {
   sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" -i build/*.sh


### PR DESCRIPTION
Release notes for the bumped versions:

- https://github.com/open-policy-agent/opa/releases/tag/v0.23.0
- https://github.com/open-policy-agent/opa/releases/tag/v0.23.1
