### PR TITLE
Update libxcursor Plan Package Version

### DIFF
--- a/libxcursor/plan.sh
+++ b/libxcursor/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=libxcursor
 pkg_distname=libXcursor
 pkg_origin=core
-pkg_version=1.1.15
+pkg_version=1.2.0
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="X11 miscellaneous extensions library"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/lib/${pkg_distname}-${pkg_version}.tar.bz2"
-pkg_shasum="294e670dd37cd23995e69aae626629d4a2dfe5708851bbc13d032401b7a3df6b"
+pkg_shasum="3ad3e9f8251094af6fe8cb4afcf63e28df504d46bfa5a5529db74a505d628782"
 pkg_deps=(
   core/glibc
   core/libxau


### PR DESCRIPTION
Updated pkg_version 1.1.15 -> 1.2.0 in support of 2021 Q2 core plans refresh.