### PR TITLE
Update fish Plan Package Version

### DIFF
--- a/fish/plan.sh
+++ b/fish/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=fish
 pkg_origin=core
-pkg_version="2.5.0"
+pkg_version="2.7.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'LGPL-2.0' 'ISC' 'BSD-2-Clause-NetBSD' 'BSD-3-Clause')
 pkg_source="https://github.com/fish-shell/fish-shell/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="f8c0edadca2de379ccf305aeace660a9255fa2180c72e85e97705a24c256b2a5"
+pkg_shasum="e92c3238d1ff1c462cc4e5276baf52c1a7e00c5bbc1ca1ba0fe798322bab406f"
 pkg_deps=(
   core/bc
   core/coreutils

--- a/fish/plan.sh
+++ b/fish/plan.sh
@@ -4,7 +4,7 @@ pkg_version="2.7.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'LGPL-2.0' 'ISC' 'BSD-2-Clause-NetBSD' 'BSD-3-Clause')
 pkg_source="https://github.com/fish-shell/fish-shell/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="e92c3238d1ff1c462cc4e5276baf52c1a7e00c5bbc1ca1ba0fe798322bab406f"
+pkg_shasum=3a76b7cae92f9f88863c35c832d2427fb66082f98e92a02203dc900b8fa87bcb
 pkg_deps=(
   core/bc
   core/coreutils


### PR DESCRIPTION
Updated pkg_version "2.5.0" -> "2.7.0" in support of 2021 Q2 core plans refresh.