### PR TITLE
Update cppcheck Plan Package Version

### DIFF
--- a/cppcheck/plan.sh
+++ b/cppcheck/plan.sh
@@ -11,18 +11,18 @@ pkg_shasum=c4864d3e09359214efdd503b52e241f4f56ba7ce26f8c11939fd9dcfac1fd105
 pkg_deps=(
   core/glibc
   core/gcc-libs
-  core/pcre
 )
 pkg_build_deps=(
   core/pkg-config
   core/cmake
   core/ninja
   core/gcc
+  core/pcre
 )
 pkg_bin_dirs=(bin)
 
 do_setup_environment() {
-  export BUILDDIR="_build"
+  export BUILDDIR="build"
 }
 
 do_prepare() {
@@ -33,14 +33,17 @@ do_build() {
   _PCRE_PATH="$(pkg_path_for pcre)"
 
   pushd "${BUILDDIR}" || exit 1
+pwd
   cmake \
     -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" \
     -DBUILD_TESTS="${DO_CHECK}" \
-    -DHAVE_RULES="yes" \
-    -DPCRE="${_PCRE_PATH}/lib" \
+    -DUSE_MATCHCOMPILER=ON \
+    -DPCRE_INCLUDE="yes" \
+    -DPCRE_LIBRARY="${_PCRE_PATH}/lib" \
     -G Ninja \
     ..
   ninja
+
   popd || exit 1
 }
 

--- a/cppcheck/plan.sh
+++ b/cppcheck/plan.sh
@@ -7,7 +7,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/danmar/cppcheck/archive/${pkg_version}.tar.gz"
 pkg_filename="${pkg_version}.tar.gz"
-pkg_shasum=c6c907ff609767417bdaadfc5cc928705838500a9400812c814ecf3aa8ba55cc
+pkg_shasum=c4864d3e09359214efdd503b52e241f4f56ba7ce26f8c11939fd9dcfac1fd105
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/cppcheck/plan.sh
+++ b/cppcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=cppcheck
 pkg_origin=core
-pkg_version=1.86
+pkg_version=1.90
 pkg_description="static analysis of C/C++ code"
 pkg_upstream_url="http://cppcheck.sourceforget.net"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0")
 pkg_source="https://github.com/danmar/cppcheck/archive/${pkg_version}.tar.gz"
 pkg_filename="${pkg_version}.tar.gz"
-pkg_shasum=86ea85c2ee5ec31a7410bfc7c206b87e600d284089428750d66d1ce1ffa0c9a6
+pkg_shasum=c6c907ff609767417bdaadfc5cc928705838500a9400812c814ecf3aa8ba55cc
 pkg_deps=(
   core/glibc
   core/gcc-libs


### PR DESCRIPTION
Updated pkg_version 1.86 -> 1.90 in support of 2021 Q2 core plans refresh.