### PR TITLE
Update mosquitto Plan Package Version

### DIFF
--- a/mosquitto/plan.sh
+++ b/mosquitto/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=mosquitto
 pkg_origin=core
-pkg_version="1.4.15"
+pkg_version="1.6.14"
 pkg_upstream_url="https://mosquitto.org"
 pkg_description="An Open Source MQTT v3.1/v3.1.1 Broker"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('EPL-1.0' 'Eclipse Distribution License - v 1.0')
 pkg_source="http://mosquitto.org/files/source/mosquitto-${pkg_version}.tar.gz"
-pkg_shasum="7d3b3e245a3b4ec94b05678c8199c806359737949f4cfe0bf936184f6ca89a83"
+pkg_shasum="5ea7e342bfbd212a0addb915036be168040dea945e5de5fe739c43c5ff3823e4"
 pkg_deps=(
   core/bash
   core/c-ares


### PR DESCRIPTION
Updated pkg_version "1.4.15" -> "1.6.14" in support of 2021 Q2 core plans refresh.