### PR TITLE
Update p11-kit Plan Package Version

### DIFF
--- a/p11-kit/plan.sh
+++ b/p11-kit/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="https://p11-glue.github.io/p11-glue/p11-kit.html"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://github.com/p11-glue/p11-kit/releases/download/0.23.10/p11-kit-0.23.10.tar.gz"
-pkg_shasum="7643151183377529af4d2fdd61d68b61a3f7639b833820b48ef12179567476f7"
+pkg_shasum=f9212a3f225ef543e13fae9945527d66c0cbb67246320035dd94fab2bce5ae43
 pkg_deps=(
   core/libtasn1
   core/libffi

--- a/p11-kit/plan.sh
+++ b/p11-kit/plan.sh
@@ -5,8 +5,9 @@ pkg_description="Provides a way to load and enumerate PKCS#11 modules."
 pkg_upstream_url="https://p11-glue.github.io/p11-glue/p11-kit.html"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
-pkg_source="https://github.com/p11-glue/p11-kit/releases/download/0.23.10/p11-kit-0.23.10.tar.gz"
-pkg_shasum=f9212a3f225ef543e13fae9945527d66c0cbb67246320035dd94fab2bce5ae43
+pkg_source="https://github.com/p11-glue/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
+#pkg_source="https://github.com/p11-glue/p11-kit/releases/download/0.23.10/p11-kit-0.23.10.tar.gz"
+pkg_shasum=8a8f40153dd5a3f8e7c03e641f8db400133fb2a6a9ab2aee1b6d0cb0495ec6b6
 pkg_deps=(
   core/libtasn1
   core/libffi

--- a/p11-kit/plan.sh
+++ b/p11-kit/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=p11-kit
 pkg_origin=core
-pkg_version="0.23.10"
+pkg_version="0.23.22"
 pkg_description="Provides a way to load and enumerate PKCS#11 modules."
 pkg_upstream_url="https://p11-glue.github.io/p11-glue/p11-kit.html"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://github.com/p11-glue/p11-kit/releases/download/0.23.10/p11-kit-0.23.10.tar.gz"
-pkg_shasum="f9212a3f225ef543e13fae9945527d66c0cbb67246320035dd94fab2bce5ae43"
+pkg_shasum="7643151183377529af4d2fdd61d68b61a3f7639b833820b48ef12179567476f7"
 pkg_deps=(
   core/libtasn1
   core/libffi


### PR DESCRIPTION
Updated pkg_version "0.23.10" -> "0.23.22" in support of 2021 Q2 core plans refresh.