### PR TITLE
Update dotnet-core Plan Package Version

### DIFF
--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=3.1.0
+pkg_version=3.1.13
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/5d139dff-4ca0-4e0c-a68b-0976281d5b2d/d306f725466e058842faa25bf1b2f379/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=3fd138add3787c5edf6446245b821dbe0b4acae032c2b9a4cc2b8eac2d9b9997
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/6880db3b-a4fe-4801-8e80-bbbec045f7c0/283b70d5e263c0341f011adf5a2ea5b1/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=4e8e308934a56f8e9b55f895642ac39297465facbd2154651bd69fdbd50db996
 pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Updated pkg_version 3.1.0 -> 3.1.13 in support of 2021 Q2 core plans refresh.