### PR TITLE
Update imagemagick Plan Package Version

### DIFF
--- a/imagemagick/plan.sh
+++ b/imagemagick/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=imagemagick
 pkg_origin=core
-pkg_version=7.0.9-9
+pkg_version=7.0.11-3
 pkg_description="A software suite to create, edit, compose, or convert bitmap images."
 pkg_upstream_url="http://imagemagick.org/"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="http://www.imagemagick.org/download/releases/ImageMagick-${pkg_version}.tar.xz"
-pkg_shasum=257c9e11480aef95ea98d13495e3beb360d48c26fa8bd3da2d21c61907111d81
+pkg_source="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${pkg_version}.tar.gz"
+pkg_shasum=2912cfffc03bd20bc32623b3bf4b68cee3d037d705eabbdd3463c36c8e4834a8
 pkg_deps=(
   core/glibc
   core/zlib

--- a/imagemagick/plan.sh
+++ b/imagemagick/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="http://imagemagick.org/"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${pkg_version}.tar.gz"
-pkg_shasum=2912cfffc03bd20bc32623b3bf4b68cee3d037d705eabbdd3463c36c8e4834a8
+pkg_shasum=ceef1e81f4ab8ebfe9e61c494b8355c1b32bbb262aa6ec12b737c607e3078a40
 pkg_deps=(
   core/glibc
   core/zlib


### PR DESCRIPTION
Updated pkg_version 7.0.9-9 -> 7.0.11-3 in support of 2021 Q2 core plans refresh.

Also had to update the `pkg_source` since the previous one no longer exists.