### PR TITLE
Update node to 14.16.0

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1052,6 +1052,11 @@ plan_path = "node12"
 paths = [
   "node/*",
 ]
+[node14]
+plan_path = "node14"
+paths = [
+  "node/*",
+]
 [node_exporter]
 plan_path = "node_exporter"
 [npth]

--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -24,5 +24,5 @@ function Invoke-Install {
 }
 
 function Invoke-Check() {
-    (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/nodejs/node" --version) -eq "v$pkg_version"
+    (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/node-v$pkg_version-x64/SourceDir/nodejs/node" --version) -eq "v$pkg_version"
 }

--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="12.14.1"
+$pkg_version="14.16.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="630bc34155e7fdb65c02ed44a37cd27dcf3f76a061c220e7af8baacdb0c2bb9c"
+$pkg_shasum="d9243c9d02f5e4801b8b3ab848f45ce0da2882b5fff448191548ca49af434066"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node14/README.md
+++ b/node14/README.md
@@ -1,0 +1,15 @@
+# node14
+
+Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/node14/plan.ps1
+++ b/node14/plan.ps1
@@ -1,0 +1,8 @@
+. "..\node\plan.ps1"
+
+$pkg_name="node14"
+$pkg_origin="core"
+$pkg_version="14.16.0"
+$pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
+$pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
+$pkg_shasum="d9243c9d02f5e4801b8b3ab848f45ce0da2882b5fff448191548ca49af434066"

--- a/node14/tests/test.pester.ps1
+++ b/node14/tests/test.pester.ps1
@@ -1,0 +1,18 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+Describe "node bin" {
+    Context "node" {
+        It "version matches" {
+            $expected_version = $PackageIdentifier.split("/")[2]
+            $output = hab pkg exec $PackageIdentifier node --version
+            $output | Out-String | Should -Match "v${expected_version}"
+        }
+        It "help command" {
+            hab pkg exec $PackageIdentifier node --help
+            $? | Should be $true
+        }
+    }
+}

--- a/node14/tests/test.ps1
+++ b/node14/tests/test.ps1
@@ -1,0 +1,16 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    Install-Module -Name Pester -Force
+}
+
+hab pkg install $PackageIdentifier
+
+$__dir=(Get-Item $PSScriptRoot)
+Invoke-Pester -EnableExit -Script @{
+    Path       = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier =$PackageIdentifier}
+}


### PR DESCRIPTION
I'm basically copying the work done by @msorens in https://github.com/habitat-sh/core-plans/pull/3158 so that we can bump Automate's node version up as well. (see https://github.com/chef/automate/issues/4698)

### Description
node 14.16.0 is now in the "active LTS" phase, so suitable for production use.

SHAs extracted from:
https://nodejs.org/download/release/latest-v14.x/SHASUMS256.txt

General Reference:
https://nodejs.org/en/about/releases/
