### PR TITLE
Update libxdamage Plan Package Version

### DIFF
--- a/libxdamage/plan.sh
+++ b/libxdamage/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libxdamage
 pkg_origin=core
-pkg_version=1.1.4
+pkg_version=1.1.5
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="X11 C Bindings"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_dirname="libXdamage-${pkg_version}"
 pkg_source="https://www.x.org/releases/individual/lib/${pkg_dirname}.tar.bz2"
-pkg_shasum="7c3fe7c657e83547f4822bfde30a90d84524efb56365448768409b77f05355ad"
+pkg_shasum="b734068643cac3b5f3d2c8279dd366b5bf28c7219d9e9d8717e1383995e0ea45"
 pkg_deps=(
   core/glibc
   core/libxau


### PR DESCRIPTION
Updated pkg_version 1.1.4 -> 1.1.5 in support of 2021 Q2 core plans refresh.