### PR TITLE
Update libssh2 Plan Package Version

### DIFF
--- a/libssh2/plan.sh
+++ b/libssh2/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libssh2
 pkg_origin=core
-pkg_version=1.8.0
+pkg_version=1.9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="libssh2 is a client-side C library implementing the SSH2 protocol"
 pkg_upstream_url="https://libssh2.org/"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://libssh2.org/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4"
+pkg_shasum="d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
 pkg_deps=(
   core/glibc
   core/openssl


### PR DESCRIPTION
Updated pkg_version 1.8.0 -> 1.9.0 in support of 2021 Q2 core plans refresh.