### PR TITLE
Update postgresql94-client Plan Package Version

### DIFF
--- a/postgresql94-client/plan.sh
+++ b/postgresql94-client/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=postgresql94-client
-pkg_version=9.4.18
+pkg_version=9.4.26
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
@@ -7,7 +7,7 @@ pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_dirname="postgresql-${pkg_version}"
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_dirname}.tar.bz2"
-pkg_shasum="428337f2b2f5e3ea21b8a44f88eb89c99a07a324559b99aebe777c9abdf4c4c0"
+pkg_shasum="f5c014fc4a5c94e8cf11314cbadcade4d84213cfcc82081c9123e1b8847a20b9"
 
 pkg_deps=(
   core/bash


### PR DESCRIPTION
Updated pkg_version 9.4.18 -> 9.4.26 in support of 2021 Q2 core plans refresh.