### PR TITLE
Update lz4 Plan Package Version

### DIFF
--- a/lz4/plan.sh
+++ b/lz4/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=lz4
-pkg_version=1.9.2
+pkg_version=1.9.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2 Clause' 'GPL-2.0')
 pkg_upstream_url=http://lz4.github.io/lz4/
 pkg_description="Extremely Fast Compression algorithm http://www.lz4.org"
 pkg_source="https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
+pkg_shasum=030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/gcc

--- a/lz4/tests/test.bats
+++ b/lz4/tests/test.bats
@@ -1,11 +1,11 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result=$(hab pkg exec ${TEST_PKG_IDENT} lz4 --version | grep "v${TEST_PKG_VERSION}")
+  result=$(hab pkg exec ${TEST_PKG_IDENT} lz4 -- --version | grep "v${TEST_PKG_VERSION}")
   [ $? -eq 0 ]
 }
 
 @test "Help command" {
-  run hab pkg exec ${TEST_PKG_IDENT} lz4 --help
+  run hab pkg exec ${TEST_PKG_IDENT} lz4 -- --help
   [ $status -eq 0 ]
 }


### PR DESCRIPTION
Updated pkg_version 1.9.2 -> 1.9.3 in support of 2021 Q2 core plans refresh.