### PR TITLE
Update postgresql11-client Plan Package Version

### DIFF
--- a/postgresql11-client/plan.sh
+++ b/postgresql11-client/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=postgresql11-client
-pkg_version=11.8
+pkg_version=11.11
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
@@ -7,7 +7,7 @@ pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_dirname="postgresql-${pkg_version}"
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_dirname}.tar.bz2"
-pkg_shasum="eaf2f4329ccc349c89e950761b81daf8c99bb8966abcab5665ccd6ee95c77ae2"
+pkg_shasum="40607b7fa15b7d63f5075a7277daf7b3412486aa5db3aedffdb7768b9298186c"
 
 pkg_deps=(
   core/bash


### PR DESCRIPTION
Updated pkg_version 11.8 -> 11.11 in support of 2021 Q2 core plans refresh.