### PR TITLE
Update openjpeg Plan Package Version

### DIFF
--- a/openjpeg/plan.sh
+++ b/openjpeg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=openjpeg
 pkg_origin=core
-pkg_version=2.3.1
+pkg_version=2.4.0
 pkg_description="An open source JPEG 2000 codec"
 pkg_upstream_url=http://www.openjpeg.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://github.com/uclouvain/openjpeg/archive/v${pkg_version}.tar.gz"
-pkg_shasum=63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9
+pkg_shasum=521b3f250fe0789aed78ab7855794d4be0629dfccf768273657efe1d0c4dafed
 pkg_deps=(
   core/lcms2
   core/libpng

--- a/openjpeg/plan.sh
+++ b/openjpeg/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=http://www.openjpeg.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://github.com/uclouvain/openjpeg/archive/v${pkg_version}.tar.gz"
-pkg_shasum=521b3f250fe0789aed78ab7855794d4be0629dfccf768273657efe1d0c4dafed
+pkg_shasum=8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d
 pkg_deps=(
   core/lcms2
   core/libpng


### PR DESCRIPTION
Updated pkg_version 2.3.1 -> 2.4.0 in support of 2021 Q2 core plans refresh.