### PR TITLE
Update libcap-ng Plan Package Version

### DIFF
--- a/libcap-ng/plan.sh
+++ b/libcap-ng/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=libcap-ng
 pkg_origin=core
-pkg_version=0.7.8
+pkg_version=0.8.2
 pkg_source=http://people.redhat.com/sgrubb/$pkg_name/$pkg_name-$pkg_version.tar.gz
-pkg_shasum=c21af997445cd4107a55d386f955c5ea6f6e96ead693e9151277c0ab5f97d05f
+pkg_shasum=52c083b77c2b0d8449dee141f9c3eba76e6d4c5ad44ef05df25891126cb85ae9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The libcap-ng library is intended to make programming with posix capabilities much easier than the traditional libcap library"
 pkg_upstream_url="https://people.redhat.com/sgrubb/libcap-ng/"


### PR DESCRIPTION
Updated pkg_version 0.7.8 -> 0.8.2 in support of 2021 Q2 core plans refresh.