### PR TITLE
Update libzip Plan Package Version

### DIFF
--- a/libzip/plan.sh
+++ b/libzip/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libzip
 pkg_origin=core
-pkg_version=1.5.1
+pkg_version=1.7.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A C library for reading, creating, and modifying zip archives"
 pkg_upstream_url="https://libzip.org/"
 pkg_license=('BSD-3-Clause')
 pkg_source="${pkg_upstream_url}/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=47eaa45faa448c72bd6906e5a096846c469a185f293cafd8456abb165841b3f2
+pkg_shasum=0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc
 pkg_deps=(
   core/bzip2-musl
   core/openssl


### PR DESCRIPTION
Updated pkg_version 1.5.1 -> 1.7.3 in support of 2021 Q2 core plans refresh.