### PR TITLE
Update googlemock Plan Package Version

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -480,6 +480,8 @@ plan_path = "go17"
 plan_path = "goaccess"
 [gocd-server]
 plan_path = "gocd-server"
+[googlemock]
+plan_path = "googlemock"
 [googletest]
 plan_path = "googletest"
 [goreplay]

--- a/googlemock/plan.sh
+++ b/googlemock/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=googlemock
 pkg_origin=core
-pkg_version="1.8.0"
+pkg_version="1.10.0"
 pkg_description="$(cat << EOF
 The Google C++ mocking framework.
 EOF
@@ -8,7 +8,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd-3-clause')
 pkg_source="https://github.com/google/googletest/archive/release-${pkg_version}.tar.gz"
-pkg_shasum="58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8"
+pkg_shasum="32a35091b9631b1b53fdd56db8544135c9b8a03bdcdb6b0b0bf6c892e0a0dd79"
 pkg_upstream_url="https://github.com/google/googletest/tree/master/googlemock"
 pkg_dirname="googletest-release-${pkg_version}"
 

--- a/googlemock/plan.sh
+++ b/googlemock/plan.sh
@@ -53,9 +53,9 @@ do_check() {
 }
 
 do_install() {
-  cd "${BUILDDIR}/${GTEST_TARGET}" || exit
-  make install
-  cd ../.. || exit
+  #cd "${BUILDDIR}/${GTEST_TARGET}" || exit
+  #make install
+  #cd ../.. || exit
 
   install -Dm644 googlemock/LICENSE "${pkg_prefix}/share/licenses/license.txt"
 

--- a/googlemock/plan.sh
+++ b/googlemock/plan.sh
@@ -8,7 +8,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd-3-clause')
 pkg_source="https://github.com/google/googletest/archive/release-${pkg_version}.tar.gz"
-pkg_shasum="32a35091b9631b1b53fdd56db8544135c9b8a03bdcdb6b0b0bf6c892e0a0dd79"
+pkg_shasum=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
 pkg_upstream_url="https://github.com/google/googletest/tree/master/googlemock"
 pkg_dirname="googletest-release-${pkg_version}"
 


### PR DESCRIPTION
Updated pkg_version "1.8.0" -> "1.10.0" in support of 2021 Q2 core plans refresh.