### PR TITLE
[corretto8, corretto, corretto11] Fix broken patchelf injection

### DIFF
--- a/corretto/plan.sh
+++ b/corretto/plan.sh
@@ -51,7 +51,7 @@ do_install() {
   build_line "Setting rpath for all libraries to '${LD_RUN_PATH}'"
 
   find "${pkg_prefix}"/bin -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "-executable; charset=binary"' _ {} \; \
     -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "${pkg_prefix}/lib" -type f -name "*.so" \

--- a/corretto8/plan.sh
+++ b/corretto8/plan.sh
@@ -35,11 +35,11 @@ do_install() {
   build_line "Setting rpath for all libraries to '${LD_RUN_PATH}'"
 
   find "${pkg_prefix}"/bin -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "-executable; charset=binary"' _ {} \; \
     -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "${pkg_prefix}"/jre/bin -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "-executable; charset=binary"' _ {} \; \
     -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "${pkg_prefix}/lib" -type f -name "*.so" \


### PR DESCRIPTION
The above mentioned corretto distributions have changed the file application file type from application/x-executable to application/x-pie-executable.  This change in type impacted the existing plan:  since a grep selection of files for patchelf injection was based on the old application type pattern, then the patchelf injection did not occur as expected.   This PR fixes the grep and therefor issue #3448.

core/corretto after doing local build in studio now works:

```bash
[7][default:/src/corretto:0]# hab pkg exec core/corretto/11.0.8.10.1/20200907182859 -- java -version
openjdk version "11.0.8" 2020-07-14 LTS
OpenJDK Runtime Environment Corretto-11.0.8.10.1 (build 11.0.8+10-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.8.10.1 (build 11.0.8+10-LTS, mixed mode)
[8][default:/src/corretto:0]# 
```