### PR TITLE
Update cpio Plan Package Version

### DIFF
--- a/cpio/plan.sh
+++ b/cpio/plan.sh
@@ -1,10 +1,10 @@
 pkg_origin=core
 pkg_name=cpio
-pkg_version='2.12'
+pkg_version='2.13'
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-3.0-or-later')
 pkg_source=http://ftp.gnu.org/gnu/cpio/cpio-${pkg_version}.tar.gz
-pkg_shasum=08a35e92deb3c85d269a0059a27d4140a9667a6369459299d08c17f713a92e73
+pkg_shasum=e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88
 pkg_description="GNU cpio copies files into or out of a cpio or tar archive. \
   The archive can be another file on the disk, a magnetic tape, or a pipe"
 pkg_upstream_url="https://www.gnu.org/software/cpio/"


### PR DESCRIPTION
Updated pkg_version '2.12' -> '2.13' in support of 2021 Q2 core plans refresh.