### PR TITLE
Update haproxy Plan Package Version

### DIFF
--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=haproxy
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=2.2.11
+pkg_version=2.2.14
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source="https://www.haproxy.org/download/2.2/src/haproxy-${pkg_version}.tar.gz"
 pkg_upstream_url="https://www.haproxy.org/"
-pkg_shasum=173a98506472bb1ba5a4a7f3a281125163f78bab5793bf6ba1f1d50853eb5f23
+pkg_shasum=6a9b702f04b07786f3e5878de8172a727acfdfdbc1cefe1c7a438df372f2fb61
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
 pkg_svc_user=root
 pkg_svc_group=root
@@ -22,6 +22,7 @@ pkg_deps=(
   core/zlib
   core/pcre
   core/openssl
+  core/gcc-libs
 )
 pkg_build_deps=(
   core/coreutils

--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=haproxy
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=2.2.2
+pkg_version=2.2.11
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source="https://www.haproxy.org/download/2.2/src/haproxy-${pkg_version}.tar.gz"
 pkg_upstream_url="https://www.haproxy.org/"
-pkg_shasum=391c705a46c6208a63a67ea842c6600146ca24618531570c89c7915b0c6a54d6
+pkg_shasum=173a98506472bb1ba5a4a7f3a281125163f78bab5793bf6ba1f1d50853eb5f23
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
 pkg_svc_user=root
 pkg_svc_group=root


### PR DESCRIPTION
Updated pkg_version 2.2.2 -> ~2.2.11~ 2.2.14 in support of 2021 Q2 core plans refresh.

**Update: 2020/05/03 Siraj:** Updated version + fixed tests