### PR TITLE
Update freetds Plan Package Version

### DIFF
--- a/freetds/plan.sh
+++ b/freetds/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=freetds
 pkg_origin=core
-pkg_version=1.00.109
+pkg_version=1.2.18
 pkg_license=('LGPL2')
 pkg_upstream_url="http://www.freetds.org"
 pkg_description="FreeTDS is a set of libraries for Unix and Linux that allows your programs to natively talk to Microsoft SQL Server and Sybase databases."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://www.freetds.org/files/stable/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="3e93b2bcdddc7246147398b9bc3b989c6e7ffed54acbce18f4f34b745c8f0034"
+pkg_shasum="10d47e60986cfc51f8170fa9eaba43114eebdde0ba6e6b1c4813d86f021aaadd"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updated pkg_version 1.00.109 -> 1.2.18 in support of 2021 Q2 core plans refresh.