### PR TITLE
Update metricbeat Plan Package Version

### DIFF
--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=metricbeat
 pkg_origin=core
-pkg_version=7.2.0
+pkg_version=7.12.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)

--- a/metricbeat/plan.sh
+++ b/metricbeat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=core
 pkg_version=7.12.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
-pkg_deps=(core/glibc)
+pkg_deps=(core/glibc core/systemd)
 pkg_build_deps=(
   core/go
   core/git
@@ -17,15 +17,18 @@ pkg_description="Metricbeat is a lightweight shipper for metrics with Elasticsea
 pkg_upstream_url="https://elastic.co/products/beats/metricbeat"
 
 do_download() {
+  SYSTEMD_INCLUDE_PATH=$(pkg_path_for core/systemd)/include
   GOPATH="$(dirname "${HAB_CACHE_SRC_PATH}")"
   export GOPATH
-  go get github.com/elastic/beats/metricbeat
+  rm -rf "${GOPATH}/src/github.com/elastic/beats"
+  git clone https://github.com/elastic/beats "${GOPATH}"/src/github.com/elastic/beats
   pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat" > /dev/null || exit 1
   git checkout "v${pkg_version}"
   popd > /dev/null || exit 1
 }
 
 do_build() {
+  SYSTEMD_INCLUDE_PATH=$(pkg_path_for core/systemd)/include
   pushd "${HAB_CACHE_SRC_PATH}/github.com/elastic/beats/metricbeat" > /dev/null || exit 1
   mage build
   popd > /dev/null || exit 1


### PR DESCRIPTION
Updated pkg_version 7.2.0 -> 7.12.0 in support of 2021 Q2 core plans refresh.