### PR TITLE
Update libice Plan Package Version

### DIFF
--- a/libice/plan.sh
+++ b/libice/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=libice
 pkg_distname=libICE
 pkg_origin=core
-pkg_version=1.0.9
+pkg_version=1.0.10
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="X11 Inter-Client Exchange library"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/lib/${pkg_distname}-${pkg_version}.tar.bz2"
-pkg_shasum="8f7032f2c1c64352b5423f6b48a8ebdc339cc63064af34d66a6c9aa79759e202"
+pkg_shasum="6f86dce12cf4bcaf5c37dddd8b1b64ed2ddf1ef7b218f22b9942595fb747c348"
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/pkg-config core/xproto core/xtrans)
 pkg_include_dirs=(include)


### PR DESCRIPTION
Updated pkg_version 1.0.9 -> 1.0.10 in support of 2021 Q2 core plans refresh.