### PR TITLE
Update boost Plan Package Version

### DIFF
--- a/boost/plan.sh
+++ b/boost/plan.sh
@@ -2,12 +2,12 @@ pkg_name=boost
 pkg_origin=core
 pkg_description='Boost provides free peer-reviewed portable C++ source libraries.'
 pkg_upstream_url='http://www.boost.org/'
-pkg_version=1.69.0
+pkg_version=1.75.0
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('Boost Software License')
-pkg_source=http://downloads.sourceforge.net/project/boost/boost/${pkg_version}/boost_1_69_0.tar.gz
-pkg_shasum=9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb
-pkg_dirname=boost_1_69_0
+pkg_source=http://downloads.sourceforge.net/project/boost/boost/${pkg_version}/boost_1_75_0.tar.gz
+pkg_shasum=aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
+pkg_dirname=boost_1_75_0
 
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
Updated pkg_version 1.69.0 -> 1.75.0 in support of 2021 Q2 core plans refresh.