### PR TITLE
[Refresh2020Q3][zookeeper] Update Zookeeper to latest version

### DIFF
--- a/zookeeper/plan.sh
+++ b/zookeeper/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=zookeeper
 pkg_origin=core
-pkg_version=3.6.1
+pkg_version=3.6.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications."
 pkg_upstream_url="https://zookeeper.apache.org"
 pkg_license=('Apache-2.0')
-pkg_source="http://downloads.apache.org/${pkg_name}/${pkg_name}-${pkg_version}/apache-${pkg_name}-${pkg_version}-bin.tar.gz"
+pkg_source="https://downloads.apache.org/zookeeper/zookeeper-${pkg_version}/apache-zookeeper-${pkg_version}-bin.tar.gz"
 pkg_dirname="apache-${pkg_name}-${pkg_version}-bin"
-pkg_shasum="5066dd085cee2a7435a1bb25677102f0d4ea585f314bd026799f333b0956a06d"
+pkg_shasum="476f6fce10f9528e3a4ad00e6cd1714563f602dd4924db78e506c0df28fea1e5"
 pkg_build_deps=()
 pkg_deps=(
   core/bash-static


### PR DESCRIPTION
This updates zookeeper to the latest version so we can still use the upstream

Signed-off-by: MindNumbing <SMarshall@chef.io>