### PR TITLE
Update rethinkdb Plan Package Version

### DIFF
--- a/rethinkdb/plan.sh
+++ b/rethinkdb/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=rethinkdb
 pkg_origin=core
-pkg_version=2.3.6
+pkg_version=2.4.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The open-source database for the realtime web."
 pkg_upstream_url="https://rethinkdb.com"
 pkg_license=('Apache-2.0')
-pkg_source="https://download.${pkg_name}.com/dist/${pkg_name}-${pkg_version}.tgz"
-pkg_shasum=c42159666910ad01be295a57caf8839ec3a89227d8919be5418e3aa1f0a3dc28
+pkg_source="https://download.${pkg_name}.com/repository/raw/dist/${pkg_name}-${pkg_version}.tgz"
+pkg_shasum=5f1786c94797a0f8973597796e22545849dc214805cf1962ef76969e0b7d495b
 pkg_build_deps=(
   core/gcc/5.2.0
   core/make


### PR DESCRIPTION
Updated pkg_version 2.3.6 -> 2.4.1 in support of 2021 Q2 core plans refresh.