### PR TITLE
Update lttng-ust Plan Package Version

### DIFF
--- a/lttng-ust/plan.sh
+++ b/lttng-ust/plan.sh
@@ -11,6 +11,7 @@ pkg_deps=(
   core/coreutils
   core/gcc-libs
   core/glibc
+  core/numactl
   core/python2
   core/userspace-rcu
 )

--- a/lttng-ust/plan.sh
+++ b/lttng-ust/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=lttng-ust
-pkg_version=2.8.1
+pkg_version=2.12.1
 pkg_description="LTTng is an open source tracing framework for Linux."
 pkg_upstream_url=http://lttng.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'MIT')
 pkg_source=$pkg_upstream_url/files/$pkg_name/$pkg_name-$pkg_version.tar.bz2
-pkg_shasum=6e41349107e83e7b43c69ed358e48788ca2fd095bad61737b850e3f3d2c0508a
+pkg_shasum=cad26d7b831503088f9834b161e47f27f9f73640d0cdcef7f860cbd74a3afedf
 pkg_deps=(
   core/coreutils
   core/gcc-libs

--- a/lttng-ust/plan.sh
+++ b/lttng-ust/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=http://lttng.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'MIT')
 pkg_source=$pkg_upstream_url/files/$pkg_name/$pkg_name-$pkg_version.tar.bz2
-pkg_shasum=cad26d7b831503088f9834b161e47f27f9f73640d0cdcef7f860cbd74a3afedf
+pkg_shasum=48a3948b168195123a749d22818809bd25127bb5f1a66458c3c012b210d2a051
 pkg_deps=(
   core/coreutils
   core/gcc-libs


### PR DESCRIPTION
Updated pkg_version 2.8.1 -> 2.12.1 in support of 2021 Q2 core plans refresh.