### PR TITLE
openssl-fips support for Windows

### DIFF
--- a/openssl-fips/README.md
+++ b/openssl-fips/README.md
@@ -1,0 +1,145 @@
+# openssl-fips
+
+The OpenSSL FIPS Object Module validation is "delivered" in source code form, meaning that if you can use it exactly as is and can build it (according to the very specific documented instructions) for your platform, then you can use it as validated cryptography on a "vendor affirmed" basis.  See [documentation](https://www.openssl.org)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+### Use as Dependency
+
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/openssl-fips as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/openssl-fips)
+
+##### Runtime dependency
+
+> pkg_deps=(core/openssl-fips)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/openssl-fips --binlink``
+
+will add the following binaries to the Chef Habitat install directory:
+
+* C:\hab\bin\fips_standalone_sha1.bat
+
+For example:
+
+```powershell
+$ hab pkg install core/openssl-fips --binlink
+» Installing core/openssl-fips
+☁ Determining latest version of core/openssl-fips in the 'stable' channel
+→ Verifying core/openssl-fips/2.0.16/20200924141023
+→ Using core/visual-cpp-redist-2015/14.0.23026/20190128180056
+√ Installed core/openssl-fips/2.0.16/20200924141023
+≡ Install of core/openssl-fips/2.0.16/20200924141023 complete with 1 new packages installed.
+» Binlinking fips_standalone_sha1.exe from core/openssl-fips/2.0.16/20200924141023 into C:\hab\bin
+Ω Creating parent directory C:\hab\bin
+≡ Binlinked fips_standalone_sha1.exe from core/openssl-fips/2.0.16/20200924141023 to C:\hab\bin\fips_standalone_sha1.bat
+Ø Binlink destination 'C:\hab/bin' is not on the PATH. Consider setting it manually or running 'hab setup' to add it to the machine PATH.
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``C:\hab\bin\fips_standalone_sha1``
+
+```powershell
+> C:\hab\bin\fips_standalone_sha1
+fips_standalone_sha1 [<file>]+
+```
+
+## Base Plans
+
+This section outlines a general playbook for maintainers who are building this plan.
+
+As a base plan, this plan has extra considerations when merging PRs and building the plan. This base plan can safely be built without a core plans base refresh.
+
+1. The following plans must be verified as successfully building, along with success of any automated tests, before merging any PRs:
+
+```
+core-plans/openssl
+core-plans/openssl-musl/
+habitat/components/hab/
+core-plans/libarchive
+habitat/components/sup
+core-plans/curl
+core-plans/postgresql
+builder/components/builder-api
+```
+
+It is important to verify each of these packages because Habitat is a self-hosting system. In other words, `hab` is used to build `core-plans` and `core-plans` is used to build `hab`. We need to perform this extra level of verification to ensure that a change in a base plan does not prevent the ability to ship new packages.
+
+1. Once the plan is merged, make a tracking issue on Github to document the work post merging the PR. This tracking issue should look something like: https://github.com/habitat-sh/core-plans/issues/2339
+
+1. You must verify that all upstream plans can build successfully in `unstable`. Habitat Builder will kick off any builds as soon as the PR is merged. These builds should take around 5 hours to complete. You can monitor with this:
+
+```
+hab bldr job status -o core
+```
+
+```
+☁ Determining status of job groups in core origin
+
+CREATED AT                        GROUP ID             STATUS       IDENT              TARGET
+2019-03-05T19:10:56.463614+00:00  1195769776017088512  Queued       core/openssl       x86_64-linux
+2019-03-05T19:10:47.343695+00:00  1195769699504586752  Dispatching  core/openssl       x86_64-windows
+2019-03-05T19:10:47.285353+00:00  1195769699034816512  Dispatching  core/openssl-musl  x86_64-linux
+2019-03-05T16:52:42.427858+00:00  1195700200616992768  Complete     core/cerebro       x86_64-linux
+2019-03-05T15:50:28.109165+00:00  1195668874861944832  Complete     core/hab-launcher  x86_64-linux
+2019-03-05T15:50:28.078409+00:00  1195668874627055616  Complete     core/hab-launcher  x86_64-windows
+2019-03-05T15:25:23.177315+00:00  1195656250594066432  Complete     core/nginx         x86_64-linux
+2019-03-05T15:25:22.814329+00:00  1195656247548993536  Complete     core/nginx         x86_64-windows
+2019-03-05T15:17:21.338684+00:00  1195652208618766336  Complete     core/packer        x86_64-linux
+2019-03-05T15:17:21.318397+00:00  1195652208450985984  Complete     core/packer        x86_64-windows
+```
+
+```
+watch -n300 "hab bldr job status 1195769776017088512 -s | grep core/ | grep Failure"
+```
+
+1. Make a list of any failed builds and investigate any failures. At this point you will want to document issues with failures, or if the failures are transient, note them as such in the tracking issue.
+
+1. At this point you can make a determination if any of the issues above are blocking promotion. You will want to block promotion if failed builds caused other core plans to become `Skipped`, but may also want to block based on other issues.
+
+1. If you are not blocked from promoting, now you will want to promote the base plan package (in this case `openssl`).
+
+1. Now you will want to interactively promote upstream packages. You can do this with:
+
+```
+hab bldr job promote <group_number> stable -o core -i
+```
+
+Where <number> is the job number.
+
+Remove any packages with `hab` in the name. DO NOT PROMOTE ANYTHING WITH `hab` in the name!
+
+1. Now you will need to do this for each job group. Note that there is currently a Builder API bug where Windows packages will return an error:
+
+```
+XXX
+XXX Failed to promote job group: APIError(NotFound, "")
+XXX
+```
+
+These will have to be promoted in the UI separately.
+
+1. Finally, you will want to track and rebuild any packages that Failed during the build after you merged the PR. Rebuild any packages, regardless if they have known build issues or were transient failures.
+
+1. Add any documentation that you learned during the process.
+
+1. Close the tracking issue.

--- a/openssl-fips/plan.ps1
+++ b/openssl-fips/plan.ps1
@@ -1,0 +1,52 @@
+$pkg_name="openssl-fips"
+$pkg_origin="core"
+$pkg_version="2.0.16"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_description="\
+The OpenSSL FIPS Object Module v2.0 provide cryptographic services to \
+external applications. The FIPS Object Module provides an API for invocation \
+of FIPS approved cryptographic functions from calling applications, and is \
+designed for use in conjunction with standard OpenSSL 1.0.1 and 1.0.2 \
+distributions. \
+"
+$pkg_upstream_url="https://www.openssl.org"
+$pkg_license=('OpenSSL')
+$pkg_source="https://www.openssl.org/source/${pkg_name}-${pkg_version}.tar.gz"
+$pkg_shasum="a3cd13d0521d22dd939063d3b4a0d4ce24494374b91408a05bdaca8b681c63d4"
+$pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+$pkg_deps=@("core/visual-cpp-redist-2015")
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm", "core/7zip")
+$pkg_bin_dirs=@("bin")
+$pkg_include_dirs=@("include")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Unpack {
+  Push-Location (Resolve-Path $HAB_CACHE_SRC_PATH).Path
+  Try {
+      $tar = $pkg_filename.Substring(0, $pkg_filename.LastIndexOf('.'))
+      7z x -y (Resolve-Path $HAB_CACHE_SRC_PATH/$pkg_filename).Path
+      7z x -y -o"$pkg_dirname" (Resolve-Path $HAB_CACHE_SRC_PATH/$tar).Path
+  } finally { Pop-Location }
+}
+
+function Invoke-SetupEnvironment {
+    . "$(Get-HabPackagePath visual-cpp-build-tools-2015)\setenv.ps1"
+}
+
+function Invoke-Build {
+    Set-Location "$pkg_name-$pkg_version"
+    perl Configure VC-WIN64A --prefix=$pkg_prefix
+    ms\do_win64a
+    nmake -f ms\ntdll.mak
+    if($LASTEXITCODE -ne 0) { Write-Error "nmake failed!" }
+}
+
+function Invoke-Install {
+    Set-Location "$pkg_name-$pkg_version"
+    ms\do_win64a
+    nmake -f ms\ntdll.mak install
+}
+function Invoke-Check {
+    Set-Location "$pkg_name-$pkg_version"
+    nmake -f ms\ntdll.mak test
+}

--- a/openssl-fips/tests/test.pester.ps1
+++ b/openssl-fips/tests/test.pester.ps1
@@ -1,0 +1,14 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "core/openssl-fips" {
+    Context "openssl-fips" {
+        Write-Output "a_byte_character" > testfile
+        $OutputVariable = (hab pkg exec $PackageIdentifier fips_standalone_sha1 testfile | Out-String).Trim().Split()
+        It "returns correct encoded string" {
+            $OutputVariable[1] | Should -BeExactly "2f0c57ed208ff153f9216856f49d27b9a56e4016"
+        }
+    }
+}

--- a/openssl-fips/tests/test.ps1
+++ b/openssl-fips/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -7,7 +7,7 @@ $pkg_upstream_url="https://www.openssl.org"
 $pkg_license=@("OpenSSL")
 $pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
 $pkg_shasum="08741e9c71ded84ad54840e611bc86a2272fbbdb72b90556a3ec7e02b11f1dd9"
-$pkg_deps=@("core/visual-cpp-redist-2015")
+$pkg_deps=@("core/visual-cpp-redist-2015", "core/openssl-fips")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
 $pkg_bin_dirs=@("bin")
 $pkg_include_dirs=@("include")
@@ -19,7 +19,8 @@ function Invoke-SetupEnvironment {
 
 function Invoke-Build {
     Set-Location "$pkg_name-OpenSSL_$_pkg_version_text"
-    perl Configure VC-WIN64A --prefix=$pkg_prefix
+    $FIPSDIR="$(Get-HabPackagePath openssl-fips)"
+    perl Configure VC-WIN64A --prefix=$pkg_prefix --with-fipsdir=$FIPSDIR fips
     ms\do_win64a
     nmake -f ms\ntdll.mak
     if($LASTEXITCODE -ne 0) { Write-Error "nmake failed!" }

--- a/openssl/tests/test.pester.ps1
+++ b/openssl/tests/test.pester.ps1
@@ -9,7 +9,7 @@ Describe "core/openssl" {
         $OutputVariable = (hab pkg exec $PackageIdentifier openssl version | Out-String).Trim()
         $OutputVariable -match "(?<=^OpenSSL )([^ ]*)"
         It "version matches $PackageVersion" {
-            $matches[0] | Should -BeExactly "$PackageVersion"
+            $matches[0] | Should -BeExactly "${PackageVersion}-fips"
         }
 
         $OutputVariable = ("a_byte_character" | hab pkg exec $PackageIdentifier openssl enc -base64| Out-String).Trim()


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### Description
Adds `openssl-fips` for Windows package support, allowing for FIPS support to `core/openssl` package for Windows.

* Adds `openssl-fips` Windows `plan.ps1` (Non-Windows is supported under `chef-base-plans`)
* Updates `openssl` to build with FIPS support, matching the functionality that non-Windows `core/openssl` currently has.

Currently when using the `chef/chef-infra-client` on Windows (such as in Effortless), FIPS support is not present due to the included `core/openssl` not having FIPS support for Windows. This update adds Windows package build for `core/openssl-fips` and updates `core/openssl` to build with FIPS support.