### PR TITLE
Update fluentd Plan Package Version

### DIFF
--- a/fluentd/plan.sh
+++ b/fluentd/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=fluentd
 pkg_origin=core
-pkg_version=1.0.2
+pkg_version=1.12.1
 pkg_deps=(
   core/ruby
   core/coreutils


### PR DESCRIPTION
Updated pkg_version 1.0.2 -> 1.12.1 in support of 2021 Q2 core plans refresh.