### PR TITLE
Update hspec-discover Plan Package Version

### DIFF
--- a/hspec-discover/plan.sh
+++ b/hspec-discover/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=hspec-discover
 pkg_origin=core
-pkg_version=2.7.0
+pkg_version=2.7.9
 pkg_license=('MIT')
 pkg_upstream_url="https://hspec.github.io/"
 pkg_description="Automatically discover and run Hspec tests"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="1cb6d6cd494a191b74aa54465005929c73911bf8cd79bb8f7773f4611bf06bd8"
+pkg_shasum="9bd0fe319bb5581fa3f3c97f846b942ec799f51617740b052224be87328226ff"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updated pkg_version 2.7.0 -> 2.7.9 in support of 2021 Q2 core plans refresh.