### PR TITLE
Update kafka2 Plan Package Version

### DIFF
--- a/kafka2/plan.sh
+++ b/kafka2/plan.sh
@@ -1,9 +1,9 @@
 pkg_name=kafka2
 pkg_root_name="kafka"
 pkg_origin=core
-pkg_version=2.5.0
+pkg_version=2.7.0
 pkg_source="https://downloads.apache.org/${pkg_root_name}/${pkg_version}/${pkg_root_name}_2.13-${pkg_version}.tgz"
-pkg_shasum="112b00678428595ff871a96215e9fd2c36d042220c29b1e91275988e623c6f70"
+pkg_shasum="1dd84b763676a02fecb48fa5d7e7e94a2bf2be9ff87bce14cf14109ce1cb7f90"
 pkg_dirname="${pkg_root_name}_2.13-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A distributed streaming platform"


### PR DESCRIPTION
Updated pkg_version 2.5.0 -> 2.7.0 in support of 2021 Q2 core plans refresh.