### PR TITLE
Update dbus Plan Package Version

### DIFF
--- a/dbus/plan.sh
+++ b/dbus/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dbus
 pkg_origin=core
-pkg_version="1.13.8"
+pkg_version="1.13.18"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPLv2')
 pkg_description="D-Bus is a message bus system, a simple way for applications to talk to one another."
 pkg_upstream_url="https://www.freedesktop.org/wiki/Software/dbus/"
 pkg_source="https://dbus.freedesktop.org/releases/dbus/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="82a89f64e1b55e459725186467770995f33cac5eb8a050b5d8cbeb338078c4f6"
+pkg_shasum="8078f5c25e34ab907ce06905d969dc8ef0ccbec367e1e1707c7ecf8460f4254e"
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/autoconf


### PR DESCRIPTION
Updated pkg_version "1.13.8" -> "1.13.18" in support of 2021 Q2 core plans refresh.