### PR TITLE
Update lzo Plan Package Version

### DIFF
--- a/lzo/plan.sh
+++ b/lzo/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=lzo
 pkg_origin=core
-pkg_version=2.09
+pkg_version=2.10
 pkg_license=('GPL-2.0-or-later')
 pkg_source=http://www.oberhumer.com/opensource/"${pkg_name}"/download/"${pkg_name}"-"${pkg_version}".tar.gz
 pkg_upstream_url="http://www.oberhumer.com/opensource/lzo/"
 pkg_description="LZO is a portable lossless data compression library written in ANSI C."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_filename="${pkg_name}"-"${pkg_version}".tar.gz
-pkg_shasum=f294a7ced313063c057c504257f437c8335c41bfeed23531ee4e6a2b87bcb34c
+pkg_shasum=c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/coreutils core/make core/gcc)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updated pkg_version 2.09 -> 2.10 in support of 2021 Q2 core plans refresh.