### PR TITLE
Update elasticsearch Plan Package Version

### DIFF
--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=elasticsearch
 pkg_origin=core
-pkg_version=6.8.5
+pkg_version=6.8.15
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Open Source, Distributed, RESTful Search Engine"
 pkg_upstream_url="https://elastic.co"
 pkg_license=('Revised BSD')
 pkg_source="https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=5fe84fa84a0ca0136aad9bbdfc2053f8dda9a3e166ddf34e947bb1fe24e4ce6d
+pkg_shasum=14fa8a88049ef8314619fa028c9a19301acc8660b0caadb6a90372f4d142e156
 pkg_build_deps=(
   core/patchelf
 )


### PR DESCRIPTION
Updated pkg_version 6.8.5 -> 6.8.15 in support of 2021 Q2 core plans refresh.