### PR TITLE
Update mksh Plan Package Version

### DIFF
--- a/mksh/plan.sh
+++ b/mksh/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=mksh
 pkg_origin=core
-pkg_version="R56c"
+pkg_version="R59c"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MirOS" "ISC" "BSD-3-Clause")
 pkg_source="https://www.mirbsd.org/MirOS/dist/mir/mksh/$pkg_name-$pkg_version.tgz"
-pkg_shasum="dd86ebc421215a7b44095dc13b056921ba81e61b9f6f4cdab08ca135d02afb77"
+pkg_shasum="77ae1665a337f1c48c61d6b961db3e52119b38e58884d1c89684af31f87bc506"
 pkg_dirname="mksh"
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/make core/gcc core/gawk core/wget)


### PR DESCRIPTION
Updated pkg_version "R56c" -> "R59c" in support of 2021 Q2 core plans refresh.