### PR TITLE
Update tlog Plan Package Version

### DIFF
--- a/tlog/plan.sh
+++ b/tlog/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=tlog
 pkg_origin=core
-pkg_version=6
+pkg_version=11
 pkg_description="Tlog is a terminal I/O recording and playback package suitable for implementing centralized user session recording."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="https://github.com/Scribery/tlog/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url="https://github.com/Scribery/tlog"
-pkg_shasum="8ea2cc4ab10e94ec1c460d0a2271a18b67502d514ec63365928e59fec890d1ee"
+pkg_shasum="3f181107cb3149b1d6cd238031acd7c61d0bf2c79463fa7272f411ee25918b53"
 
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Updated pkg_version 6 -> 11 in support of 2021 Q2 core plans refresh.