### PR TITLE
Update wal-e Plan Package Version

### DIFF
--- a/wal-e/plan.sh
+++ b/wal-e/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=wal-e
-pkg_version=1.1.0
+pkg_version=1.1.1
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('wal-e license')
 pkg_description="Continuous Archiving for Postgres"
 pkg_upstream_url="https://github.com/wal-e/wal-e"
 pkg_source=https://github.com/wal-e/wal-e/archive/v${pkg_version}.tar.gz
-pkg_shasum=d3478e6eb4bfe00ac696af3e7ded4a91a0a2db6f9aa1a51ce780e43e4c12d6c7
+pkg_shasum=f5f8750ca8999802302b1c127a7d90b3b0f24ad376205fc9bf574abbcf365046
 pkg_deps=(core/envdir core/lzop core/pv core/python)
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Updated pkg_version 1.1.0 -> 1.1.1 in support of 2021 Q2 core plans refresh.