### PR TITLE
Update dnsmasq Plan Package Version

### DIFF
--- a/dnsmasq/plan.sh
+++ b/dnsmasq/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dnsmasq
 pkg_origin=core
-pkg_version=2.84
+pkg_version=2.85
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Provides network infrastructure for small networks"
 pkg_upstream_url="http://www.thekelleys.org.uk/dnsmasq/doc.html"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${pkg_version}.tar.gz"
-pkg_shasum=4caf385376f34fae5c55244a1f870dcf6f90e037bb7c4487210933dc497f9c36
+pkg_shasum=f36b93ecac9397c15f461de9b1689ee5a2ed6b5135db0085916233053ff3f886
 pkg_deps=(
   core/glibc
 )

--- a/dnsmasq/plan.sh
+++ b/dnsmasq/plan.sh
@@ -6,7 +6,7 @@ pkg_description="Provides network infrastructure for small networks"
 pkg_upstream_url="http://www.thekelleys.org.uk/dnsmasq/doc.html"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${pkg_version}.tar.gz"
-pkg_shasum=42a765e0b7df35d81485bee7c67009bda3280d8f52c9d743a2fade2c8eb6211e
+pkg_shasum=4caf385376f34fae5c55244a1f870dcf6f90e037bb7c4487210933dc497f9c36
 pkg_deps=(
   core/glibc
 )

--- a/dnsmasq/plan.sh
+++ b/dnsmasq/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dnsmasq
 pkg_origin=core
-pkg_version=2.81
+pkg_version=2.84
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Provides network infrastructure for small networks"
 pkg_upstream_url="http://www.thekelleys.org.uk/dnsmasq/doc.html"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${pkg_version}.tar.gz"
-pkg_shasum=3c28c68c6c2967c3a96e9b432c0c046a5df17a426d3a43cffe9e693cf05804d0
+pkg_shasum=42a765e0b7df35d81485bee7c67009bda3280d8f52c9d743a2fade2c8eb6211e
 pkg_deps=(
   core/glibc
 )

--- a/dnsmasq/tests/test.bats
+++ b/dnsmasq/tests/test.bats
@@ -9,11 +9,11 @@ expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 }
 
 @test "dnsmasq binary matches version ${expected_version}" {
-  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" dnsmasq --version | grep "Dnsmasq version" | awk '{print $3}')"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" dnsmasq -- --version | grep "Dnsmasq version" | awk '{print $3}')"
   diff <( echo "$actual_version" ) <( echo "${expected_version}" )
 }
 
 @test "dnsmasq binary test returns success" {
-  actual="$(hab pkg exec "${TEST_PKG_IDENT}" dnsmasq --test 2>&1)"
+  actual="$(hab pkg exec "${TEST_PKG_IDENT}" dnsmasq -- --test 2>&1)"
   diff <( echo "$actual" ) <( echo "dnsmasq: syntax check OK." )
 }


### PR DESCRIPTION
Updated pkg_version 2.81 -> 2.84 in support of 2021 Q2 core plans refresh.