### PR TITLE
Update mage Plan Package Version

### DIFF
--- a/mage/plan.sh
+++ b/mage/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=mage
 pkg_origin=core
-pkg_version=1.9.0
+pkg_version=1.11.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Mage is a make/rake-like build tool using Go. You write plain-old go functions, and Mage automatically uses them as Makefile-like runnable targets."

--- a/mage/tests/test.bats
+++ b/mage/tests/test.bats
@@ -1,7 +1,7 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} mage --version 2>&1 | head -1)"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} mage -- --version 2>&1 | head -1)"
   [ "${result}" = "Mage Build Tool v${TEST_PKG_VERSION}" ]
 }
 


### PR DESCRIPTION
Updated pkg_version 1.9.0 -> 1.11.0 in support of 2021 Q2 core plans refresh.