### PR TITLE
Update ghc82-bootstrap Plan Package Version

### DIFF
--- a/ghc82-bootstrap/plan.sh
+++ b/ghc82-bootstrap/plan.sh
@@ -11,7 +11,7 @@ pkg_dirname="ghc-${pkg_version}"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
-pkg_include_dirs=(lib/ghc-${pkg_version}/include)
+pkg_include_dirs=(lib/ghc-"${pkg_version}"/include)
 pkg_interpreters=(bin/runhaskell bin/runghc)
 
 pkg_deps=(

--- a/ghc82-bootstrap/plan.sh
+++ b/ghc82-bootstrap/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ghc82-bootstrap
 pkg_origin=core
-pkg_version=8.2.1
+pkg_version=8.2.2
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler - Binary Bootstrap"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-x86_64-deb8-linux.tar.xz"
-pkg_shasum="543b81bf610240bd0398111d6c6607a9094dc2d159b564057d46c8a3d1aaa130"
+pkg_shasum="bb8ec3634aa132d09faa270bbd604b82dfa61f04855655af6f9d14a9eedc05fc"
 pkg_dirname="ghc-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/ghc82-bootstrap/plan.sh
+++ b/ghc82-bootstrap/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="https://www.haskell.org/ghc/"
 pkg_description="The Glasgow Haskell Compiler - Binary Bootstrap"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-x86_64-deb8-linux.tar.xz"
-pkg_shasum="bb8ec3634aa132d09faa270bbd604b82dfa61f04855655af6f9d14a9eedc05fc"
+pkg_shasum="48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a"
 pkg_dirname="ghc-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 8.2.1 -> 8.2.2 in support of 2021 Q2 core plans refresh.