### PR TITLE
Update fping Plan Package Version

### DIFF
--- a/fping/plan.sh
+++ b/fping/plan.sh
@@ -11,7 +11,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('custom')
 pkg_source="https://github.com/schweikert/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="9f854b65a52dc7b1749d6743e35d0a6268179d1a724267339fc9a066b2b72d11"
+pkg_shasum=538ef95e4c1cdb488339e91f21d4eb8542aec7ee8dcc9cdbce6eb680a1ddd090
 pkg_upstream_url="http://fping.org/"
 pkg_build_deps=(
   core/autoconf

--- a/fping/plan.sh
+++ b/fping/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=fping
 pkg_origin=core
-pkg_version="4.2"
+pkg_version="4.4"
 pkg_description="$(cat << EOF
   fping is a program to send ICMP echo probes to network hosts, similar to
   ping, but much better performing when pinging multiple hosts. fping has a
@@ -11,7 +11,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('custom')
 pkg_source="https://github.com/schweikert/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum="49b0ac77fd67c1ed45c9587ffab0737a3bebcfa5968174329f418732dbf655d4"
+pkg_shasum="9f854b65a52dc7b1749d6743e35d0a6268179d1a724267339fc9a066b2b72d11"
 pkg_upstream_url="http://fping.org/"
 pkg_build_deps=(
   core/autoconf


### PR DESCRIPTION
Updated pkg_version "4.2" -> "4.4" in support of 2021 Q2 core plans refresh.