### PR TITLE
Update libepoxy Plan Package Version

### DIFF
--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -20,6 +20,7 @@ pkg_deps=(
   core/xlib # not linked to bins/libs
 )
 pkg_build_deps=(
+  core/coreutils
   core/damageproto
   core/fixesproto
   core/gcc
@@ -29,12 +30,19 @@ pkg_build_deps=(
   core/ninja
   core/pkg-config
   core/python
-  core/xextproto
+  core/xextproto 
   core/xproto
 )
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_prepare() {
+  if [[ ! -r /usr/bin/env ]]; then
+    ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+    _clean_env=true
+  fi
+}
 
 do_build() {
   mkdir _build
@@ -49,4 +57,11 @@ do_install() {
   pushd _build > /dev/null
     ninja install
   popd > /dev/null
+}
+
+do_end() {
+  # Clean up the `env` link, if we set it up.
+  if [[ -n "$_clean_env" ]]; then
+    rm -fv /usr/bin/env
+  fi
 }

--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libepoxy
 pkg_origin=core
-pkg_version=1.4.3
+pkg_version=1.5.5
 pkg_description="Epoxy is a library for handling OpenGL function pointer management for you"
 pkg_upstream_url="https://github.com/anholt/libepoxy"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/anholt/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=0b808a06c9685a62fca34b680abb8bc7fb2fda074478e329b063c1f872b826f6
+pkg_shasum=412b7f359da4ae15ebbda8776e853be6bb8831151917756dd1666962fc8ab239
 pkg_deps=(
   core/glibc
   core/libdrm # not linked to bins/libs

--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -30,7 +30,7 @@ pkg_build_deps=(
   core/ninja
   core/pkg-config
   core/python
-  core/xextproto 
+  core/xextproto
   core/xproto
 )
 pkg_include_dirs=(include)

--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="https://github.com/anholt/libepoxy"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/anholt/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=412b7f359da4ae15ebbda8776e853be6bb8831151917756dd1666962fc8ab239
+pkg_shasum=261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556
 pkg_deps=(
   core/glibc
   core/libdrm # not linked to bins/libs


### PR DESCRIPTION
Updated pkg_version 1.4.3 -> 1.5.5 in support of 2021 Q2 core plans refresh.