### PR TITLE
Update nginx-prometheus-exporter Plan Package Version

### DIFF
--- a/nginx-prometheus-exporter/plan.sh
+++ b/nginx-prometheus-exporter/plan.sh
@@ -1,13 +1,13 @@
 
 pkg_name=nginx-prometheus-exporter
 pkg_origin=core
-pkg_version="0.4.2"
+pkg_version="0.9.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="NGINX Prometheus exporter makes it possible to monitor NGINX or NGINX Plus using Prometheus."
 pkg_upstream_url="https://github.com/nginxinc/nginx-prometheus-exporter"
 pkg_source="https://github.com/nginxinc/nginx-prometheus-exporter/archive/v${pkg_version}.tar.gz"
-pkg_shasum=d8931629a2aac26600f0b7c9a366e6fe2373c30d40e9a7572ad8ecc2aff92777
+pkg_shasum=56d2c45eca703c4d17c5358f2a297e4f71704324fe93ffcc4707540d6d20bd27
 pkg_deps=(
   core/glibc
 )

--- a/nginx-prometheus-exporter/plan.sh
+++ b/nginx-prometheus-exporter/plan.sh
@@ -7,7 +7,7 @@ pkg_license=("Apache-2.0")
 pkg_description="NGINX Prometheus exporter makes it possible to monitor NGINX or NGINX Plus using Prometheus."
 pkg_upstream_url="https://github.com/nginxinc/nginx-prometheus-exporter"
 pkg_source="https://github.com/nginxinc/nginx-prometheus-exporter/archive/v${pkg_version}.tar.gz"
-pkg_shasum=56d2c45eca703c4d17c5358f2a297e4f71704324fe93ffcc4707540d6d20bd27
+pkg_shasum=ea4fc130c2e19751b4563c819a0641639077f9c300776a1bd7116b56a14f7eca
 pkg_deps=(
   core/glibc
 )


### PR DESCRIPTION
Updated pkg_version "0.4.2" -> "0.9.0" in support of 2021 Q2 core plans refresh.