### PR TITLE
Update flatbuffers Plan Package Version

### DIFF
--- a/flatbuffers/plan.sh
+++ b/flatbuffers/plan.sh
@@ -10,7 +10,7 @@ pkg_description="$(cat << EOF
 EOF
 )"
 pkg_source="https://github.com/google/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="2bbef726f75f46daca9630d61fceb24a05b4236e3bf95c37633d6bc3ec339f35"
+pkg_shasum=62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45
 pkg_upstream_url="http://google.github.io/flatbuffers/index.html"
 pkg_deps=(
   core/glibc

--- a/flatbuffers/plan.sh
+++ b/flatbuffers/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=flatbuffers
 pkg_origin=core
-pkg_version=1.11.0
+pkg_version=1.12.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="$(cat << EOF
@@ -10,7 +10,7 @@ pkg_description="$(cat << EOF
 EOF
 )"
 pkg_source="https://github.com/google/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="3f4a286642094f45b1b77228656fbd7ea123964f19502f9ecfd29933fd23a50b"
+pkg_shasum="2bbef726f75f46daca9630d61fceb24a05b4236e3bf95c37633d6bc3ec339f35"
 pkg_upstream_url="http://google.github.io/flatbuffers/index.html"
 pkg_deps=(
   core/glibc

--- a/flatbuffers/tests/test.bats
+++ b/flatbuffers/tests/test.bats
@@ -1,6 +1,6 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} flatc --version | awk '{print $3}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} flatc -- --version | awk '{print $3}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }


### PR DESCRIPTION
Updated pkg_version 1.11.0 -> 1.12.0 in support of 2021 Q2 core plans refresh.