### PR TITLE
Update kubectl Plan Package Version

### DIFF
--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_version=1.20.5
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=5525ffdf29cbf298656c6418a062175b85586c5bfc2a6b36e64e05547fe1a81d
+pkg_shasum=d237e3c986288366f5f27e0142028c65fe6b1663484b5ea2a669427ed3c6d97c
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_version=1.20.5
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=d237e3c986288366f5f27e0142028c65fe6b1663484b5ea2a669427ed3c6d97c
+pkg_shasum=5525ffdf29cbf298656c6418a062175b85586c5bfc2a6b36e64e05547fe1a81d
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -4,9 +4,9 @@ pkg_description="kubectl CLI tool"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.18.5
+pkg_version=1.20.5
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=3fd73d1094f3b24f5b94d390b30a0613de272bbdb419f23b5e54185c3060b0e3
+pkg_shasum=3edf9c2384a4449efec7eab28b22530982bb44222c6f3d45d9921638cab2fe4c
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/kubectl/plan.sh
+++ b/kubectl/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_version=1.20.5
 pkg_source=https://github.com/kubernetes/kubernetes/archive/v${pkg_version}.tar.gz
-pkg_shasum=3edf9c2384a4449efec7eab28b22530982bb44222c6f3d45d9921638cab2fe4c
+pkg_shasum=5525ffdf29cbf298656c6418a062175b85586c5bfc2a6b36e64e05547fe1a81d
 pkg_dirname="kubernetes-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 1.18.5 -> 1.20.5 in support of 2021 Q2 core plans refresh.