### PR TITLE
Update lsyncd Plan Package Version

### DIFF
--- a/lsyncd/patches/000-lua-static.patch
+++ b/lsyncd/patches/000-lua-static.patch
@@ -1,0 +1,24 @@
+From 0af99d8d5ba35118e8799684a2d4a8ea4b0c6957 Mon Sep 17 00:00:00 2001
+From: yokogawa-k <yokogawa-k@klab.com>
+Date: Mon, 26 Mar 2018 17:11:29 +0900
+Subject: [PATCH] fix non-versioned lua not search in cmake
+
+"FOREACH" ignore empty elements, but "FOREACH IN LISTS" include emoty elements.
+https://cmake.org/cmake/help/latest/command/foreach.html
+---
+ cmake/FindLua.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/FindLua.cmake b/cmake/FindLua.cmake
+index 1f95bf9..6d33dbe 100644
+--- a/cmake/FindLua.cmake
++++ b/cmake/FindLua.cmake
+@@ -39,7 +39,7 @@ SET(_POSSIBLE_LUA_INCLUDE include include/lua)
+ SET(_POSSIBLE_SUFFIXES "52" "5.2" "-5.2" "53" "5.3" "-5.3" "")
+ 
+ # Set up possible search names and locations
+-FOREACH(_SUFFIX ${_POSSIBLE_SUFFIXES})
++FOREACH(_SUFFIX IN LISTS _POSSIBLE_SUFFIXES)
+   LIST(APPEND _POSSIBLE_LUA_INCLUDE "include/lua${_SUFFIX}")
+   LIST(APPEND _POSSIBLE_LUA_EXECUTABLE "lua${_SUFFIX}")
+   LIST(APPEND _POSSIBLE_LUA_COMPILER "luac${_SUFFIX}")

--- a/lsyncd/plan.sh
+++ b/lsyncd/plan.sh
@@ -12,10 +12,15 @@ pkg_build_deps=(
   core/gcc
   core/lua
   core/make
+  core/patch
 )
 pkg_bin_dirs=(bin)
 pkg_description="Lsyncd watches a local directory trees event monitor interface (inotify or fsevents)"
 pkg_upstream_url="https://axkibe.github.io/lsyncd/"
+
+do_prepare() {
+  patch -p1 < "${PLAN_CONTEXT}"/patches/000-lua-static.patch
+}
 
 do_build() {
   cmake \

--- a/lsyncd/plan.sh
+++ b/lsyncd/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source="https://github.com/axkibe/$pkg_name/archive/release-$pkg_version.tar.gz"
 pkg_dirname="$pkg_name-release-$pkg_version"
-pkg_shasum="4423d107041a62f23d7d0eda195f990161983d6f6a09e2f1f42998c38570c65c"
+pkg_shasum=7bcd0f4ae126040bb078c482ff856c87e61c22472c23fa3071798dcb1dc388dd
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/cmake

--- a/lsyncd/plan.sh
+++ b/lsyncd/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=lsyncd
 pkg_origin=core
-pkg_version=2.2.1
+pkg_version=2.2.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source="https://github.com/axkibe/$pkg_name/archive/release-$pkg_version.tar.gz"
 pkg_dirname="$pkg_name-release-$pkg_version"
-pkg_shasum="f41969454a17f9441a9b1809bb251235631768393bf5d29ad8e8142670ae4735"
+pkg_shasum="4423d107041a62f23d7d0eda195f990161983d6f6a09e2f1f42998c38570c65c"
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/cmake


### PR DESCRIPTION
Updated pkg_version 2.2.1 -> 2.2.3 in support of 2021 Q2 core plans refresh.