### PR TITLE
Update scaffolding-ruby to be compatible with Ruby 2.7

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -440,7 +440,7 @@ _setup_funcs() {
 
 _setup_vars() {
   # The default Ruby package if one cannot be detected
-  _default_ruby_pkg="core/ruby"
+  _default_ruby_pkg="core/ruby27"
   # The absolute path to the `gemfile-parser` program
   _gemfile_parser="$(pkg_path_for scaffolding-ruby)/bin/gemfile-parser"
   # `$scaffolding_ruby_pkg` is empty by default

--- a/scaffolding-ruby/plan.sh
+++ b/scaffolding-ruby/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Plan Scaffolding for Ruby Applications"
 pkg_upstream_url="https://github.com/habitat-sh/core-plans/tree/master/scaffolding-ruby"
-pkg_deps=(core/bundler core/ruby core/tar core/busybox-static core/rq core/gcc core/make core/pkg-config)
+pkg_deps=(core/bundler core/ruby27 core/tar core/busybox-static core/rq core/gcc core/make core/pkg-config)
 pkg_build_deps=(core/coreutils core/sed)
 pkg_bin_dirs=(bin)
 
@@ -53,7 +53,7 @@ export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 unset RUBYOPT GEMRC
 
-exec $(pkg_path_for ruby)/bin/ruby ${bin}.real \$@
+exec $(pkg_path_for ruby27)/bin/ruby ${bin}.real \$@
 EOF
   chmod -v 755 "$bin"
 }


### PR DESCRIPTION
This update fixes an error when, with building with Ruby 2.7, the Gemfile path was being set incorrectly to Ruby 2.5 due to multiple versions of Ruby being installed (```core/bundler``` depends on ```core/ruby```, which is at 2.5), causing issues with bundler.

Right now this fix will only work with Ruby 2.7. I think getting compatibility for 2.6 and prior is going to be a little trickier. If that's something Chef is interested in, I'd love to talk to someone on the team about their roadmap and how this could be integrated in.

Let me know if there's any more details I can give or other information that would be helpful.

Signed-off-by: RachelWyatt <rwyatt@taphere.com>