### PR TITLE
Update tmux Plan Package Version

### DIFF
--- a/benchmark/plan.sh
+++ b/benchmark/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=benchmark
 pkg_origin=core
-pkg_version=1.4.1
+pkg_version=1.5.2
 pkg_description="Google's microbenchmark support library"
 pkg_upstream_url=https://github.com/google/benchmark
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/google/benchmark/archive/v${pkg_version}.tar.gz"
 pkg_filename="v${pkg_version}.tar.gz"
-pkg_shasum=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
+pkg_shasum=0db8066b8476c5cc8393bfa95e4198b59d6bf3156e6c589872730be1083c16dd
 pkg_deps=(
   core/gcc-libs
   core/glibc

--- a/benchmark/plan.sh
+++ b/benchmark/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=benchmark
 pkg_origin=core
-pkg_version=1.5.2
+pkg_version=1.4.1
 pkg_description="Google's microbenchmark support library"
 pkg_upstream_url=https://github.com/google/benchmark
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/google/benchmark/archive/v${pkg_version}.tar.gz"
 pkg_filename="v${pkg_version}.tar.gz"
-pkg_shasum=0db8066b8476c5cc8393bfa95e4198b59d6bf3156e6c589872730be1083c16dd
+pkg_shasum=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
 pkg_deps=(
   core/gcc-libs
   core/glibc

--- a/tmux/plan.sh
+++ b/tmux/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=tmux
 pkg_origin=core
-pkg_version=3.0a
+pkg_version=3.1c
 pkg_description="A terminal multiplexer"
 pkg_upstream_url=https://tmux.github.io/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/tmux/tmux/releases/download/${pkg_version}/tmux-${pkg_version}.tar.gz"
-pkg_shasum=4ad1df28b4afa969e59c08061b45082fdc49ff512f30fc8e43217d7b0e5f8db9
+pkg_shasum=5555de5a540d3469421fbe9c14e4086504b2dac945c39651cf227196ecf905c7
 pkg_deps=(
   core/glibc
   core/libevent

--- a/tmux/plan.sh
+++ b/tmux/plan.sh
@@ -15,5 +15,6 @@ pkg_deps=(
 pkg_build_deps=(
   core/gcc
   core/make
+  core/pkg-config
 )
 pkg_bin_dirs=(bin)

--- a/tmux/plan.sh
+++ b/tmux/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=https://tmux.github.io/
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/tmux/tmux/releases/download/${pkg_version}/tmux-${pkg_version}.tar.gz"
-pkg_shasum=5555de5a540d3469421fbe9c14e4086504b2dac945c39651cf227196ecf905c7
+pkg_shasum=918f7220447bef33a1902d4faff05317afd9db4ae1c9971bef5c787ac6c88386
 pkg_deps=(
   core/glibc
   core/libevent

--- a/tmux/tests/test.bats
+++ b/tmux/tests/test.bats
@@ -1,6 +1,6 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} tmux -V | head -1 | awk '{print $2}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} tmux -- -V | head -1 | awk '{print $2}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }


### PR DESCRIPTION
Updated pkg_version 3.0a -> 3.1c in support of 2021 Q2 core plans refresh.