### PR TITLE
Update libnsl Plan Package Version

### DIFF
--- a/libnsl/autogen.patch
+++ b/libnsl/autogen.patch
@@ -1,0 +1,13 @@
+diff --git a/autogen.sh b/autogen.sh
+index e4215218..0425739a 100644
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -1,7 +1,7 @@
+ !/bin/sh -x
+ 
+ rm -fv ltmain.sh config.sub config.guess config.h.in config.rpath
+-gettextize -f
++autopoint -f
+ rm -fv po/Makevars.template po/ChangeLog
+ mkdir -p m4
+ aclocal -I m4

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -10,6 +10,7 @@ pkg_shasum=8e88017f01dd428f50386186b0cd82ad06c9b2a47f9c5ea6b3023fc6e08a6b0f
 pkg_deps=(
   core/glibc
   core/krb5
+  core/libtirpc
 )
 pkg_build_deps=(
   core/autoconf
@@ -17,7 +18,6 @@ pkg_build_deps=(
   core/diffutils
   core/gcc
   core/gettext
-  core/libtirpc
   core/libtool
   core/make
   core/patch

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -6,7 +6,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.1-or-later")
 pkg_upstream_url="https://github.com/thkukuk/libnsl"
 pkg_source="https://github.com/thkukuk/libnsl/archive/v${pkg_version}.tar.gz"
-pkg_shasum="b7eb25b0e938c5e504eaef7888ced8aae3d70c749cecf532817379a0eb785560"
+pkg_shasum=8e88017f01dd428f50386186b0cd82ad06c9b2a47f9c5ea6b3023fc6e08a6b0f
 pkg_deps=(
   core/glibc
 )

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -16,6 +16,7 @@ pkg_build_deps=(
   core/diffutils
   core/gcc
   core/gettext
+  core/libtirpc
   core/libtool
   core/make
   core/pkg-config

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libnsl
 pkg_origin=core
-pkg_version="1.2.0"
+pkg_version="1.3.0"
 pkg_description="This library contains the public client interface for NIS(YP) and NIS+ in a IPv6 ready version"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.1-or-later")
 pkg_upstream_url="https://github.com/thkukuk/libnsl"
 pkg_source="https://github.com/thkukuk/libnsl/archive/v${pkg_version}.tar.gz"
-pkg_shasum="a5a28ef17c4ca23a005a729257c959620b09f8c7f99d0edbfe2eb6b06bafd3f8"
+pkg_shasum="b7eb25b0e938c5e504eaef7888ced8aae3d70c749cecf532817379a0eb785560"
 pkg_deps=(
   core/glibc
 )

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -9,6 +9,7 @@ pkg_source="https://github.com/thkukuk/libnsl/archive/v${pkg_version}.tar.gz"
 pkg_shasum=8e88017f01dd428f50386186b0cd82ad06c9b2a47f9c5ea6b3023fc6e08a6b0f
 pkg_deps=(
   core/glibc
+  core/krb5
 )
 pkg_build_deps=(
   core/autoconf

--- a/libnsl/plan.sh
+++ b/libnsl/plan.sh
@@ -19,6 +19,7 @@ pkg_build_deps=(
   core/libtirpc
   core/libtool
   core/make
+  core/patch
   core/pkg-config
 )
 pkg_include_dirs=(include)
@@ -30,5 +31,6 @@ do_prepare() {
   export ACLOCAL_PATH
 
   autoreconf --force --install
+  patch < "$PLAN_CONTEXT/autogen.patch"
   ./autogen.sh
 }


### PR DESCRIPTION
Updated pkg_version "1.2.0" -> "1.3.0" in support of 2021 Q2 core plans refresh.