### PR TITLE
Update libtalloc Plan Package Version

### DIFF
--- a/libtalloc/plan.sh
+++ b/libtalloc/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libtalloc
 pkg_origin=core
-pkg_version="2.1.14"
+pkg_version="2.3.2"
 pkg_upstream_url=https://talloc.samba.org
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Talloc is a hierarchical, reference counted memory pool system with destructors. It is the core memory allocator used in Samba."
 pkg_license=("GPL-3.0")
 pkg_source="https://www.samba.org/ftp/talloc/talloc-${pkg_version}.tar.gz"
 pkg_dirname="talloc-${pkg_version}"
-pkg_shasum="b185602756a628bac507fa8af8b9df92ace69d27c0add5dab93190ad7c3367ce"
+pkg_shasum="27a03ef99e384d779124df755deb229cd1761f945eca6d200e8cfd9bf5297bd7"
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)

--- a/libtalloc/plan.sh
+++ b/libtalloc/plan.sh
@@ -12,13 +12,17 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)
 
-pkg_deps=(core/python2 core/glibc)
+pkg_deps=(
+  core/python
+  core/glibc
+)
 
 pkg_build_deps=(
-core/gcc
-core/make
-core/coreutils
-core/pkg-config
+  core/gcc
+  core/make
+  core/coreutils
+  core/pkg-config
+  core/which
 )
 
 do_prepare() {


### PR DESCRIPTION
Updated pkg_version "2.1.14" -> "2.3.2" in support of 2021 Q2 core plans refresh.