### PR TITLE
Update ncdu Plan Package Version

### DIFF
--- a/ncdu/plan.sh
+++ b/ncdu/plan.sh
@@ -10,3 +10,7 @@ pkg_shasum=4a593dc5cceb2492a9669f5f5d69d0e517de457a11036788ea4591f33c5297fb
 pkg_deps=(core/glibc core/ncurses)
 pkg_build_deps=(core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  export LDFLAGS="$LDFLAGS -Wl,--copy-dt-needed-entries"
+}

--- a/ncdu/plan.sh
+++ b/ncdu/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ncdu
 pkg_origin=core
-pkg_version=1.11
+pkg_version=1.15
 pkg_license=('MIT')
 pkg_description="Ncdu is a disk usage analyzer with an ncurses interface"
 pkg_upstream_url=https://dev.yorhel.nl/ncdu
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://dev.yorhel.nl/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=d0aea772e47463c281007f279a9041252155a2b2349b18adb9055075e141bb7b
+pkg_shasum=4a593dc5cceb2492a9669f5f5d69d0e517de457a11036788ea4591f33c5297fb
 pkg_deps=(core/glibc core/ncurses)
 pkg_build_deps=(core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 1.11 -> 1.15 in support of 2021 Q2 core plans refresh.