### PR TITLE
Update gocd-server Plan Package Version

### DIFF
--- a/gocd-server/plan.sh
+++ b/gocd-server/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=gocd-server
 pkg_origin=core
-pkg_version="18.9.0"
-pkg_buildnumber="7478"
+pkg_version="18.12.0"
+pkg_buildnumber="8222"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://download.gocd.org/binaries/${pkg_version}-${pkg_buildnumber}/generic/go-server-${pkg_version}-${pkg_buildnumber}.zip"
-pkg_shasum="6a9de3f9a5a726d19946e1154d326c625c51ab371fcce5427a5819cfe9f143b2"
+pkg_shasum="5ca5b1f504ef2e47ede02df8ed0145e9cccff18106f8356bb3e6a793df24a707"
 pkg_description="GoCD is an open source tool which is used in software development to help teams and organizations automate the continuous delivery (CD) of software."
 pkg_upstream_url="https://www.gocd.org"
 pkg_filename="go-server-${pkg_version}-${pkg_buildnumber}.zip"


### PR DESCRIPTION
Updated pkg_version "18.9.0" -> "18.12.0" in support of 2021 Q2 core plans refresh.