### PR TITLE
Update cerebro Plan Package Version

### DIFF
--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -7,7 +7,7 @@ pkg_upstream_url="https://github.com/lmenezes/cerebro"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum=0c96d4bfd701b012eefb2464c11b25421c5da3f31ea9667da8fa31f8c8b36d35
+pkg_shasum=8fb294ffae01faf3ea8f980760db199b8dcb2bd44c406f63ae3078301ff62753
 pkg_deps=(
 	core/coreutils
 	core/openjdk11

--- a/cerebro/plan.sh
+++ b/cerebro/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cerebro
 pkg_origin=core
-pkg_version=0.9.0
+pkg_version=0.9.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Cerebro: Elasticsearch Administration"
 pkg_upstream_url="https://github.com/lmenezes/cerebro"
 pkg_license=("Apache-2.0")
 pkg_filename="${pkg_name}-${pkg_version}.tgz"
 pkg_source="https://github.com/lmenezes/cerebro/releases/download/v${pkg_version}/${pkg_filename}"
-pkg_shasum=44f7d1b7c990571b483771ed8056eccbff37b8381aa3d148497e8a12161b4b91
+pkg_shasum=0c96d4bfd701b012eefb2464c11b25421c5da3f31ea9667da8fa31f8c8b36d35
 pkg_deps=(
 	core/coreutils
 	core/openjdk11


### PR DESCRIPTION
Updated pkg_version 0.9.0 -> 0.9.3 in support of 2021 Q2 core plans refresh.