### PR TITLE
Update json-c Plan Package Version

### DIFF
--- a/json-c/plan.sh
+++ b/json-c/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=json-c
 pkg_origin=core
-pkg_version=0.13.1
+pkg_version=0.15
 pkg_description="A JSON implementation in C"
 pkg_upstream_url=https://github.com/json-c/json-c
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://s3.amazonaws.com/json-c_releases/releases/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
+pkg_shasum=b8d80a1ddb718b3ba7492916237bbf86609e9709fb007e7f7d4322f02341a4c6
 pkg_build_deps=(
   core/autoconf
   core/busybox-static

--- a/json-c/plan.sh
+++ b/json-c/plan.sh
@@ -11,6 +11,7 @@ pkg_build_deps=(
   core/autoconf
   core/busybox-static
   core/gcc
+  core/cmake
   core/make
 )
 pkg_deps=(
@@ -19,6 +20,18 @@ pkg_deps=(
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+  mkdir build
+  cd build
+  ../cmake-configure --prefix=$pkg_prefix
+  make
+}
+
+do_install() {
+  cd build
+  make install
+}
 
 do_check() {
   make check

--- a/json-c/plan.sh
+++ b/json-c/plan.sh
@@ -18,21 +18,26 @@ pkg_deps=(
   core/glibc
 )
 pkg_include_dirs=(include)
-pkg_lib_dirs=(lib)
-pkg_pconfig_dirs=(lib/pkgconfig)
+pkg_lib_dirs=(lib64)
+pkg_pconfig_dirs=(lib64/pkgconfig)
+
+do_clean() {
+  rm -rf "${HAB_CACHE_SRC_PATH}"/json-c-build
+}
 
 do_build() {
-  mkdir build
-  cd build
-  ../cmake-configure --prefix="$pkg_prefix"
-  make
+  mkdir "${HAB_CACHE_SRC_PATH}"/json-c-build
+  cd "${HAB_CACHE_SRC_PATH}"/json-c-build
+  cmake -DCMAKE_INSTALL_PREFIX="${pkg_prefix}" "${HAB_CACHE_SRC_PATH}"/"${pkg_dirname}"
 }
 
 do_install() {
-  cd build
+  cd "${HAB_CACHE_SRC_PATH}"/json-c-build
   make install
 }
 
 do_check() {
-  make check
+  cd "${HAB_CACHE_SRC_PATH}"/json-c-build
+  make
+  make test
 }

--- a/json-c/plan.sh
+++ b/json-c/plan.sh
@@ -24,7 +24,7 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 do_build() {
   mkdir build
   cd build
-  ../cmake-configure --prefix=$pkg_prefix
+  ../cmake-configure --prefix="$pkg_prefix"
   make
 }
 


### PR DESCRIPTION
Updated pkg_version 0.13.1 -> 0.15 in support of 2021 Q2 core plans refresh.