### PR TITLE
Update utf8proc Plan Package Version

### DIFF
--- a/utf8proc/plan.sh
+++ b/utf8proc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=utf8proc
 pkg_origin=core
-pkg_version="2.4.0"
+pkg_version="2.6.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT-Expat")
 pkg_description="A clean C library for processing UTF-8 Unicode data"
 pkg_upstream_url=https://juliastrings.github.io/utf8proc/
 pkg_source="https://github.com/JuliaStrings/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=b2e5d547c1d94762a6d03a7e05cea46092aab68636460ff8648f1295e2cdfbd7
+pkg_shasum=8ff440b288b57b1d91dcbcf984a4bcfc8e5cf8089eb936be95055a0d1b174f43
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/make

--- a/utf8proc/plan.sh
+++ b/utf8proc/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("MIT-Expat")
 pkg_description="A clean C library for processing UTF-8 Unicode data"
 pkg_upstream_url=https://juliastrings.github.io/utf8proc/
 pkg_source="https://github.com/JuliaStrings/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=8ff440b288b57b1d91dcbcf984a4bcfc8e5cf8089eb936be95055a0d1b174f43
+pkg_shasum=4c06a9dc4017e8a2438ef80ee371d45868bda2237a98b26554de7a95406b283b
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/make


### PR DESCRIPTION
Updated pkg_version "2.4.0" -> "2.6.1" in support of 2021 Q2 core plans refresh.