### PR TITLE
Update libxshmfence Plan Package Version

### DIFF
--- a/libxshmfence/plan.sh
+++ b/libxshmfence/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libxshmfence
 pkg_origin=core
-pkg_version=1.2
+pkg_version=1.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="X11 C Bindings"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/archive/individual/lib/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum="d21b2d1fd78c1efbe1f2c16dae1cb23f8fd231dcf891465b8debe636a9054b0c"
+pkg_shasum="b884300d26a14961a076fbebc762a39831cb75f92bed5ccf9836345b459220c7"
 pkg_deps=(
   core/glibc
 )


### PR DESCRIPTION
Updated pkg_version 1.2 -> 1.3 in support of 2021 Q2 core plans refresh.