### PR TITLE
Update happy Plan Package Version

### DIFF
--- a/happy/plan.sh
+++ b/happy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=happy
 pkg_origin=core
-pkg_version=1.19.12
+pkg_version=1.20.0
 pkg_license=('BSD-3-Clause')
 pkg_upstream_url="https://www.haskell.org/happy/"
 pkg_description="Happy is a parser generator for Haskell. Given a grammar specification in BNF, Happy generates Haskell code to parse the grammar. Happy works in a similar way to the yacc tool for C."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f"
+pkg_shasum="3b1d3a8f93a2723b554d9f07b2cd136be1a7b2fcab1855b12b7aab5cbac8868c"
 
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Updated pkg_version 1.19.12 -> 1.20.0 in support of 2021 Q2 core plans refresh.