### PR TITLE
Update cabal-install Plan Package Version

### DIFF
--- a/cabal-install/plan.sh
+++ b/cabal-install/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=cabal-install
 pkg_origin=core
-pkg_version=3.0.0.0
+pkg_version=3.4.0.0
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/cabal/"
 pkg_description="Command-line interface for Cabal and Hackage"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://downloads.haskell.org/~cabal/cabal-install-${pkg_version}/cabal-install-${pkg_version}.tar.gz"
-pkg_shasum="a432a7853afe96c0fd80f434bd80274601331d8c46b628cd19a0d8e96212aaf1"
+pkg_shasum="1980ef3fb30001ca8cf830c4cae1356f6065f4fea787c7786c7200754ba73e97"
 
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Updated pkg_version 3.0.0.0 -> 3.4.0.0 in support of 2021 Q2 core plans refresh.