### PR TITLE
Update at-spi2-atk Plan Package Version

### DIFF
--- a/at-spi2-atk/plan.sh
+++ b/at-spi2-atk/plan.sh
@@ -21,8 +21,22 @@ pkg_build_deps=(
   core/diffutils
   core/gcc
   core/make
+  core/meson
+  core/ninja
   core/pkg-config
+  core/python
 )
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+  meson _build .
+  cd _build
+  ninja
+}
+
+do_install() {
+  cd _build
+  ninja install
+}

--- a/at-spi2-atk/plan.sh
+++ b/at-spi2-atk/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=at-spi2-atk
 pkg_origin=core
-pkg_version=2.40.0
+pkg_version=2.38.0
 pkg_description="Service Provider Interface for the Assistive Technologies available on the GNOME platform"
 pkg_upstream_url=https://wiki.linuxfoundation.org/accessibility/atk/at-spi/at-spi_on_d-bus
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.0")
 pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=7515bf959b73b956ceb967351c7e299cbb3668a53d35f9c770eb72e00d93ced6
+pkg_shasum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 pkg_deps=(
   core/at-spi2-core
   core/atk

--- a/at-spi2-atk/plan.sh
+++ b/at-spi2-atk/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=https://wiki.linuxfoundation.org/accessibility/atk/at-spi/at-sp
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.0")
 pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+pkg_shasum=cfa008a5af822b36ae6287f18182c40c91dd699c55faa38605881ed175ca464f
 pkg_deps=(
   core/at-spi2-core
   core/atk

--- a/at-spi2-atk/plan.sh
+++ b/at-spi2-atk/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=at-spi2-atk
 pkg_origin=core
-pkg_version=2.26.1
+pkg_version=2.40.0
 pkg_description="Service Provider Interface for the Assistive Technologies available on the GNOME platform"
 pkg_upstream_url=https://wiki.linuxfoundation.org/accessibility/atk/at-spi/at-spi_on_d-bus
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.0")
 pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=b4f0c27b61dbffba7a5b5ba2ff88c8cee10ff8dac774fa5b79ce906853623b75
+pkg_shasum=7515bf959b73b956ceb967351c7e299cbb3668a53d35f9c770eb72e00d93ced6
 pkg_deps=(
   core/at-spi2-core
   core/atk


### PR DESCRIPTION
Updated pkg_version 2.26.1 -> 2.40.0 in support of 2021 Q2 core plans refresh.