### PR TITLE
Update shellcheck Plan Package Version

### DIFF
--- a/shellcheck/plan.sh
+++ b/shellcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=shellcheck
 hkg_name=ShellCheck
 pkg_origin=core
-pkg_version=0.7.0
+pkg_version=0.7.1
 pkg_license=('GPL-3')
 pkg_upstream_url="http://www.shellcheck.net/"
 pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="3af93f97750fe896b5e9c5247b84f1a99e34293992bb0e9001b0cc725949a8ef"
+pkg_shasum="415f23ed77c17cb6837b328a35b9fa262c7d9b1a9093bc801f50d99010e4a41a"
 pkg_dirname="${hkg_name}-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 0.7.0 -> 0.7.1 in support of 2021 Q2 core plans refresh.