### PR TITLE
[pax-utils] update 1.2.5 -> 1.2.6

### DIFF
--- a/pax-utils/plan.sh
+++ b/pax-utils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=pax-utils
-pkg_version=1.2.5
+pkg_version=1.2.6
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL')
@@ -7,7 +7,7 @@ pkg_description="ELF related utils for ELF 32/64 binaries that can check files
   for security relevant properties"
 pkg_upstream_url='http://hardened.gentoo.org/pax-utils.xml'
 pkg_source="http://distfiles.gentoo.org/distfiles/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="7ce7170ceed255bb47cac03b88bcbc636b0e412cac974e213e8017a1dae292ec"
+pkg_shasum="9742d2a31d53a4e0f6df0d3721ab6f7cf8b0404c95fee3b00e678c1ff6db7f21"
 pkg_deps=(
   core/bash
   core/glibc


### PR DESCRIPTION
This updates pax-utils to latest version, v1.2.5 no longer available at source.

Signed-off-by: MindNumbing <SMarshall@chef.io>