### PR TITLE
Update libtiff Plan Package Version

### DIFF
--- a/libtiff/plan.sh
+++ b/libtiff/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libtiff
 pkg_origin=core
-pkg_version=4.1.0
+pkg_version=4.2.0
 pkg_description="Library for reading and writting files in the Tag Image File Format (TIFF)"
 pkg_upstream_url="http://www.remotesensing.org/libtiff/"
 pkg_license=('libtiff')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://download.osgeo.org/libtiff/tiff-${pkg_version}.tar.gz"
-pkg_shasum=5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634
+pkg_shasum=eb0484e568ead8fa23b513e9b0041df7e327f4ee2d22db5a533929dfc19633cb
 pkg_deps=(
   core/glibc
   core/zlib


### PR DESCRIPTION
Updated pkg_version 4.1.0 -> 4.2.0 in support of 2021 Q2 core plans refresh.