### PR TITLE
Update mc Plan Package Version

### DIFF
--- a/mc/plan.sh
+++ b/mc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=mc
 pkg_origin=core
-pkg_version=4.8.21
+pkg_version=4.8.26
 pkg_description="Midnight Commander."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-3.0')
 pkg_source=http://ftp.midnight-commander.org/mc-${pkg_version}.tar.xz
 pkg_upstream_url=https://www.midnight-commander.org
-pkg_shasum=8f37e546ac7c31c9c203a03b1c1d6cb2d2f623a300b86badfd367e5559fe148c
+pkg_shasum=c6deadc50595f2d9a22dc6c299a9f28b393e358346ebf6ca444a8469dc166c27
 pkg_deps=(
   core/glib
   core/glibc


### PR DESCRIPTION
Updated pkg_version 4.8.21 -> 4.8.26 in support of 2021 Q2 core plans refresh.