### PR TITLE
Update tomcat-native Plan Package Version

### DIFF
--- a/tomcat-native/plan.sh
+++ b/tomcat-native/plan.sh
@@ -1,11 +1,11 @@
 pkg_origin=core
 pkg_name=tomcat-native
 pkg_description="The Apache Tomcat Native Library is an optional component for use with Apache Tomcat that allows Tomcat to use certain native resources for performance, compatibility, etc."
-pkg_version='1.2.8'
+pkg_version='1.2.26'
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('Apache 2.0')
 pkg_source="http://archive.apache.org/dist/tomcat/tomcat-connectors/native/$pkg_version/source/$pkg_name-$pkg_version-src.tar.gz"
-pkg_shasum=408ece0b027c8967b3aa85533c5fca642827e235b1857d28df918a4eab861d30
+pkg_shasum=b7e5449d206803d6581e0bda7694c9ca8b989938e0054c468df87f9ecb28757d
 pkg_deps=(core/apr core/gcc-libs)
 pkg_build_deps=(core/gcc core/make core/openssl core/openjdk11)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updated pkg_version '1.2.8' -> '1.2.26' in support of 2021 Q2 core plans refresh.