### PR TITLE
Update libgcrypt Plan Package Version

### DIFF
--- a/libgcrypt/plan.sh
+++ b/libgcrypt/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=libgcrypt
 pkg_origin=core
-pkg_version=1.8.5
+pkg_version=1.9.2
 pkg_license=('LGPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="ftp://ftp.gnupg.org/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum=3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
+pkg_shasum=b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a
 pkg_deps=(
   core/glibc
   core/libgpg-error


### PR DESCRIPTION
Updated pkg_version 1.8.5 -> 1.9.2 in support of 2021 Q2 core plans refresh.