### PR TITLE
Update unixodbc Plan Package Version

### DIFF
--- a/unixodbc/plan.sh
+++ b/unixodbc/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=unixodbc
 pkg_origin=core
-pkg_version=2.3.6
+pkg_version=2.3.9
 pkg_license=('LGPL2.1')
 pkg_upstream_url="http://www.unixodbc.org/"
 pkg_description="ODBC driver manager for Unix"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${pkg_version}.tar.gz"
-pkg_shasum="88b637f647c052ecc3861a3baa275c3b503b193b6a49ff8c28b2568656d14d69"
+pkg_shasum="52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207"
 pkg_dirname="unixODBC-${pkg_version}"
 
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Updated pkg_version 2.3.6 -> 2.3.9 in support of 2021 Q2 core plans refresh.