### PR TITLE
Update img Plan Package Version

### DIFF
--- a/img/plan.sh
+++ b/img/plan.sh
@@ -1,6 +1,6 @@
 pkg_name="img"
 pkg_origin="core"
-pkg_version=0.5.7
+pkg_version=0.5.11
 pkg_description="Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder."
 pkg_upstream_url="https://github.com/genuinetools/img"
 pkg_license=('MIT')


### PR DESCRIPTION
Updated pkg_version 0.5.7 -> 0.5.11 in support of 2021 Q2 core plans refresh.