### PR TITLE
Update mongodb Plan Package Version

### DIFF
--- a/hwloc/plan.sh
+++ b/hwloc/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=hwloc
 pkg_origin=core
-pkg_major_minor=2.0
+pkg_major_minor=2.4
 pkg_version="${pkg_major_minor}.1"
 pkg_description="Portable Hardware Locality"
 pkg_upstream_url=https://www.open-mpi.org/software/hwloc
 pkg_license=('BSD-2-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://www.open-mpi.org/software/hwloc/v${pkg_major_minor}/downloads/hwloc-${pkg_version}.tar.gz"
-pkg_shasum=f1156df22fc2365a31a3dc5f752c53aad49e34a5e22d75ed231cd97eaa437f9d
+pkg_shasum=392421e69f26120c8ab95d151fe989f2b4b69dab3c7735741c4e0a6d7de5de63
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_build_deps=(core/gcc core/make core/diffutils)
 pkg_bin_dirs=(bin sbin)

--- a/hwloc/plan.sh
+++ b/hwloc/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=hwloc
 pkg_origin=core
-pkg_major_minor=2.4
+pkg_major_minor=2.0
 pkg_version="${pkg_major_minor}.1"
 pkg_description="Portable Hardware Locality"
 pkg_upstream_url=https://www.open-mpi.org/software/hwloc

--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=mongodb
 pkg_origin=core
-pkg_version=3.6.4
+pkg_version=3.6.23
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="High-performance, schema-free, document-oriented database"
 pkg_license=('AGPL-3.0')
 pkg_source="https://fastdl.mongodb.org/src/mongodb-src-r${pkg_version}.tar.gz"
-pkg_shasum=1a9697c3ad2f5545b5160d5e32d5f3c0f6f0a3371ceb9fa85961aec513acd7ac
+pkg_shasum=109a487ab5b8cdc189bc77ea27ae5f1bcc8db0b465527464bd87c2fa3928149e
 pkg_upstream_url=https://www.mongodb.com/
 pkg_filename="${pkg_name}-src-r${pkg_version}.tar.gz"
 pkg_dirname="${pkg_name}-src-r${pkg_version}"


### PR DESCRIPTION
Updated pkg_version 3.6.4 -> 3.6.23 in support of 2021 Q2 core plans refresh.