### PR TITLE
[dex] bump v2.24.0 -> v2.25.0, simplify plan.sh

### DIFF
--- a/dex/plan.sh
+++ b/dex/plan.sh
@@ -2,11 +2,12 @@ gopkg="github.com/dexidp/dex"
 pkg_name=dex
 pkg_description="OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors"
 pkg_origin=core
-pkg_version="2.24.0"
+pkg_version="2.25.0"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Apache-2.0")
-pkg_source="https://$gopkg"
-pkg_upstream_url=$pkg_source
+pkg_source="https://$gopkg/archive/v${pkg_version}.tar.gz"
+pkg_shasum="d8db01b592391a50a8ef0e09fbc54fb57a1bca8bcfed0cf118d2341d1f7e4f84"
+pkg_upstream_url="https://$gopkg"
 pkg_exports=(
   [port]=service.port
   [host]=service.host
@@ -15,36 +16,15 @@ pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/git core/gcc)
 pkg_bin_dirs=(bin)
 
-do_before() {
-  GOPATH=$HAB_CACHE_SRC_PATH/$pkg_dirname
-  export GOPATH
-}
-
-do_prepare() {
-  export GO_LDFLAGS="-w -X $gopkg/version.Version=v$pkg_version"
-}
-
-do_download() {
-  return 0
-}
-
-do_verify() {
-  return 0
-}
-
-# Use unpack instead of download, so that plan-build can manage the
-# source path. This ensures us a clean checkout every time we build.
-do_unpack() {
-  git clone "$pkg_source" "$GOPATH/src/$gopkg"
-  ( cd "$GOPATH/src/$gopkg" || exit
-    git reset --hard "v$pkg_version"
-  )
-}
-
 do_build() {
-  go build --ldflags "${GO_LDFLAGS}" -o "$pkg_prefix/bin/dex" "$gopkg/cmd/dex"
+  cat >scripts/git-version <<EOF
+#!/bin/sh
+echo "v${pkg_version}"
+EOF
+  make build
 }
 
 do_install() {
-  cp -r "$GOPATH/src/$gopkg/web" "$pkg_prefix"
+  cp bin/dex "$pkg_prefix/bin"
+  cp -r "web" "$pkg_prefix"
 }


### PR DESCRIPTION
This is now modelled after opa/plan.sh, downloading the tarball, working with
that.

Since 2.25.0, dex no longer vendors its dependencies, so there's no need to
tender any GOPATH.

To have `dex version` return its version correctly, this fiddles with one of the
scripts.  However, if it means we don't have to mess with `go install`, `go
build`, and the proper ldflags, but can use the make target instead, I think
that's preferable.

----

https://github.com/dexidp/dex/releases/tag/v2.25.0