### PR TITLE
Update kafka0 Plan Package Version

### DIFF
--- a/kafka0/plan.sh
+++ b/kafka0/plan.sh
@@ -1,9 +1,9 @@
 pkg_name=kafka0
 pkg_basename=kafka
 pkg_origin=core
-pkg_version=0.10.2.2
+pkg_version=0.11.0.3
 pkg_source="http://archive.apache.org/dist/${pkg_basename}/${pkg_version}/${pkg_basename}_2.11-${pkg_version}.tgz"
-pkg_shasum="60f587ed8d1ee6e8e8057f13da6eee472f95c8d2ea691f6aab74edb842dc9950"
+pkg_shasum="c73f1e1b8cd3d754747e5a8750e868fcb6efe5cd9dae17c828fe20d6a400837a"
 pkg_dirname="${pkg_basename}_2.11-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A distributed streaming platform"


### PR DESCRIPTION
Updated pkg_version 0.10.2.2 -> 0.11.0.3 in support of 2021 Q2 core plans refresh.