### PR TITLE
Update libfastjson Plan Package Version

### DIFF
--- a/libfastjson/plan.sh
+++ b/libfastjson/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("MIT")
 pkg_description="A fast JSON library for C."
 pkg_upstream_url="https://github.com/rsyslog/libfastjson"
 pkg_source="https://github.com/rsyslog/libfastjson/archive/v${pkg_version}.tar.gz"
-pkg_shasum=6e6e3702589ad229cb53547af0fecdd43ea9ac883ff09992c14b7ce2d2b27830
+pkg_shasum=881f954633aa76931e4c756ece0bda6fd8a673c6e66955a3db3b2bb9d6bbff72
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/make

--- a/libfastjson/plan.sh
+++ b/libfastjson/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libfastjson
 pkg_origin=core
-pkg_version=0.99.8
+pkg_version=0.99.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
 pkg_description="A fast JSON library for C."
 pkg_upstream_url="https://github.com/rsyslog/libfastjson"
 pkg_source="https://github.com/rsyslog/libfastjson/archive/v${pkg_version}.tar.gz"
-pkg_shasum=7e49057b26a5a9e3c6623e024f95f9fd9a14b571b9150aeb89d6d475fc3633e3
+pkg_shasum=6e6e3702589ad229cb53547af0fecdd43ea9ac883ff09992c14b7ce2d2b27830
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/make


### PR DESCRIPTION
Updated pkg_version 0.99.8 -> 0.99.9 in support of 2021 Q2 core plans refresh.