### PR TITLE
Update restic Plan Package Version

### DIFF
--- a/restic/plan.sh
+++ b/restic/plan.sh
@@ -4,7 +4,7 @@ pkg_version="0.12.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("BSD-2-Clause")
 pkg_source="https://github.com/restic/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="d15c0ac1372d47d0a34b6e3c60dbf39ec503ad29e818f8a8f1b7f916de383c68"
+pkg_shasum=39b615a36a5082209a049cce188f0654c6435f0bc4178b7663672334594f10fe
 pkg_build_deps=(
   core/go
 )

--- a/restic/plan.sh
+++ b/restic/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=restic
 pkg_origin=core
-pkg_version="0.9.3"
+pkg_version="0.12.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("BSD-2-Clause")
 pkg_source="https://github.com/restic/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="b95a258099aee9a56e620ccebcecabc246ee7f8390e3937ccedadd609c6d2dd0"
+pkg_shasum="d15c0ac1372d47d0a34b6e3c60dbf39ec503ad29e818f8a8f1b7f916de383c68"
 pkg_build_deps=(
   core/go
 )

--- a/restic/plan.sh
+++ b/restic/plan.sh
@@ -13,9 +13,9 @@ pkg_description="Fast, secure, efficient backup program"
 pkg_upstream_url="https://restic.net/"
 
 do_build() {
-  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -mod=vendor -ldflags "-s -w" -tags selfupdate -o restic_linux_amd64 ./cmd/restic
+  go run build.go --goos linux --goarch amd64
 }
 
 do_install() {
-  cp -v restic_linux_amd64 "${pkg_prefix}/bin/restic"
+  cp -v restic "${pkg_prefix}/bin/restic"
 }


### PR DESCRIPTION
Updated pkg_version "0.9.3" -> "0.12.0" in support of 2021 Q2 core plans refresh.