### PR TITLE
Update gsl Plan Package Version

### DIFF
--- a/gsl/plan.sh
+++ b/gsl/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=gsl
 pkg_origin=core
-pkg_version=2.3
+pkg_version=2.6
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPLv3')
 pkg_description="GSL is a numerical library for C and C++"
 pkg_upstream_url="https://www.gnu.org/software/gsl/"
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=562500b789cd599b3a4f88547a7a3280538ab2ff4939504c8b4ac4ca25feadfb
+pkg_shasum=b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8
 pkg_build_deps=(core/make core/gcc core/diffutils)
 pkg_deps=(core/glibc)
 pkg_include_dirs=(include)


### PR DESCRIPTION
Updated pkg_version 2.3 -> 2.6 in support of 2021 Q2 core plans refresh.