### PR TITLE
Update telegraf Plan Package Version

### DIFF
--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version=1.12.2
+pkg_version=1.18.0
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
 pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum=dab9ae72b53c99f93e708ab911d556d6906c0691c6858da09b4e74e24e344c8a
+pkg_shasum=2f0ca60b9172db8f52cb4afd8adac3c31573492b1b7da1c4950f5a70bbba361d
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config ${pkg_svc_config_path}/telegraf.conf"
 pkg_build_deps=(

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=telegraf
 pkg_origin=core
-pkg_version=1.18.0
+pkg_version=1.18.1
 pkg_license=('MIT')
 pkg_description="telegraf - client for InfluxDB"
 pkg_upstream_url="https://github.com/influxdata/telegraf/"
-pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}-static_linux_amd64.tar.gz"
-pkg_shasum=2f0ca60b9172db8f52cb4afd8adac3c31573492b1b7da1c4950f5a70bbba361d
+pkg_source="https://dl.influxdata.com/${pkg_name}/releases/${pkg_name}-${pkg_version}_static_linux_amd64.tar.gz"
+pkg_shasum=e1be5cbc3d8e48f5919ebf3044c25555c8210ab11a0803d2feeb94c0f4ddebba
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_svc_run="telegraf --config ${pkg_svc_config_path}/telegraf.conf"
 pkg_build_deps=(

--- a/telegraf/plan.sh
+++ b/telegraf/plan.sh
@@ -20,5 +20,5 @@ do_build() {
 }
 
 do_install() {
-  install -vD "${HAB_CACHE_SRC_PATH}/telegraf/telegraf" "${pkg_prefix}/bin/telegraf"
+  install -vD "${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}/usr/bin/telegraf" "${pkg_prefix}/bin/telegraf"
 }


### PR DESCRIPTION
Updated pkg_version 1.12.2 -> 1.18.0 in support of 2021 Q2 core plans refresh.