### PR TITLE
Update logstash Plan Package Version

### DIFF
--- a/logstash/plan.sh
+++ b/logstash/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=logstash
-pkg_version=6.4.3
+pkg_version=6.8.15
 pkg_description="Logstash is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite 'stash.'"
 pkg_upstream_url=https://github.com/elastic/logstash
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=(Apache-2.0)
 pkg_source=https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=72dcd1cf21e55cd44503ca7c452aaaa88286564ba1450d5d05941f88e2699cc3
+pkg_shasum=63e8d53f99a83b2f20b6c21d8d4be9f55e9a7418b4f56dc496c4c7c2679bbb9e
 pkg_deps=(core/bash
   core/corretto8
   core/coreutils

--- a/logstash/tests/test.bats
+++ b/logstash/tests/test.bats
@@ -1,6 +1,6 @@
 expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 @test "logstash binary matches version ${expected_version}" {
-  local actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" logstash --version | awk '{print $2}')"
+  local actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" logstash -- --version | awk '{print $2}')"
   diff <(echo "${actual_version}") <(echo "${expected_version}")
 }
 


### PR DESCRIPTION
Updated pkg_version 6.4.3 -> 6.8.15 in support of 2021 Q2 core plans refresh.