### PR TITLE
Update llvm7 Plan Package Version

### DIFF
--- a/llvm7/plan.sh
+++ b/llvm7/plan.sh
@@ -3,11 +3,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../llvm/plan.sh"
 
 pkg_name=llvm7
 pkg_origin=core
-pkg_version=7.0.1
+pkg_version=7.1.0
 pkg_license=('NCSA')
 pkg_description="Next-gen compiler infrastructure"
 pkg_upstream_url="http://llvm.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_filename="llvm-${pkg_version}.src.tar.xz"
-pkg_source="http://llvm.org/releases/${pkg_version}/llvm-${pkg_version}.src.tar.xz"
-pkg_shasum="a38dfc4db47102ec79dcc2aa61e93722c5f6f06f0a961073bd84b78fb949419b"
+pkg_source="https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkg_version}/llvm-${pkg_version}.src.tar.xz"
+pkg_shasum="512a9a8e0f7a2cf09dd26c8789582623d84bfa707275cbeecdb26c603d9c314e"

--- a/llvm7/plan.sh
+++ b/llvm7/plan.sh
@@ -10,4 +10,4 @@ pkg_upstream_url="http://llvm.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_filename="llvm-${pkg_version}.src.tar.xz"
 pkg_source="https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkg_version}/llvm-${pkg_version}.src.tar.xz"
-pkg_shasum="512a9a8e0f7a2cf09dd26c8789582623d84bfa707275cbeecdb26c603d9c314e"
+pkg_shasum=1bcc9b285074ded87b88faaedddb88e6b5d6c331dfcfb57d7f3393dd622b3764


### PR DESCRIPTION
Updated pkg_version 7.0.1 -> 7.1.0 in support of 2021 Q2 core plans refresh.

Also had to update the `pkg_source` since the old one no longer exists.