### PR TITLE
Update compositeproto Plan Package Version

### DIFF
--- a/compositeproto/plan.sh
+++ b/compositeproto/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=compositeproto
 pkg_origin=core
-pkg_version=0.4
+pkg_version=0.4.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="X11 Composite extension header files"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/proto/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="6013d1ca63b2b7540f6f99977090812b899852acfbd9df123b5ebaa911e30003"
+pkg_shasum="049359f0be0b2b984a8149c966dd04e8c58e6eade2a4a309cf1126635ccd0cfc"
 pkg_build_deps=(
   core/gcc
   core/make


### PR DESCRIPTION
Updated pkg_version 0.4 -> 0.4.2 in support of 2021 Q2 core plans refresh.