### PR TITLE
Update gperftools Plan Package Version

### DIFF
--- a/gperftools/plan.sh
+++ b/gperftools/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=https://github.com/gperftools/gperftools
 pkg_license=('BSDv3')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/gperftools/gperftools/releases/download/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=0f59a4dcdb3f64e9ff5ea760731089de5872ef70f506afc537d48995a090c2b1
+pkg_shasum=ea566e528605befb830671e359118c2da718f721c27225cbbc93858c7520fee3
 pkg_build_deps=(
   core/gcc
   core/make

--- a/gperftools/plan.sh
+++ b/gperftools/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=gperftools
 pkg_origin=core
-pkg_version=2.7
+pkg_version=2.9.1
 pkg_description="Google Performance Tools"
 pkg_upstream_url=https://github.com/gperftools/gperftools
 pkg_license=('BSDv3')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/gperftools/gperftools/releases/download/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9
+pkg_shasum=0f59a4dcdb3f64e9ff5ea760731089de5872ef70f506afc537d48995a090c2b1
 pkg_build_deps=(
   core/gcc
   core/make


### PR DESCRIPTION
Updated pkg_version 2.7 -> 2.9.1 in support of 2021 Q2 core plans refresh.