### PR TITLE
Update nspr Plan Package Version

### DIFF
--- a/nspr/plan.sh
+++ b/nspr/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nspr
 pkg_origin=core
-pkg_version=4.21
+pkg_version=4.30
 pkg_license=("MPL-2.0")
 pkg_description="Netscape Portable Runtime"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url=https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
 pkg_source=https://ftp.mozilla.org/pub/nspr/releases/v${pkg_version}/src/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=15ea32c7b100217b6e3193bc03e77f485d9bf7504051443ba9ce86d1c17c6b5a
+pkg_shasum=8d4cd8f8409484dc4c3d31e180354bfc506573eccf86cd691106a1ef7edc913b
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 4.21 -> 4.30 in support of 2021 Q2 core plans refresh.