### PR TITLE
Update chrony Plan Package Version

### DIFF
--- a/chrony/plan.sh
+++ b/chrony/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=chrony
 pkg_origin=core
-pkg_version=3.4
+pkg_version=3.5.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Chrony is a versatile implementation of the Network Time Protocol (NTP)."
 pkg_upstream_url="https://chrony.tuxfamily.org/"
 pkg_license=("GPL-2.0")
 pkg_source="https://download.tuxfamily.org/chrony/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="af77e47c2610a7e55c8af5b89a8aeff52d9a867dd5983d848b52d374bc0e6b9f"
+pkg_shasum="1ba82f70db85d414cd7420c39858e3ceca4b9eb8b028cbe869512c3a14a2dca7"
 pkg_deps=(
   core/glibc
   core/nss


### PR DESCRIPTION
Updated pkg_version 3.4 -> 3.5.1 in support of 2021 Q2 core plans refresh.