### PR TITLE
Update postgresql95-client Plan Package Version

### DIFF
--- a/postgresql95-client/plan.sh
+++ b/postgresql95-client/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=postgresql95-client
-pkg_version=9.5.13
+pkg_version=9.6.21
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
-pkg_shasum="5408b86a0b56fd0140c6a0016bf9179bc7817fa03d5571cca346c9ab122ea5ee"
+pkg_shasum="930feaef28885c97ec40c26ab6221903751eeb625de92b22602706d7d47d1634"
 pkg_dirname="postgresql-${pkg_version}"
 
 pkg_deps=(


### PR DESCRIPTION
Updated pkg_version 9.5.13 -> 9.6.21 in support of 2021 Q2 core plans refresh.