### PR TITLE
Update leveldb Plan Package Version

### DIFF
--- a/leveldb/plan.sh
+++ b/leveldb/plan.sh
@@ -5,25 +5,49 @@ pkg_upstream_url="https://github.com/google/leveldb"
 pkg_version="1.23"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
-pkg_source="https://github.com/google/leveldb/archive/v${pkg_version}.tar.gz"
-pkg_shasum="9ccc8706561591a540ce0165041beb1b0361338a11e135a9fcff18fd5984d7c7"
+pkg_source="https://github.com/google/${pkg_name}.git"
 pkg_deps=(
   core/snappy
   core/glibc
   core/gcc-libs
+  core/sqlite
 )
 pkg_build_deps=(
-  core/make
+  core/cmake
   core/gcc
+  core/git
 )
-pkg_lib_dirs=(lib)
+pkg_lib_dirs=(lib64)
 pkg_include_dirs=(include)
 
+do_download() {
+  if [ ! -d "${SRC_PATH}" ]; then
+    git clone --recurse-submodules "${pkg_source}" "${SRC_PATH}"
+  fi
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_clean() {
+  rm -rf "${SRC_PATH}/build"
+}
+
 do_build() {
-  make
+  mkdir -p build
+  pushd build &>/dev/null || exit 1
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" ..
+    cmake --build .
+  popd &>/dev/null || exit 1
 }
 
 do_install() {
-  cp --preserve=links out-shared/libleveldb.* "${pkg_prefix}/lib"
-  cp -r include/leveldb "${pkg_prefix}/include"
+  pushd build &>/dev/null || exit 1
+    cmake --install .
+  popd &>/dev/null || exit 1
 }

--- a/leveldb/plan.sh
+++ b/leveldb/plan.sh
@@ -2,11 +2,11 @@ pkg_name=leveldb
 pkg_origin=core
 pkg_description="LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values."
 pkg_upstream_url="https://github.com/google/leveldb"
-pkg_version="1.20"
+pkg_version="1.23"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://github.com/google/leveldb/archive/v${pkg_version}.tar.gz"
-pkg_shasum="f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664"
+pkg_shasum="9ccc8706561591a540ce0165041beb1b0361338a11e135a9fcff18fd5984d7c7"
 pkg_deps=(
   core/snappy
   core/glibc


### PR DESCRIPTION
Updated pkg_version "1.20" -> "1.23" in support of 2021 Q2 core plans refresh.