### PR TITLE
Update jenkins Plan Package Version

### DIFF
--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.204.5
+pkg_version=2.277.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum=94c73fa5b72e0a4eb52c5c99c08351f85a51d138f3dbaff6f64e4406353f839c
+pkg_shasum=399741db1152ee7bbe8dc08e0972efa0b128a1b55a0f8b10c087fefeec66d151
 pkg_deps=(
   core/openjdk11
   core/curl


### PR DESCRIPTION
Updated pkg_version 2.204.5 -> 2.277.1 in support of 2021 Q2 core plans refresh.