### PR TITLE
Update tcpdump Plan Package Version

### DIFF
--- a/tcpdump/plan.sh
+++ b/tcpdump/plan.sh
@@ -21,7 +21,7 @@ pkg_build_deps=(
   core/perl
   core/diffutils
 )
-pkg_bin_dirs=(sbin)
+pkg_bin_dirs=(bin)
 
 do_build() {
   ./configure \

--- a/tcpdump/plan.sh
+++ b/tcpdump/plan.sh
@@ -31,6 +31,6 @@ do_build() {
 }
 
 do_check() {
-  fix_interpreter "tests/TESTonce" core/coreutils bin/env
+  fix_interpreter "tests/TESTrun" core/coreutils bin/env
   make check
 }

--- a/tcpdump/plan.sh
+++ b/tcpdump/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=tcpdump
 pkg_origin=core
-pkg_version=4.9.3
+pkg_version=4.99.0
 pkg_description="A powerful command-line packet analyzer."
 pkg_upstream_url="http://www.tcpdump.org/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://www.tcpdump.org/release/tcpdump-${pkg_version}.tar.gz"
-pkg_shasum=2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410
+pkg_shasum=8cf2f17a9528774a7b41060323be8b73f76024f7778f59c34efa65d49d80b842
 # core/coreutils isn't /really/ needed at runtime, but fix_interpreter
 # only works if the dep is listed in pkg_deps
 pkg_deps=(

--- a/tcpdump/tests/test.bats
+++ b/tcpdump/tests/test.bats
@@ -1,7 +1,7 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} tcpdump --version 2>&1 | head -1 | awk '{print $3}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} tcpdump -- --version 2>&1 | head -1 | awk '{print $3}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 


### PR DESCRIPTION
Updated pkg_version 4.9.3 -> 4.99.0 in support of 2021 Q2 core plans refresh.