### PR TITLE
Update coredns Plan Package Version

### DIFF
--- a/coredns/plan.sh
+++ b/coredns/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=coredns
 pkg_origin=core
-pkg_version=1.7.0
+pkg_version=1.8.3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="CoreDNS is a DNS server/forwarder, written in Go, that chains plugins."
 pkg_upstream_url=https://coredns.io/
 pkg_source="https://github.com/coredns/coredns/archive/v${pkg_version}.tar.gz"
-pkg_shasum=7e436e9d0c0b84af863685e05d701b84247bb0f12b6dbf05ea87e165c1398b2b
+pkg_shasum=6b2eb758672fb72d2e04d41d4eea935a0d50f33fc3bdb03d6bf6e8cb8f71bcf7
 pkg_deps=(
   core/glibc
   core/coreutils

--- a/coredns/plan.sh
+++ b/coredns/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("Apache-2.0")
 pkg_description="CoreDNS is a DNS server/forwarder, written in Go, that chains plugins."
 pkg_upstream_url=https://coredns.io/
 pkg_source="https://github.com/coredns/coredns/archive/v${pkg_version}.tar.gz"
-pkg_shasum=6b2eb758672fb72d2e04d41d4eea935a0d50f33fc3bdb03d6bf6e8cb8f71bcf7
+pkg_shasum=9fa12d1f0cc7678cd9973b4a1a27718a4d1e12d78f4a46681cea39f569c2a166
 pkg_deps=(
   core/glibc
   core/coreutils

--- a/coredns/tests/test.bats
+++ b/coredns/tests/test.bats
@@ -1,17 +1,17 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} coredns -version | grep CoreDNS | awk -F'-' '{print $2}')"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} coredns -- -version | grep CoreDNS | awk -F'-' '{print $2}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Help command" {
-  run hab pkg exec ${TEST_PKG_IDENT} coredns -help
-  [ $status -eq 2 ]
+  run hab pkg exec ${TEST_PKG_IDENT} coredns -- -help
+  [ $status -eq 0 ]
 }
 
 @test "Plugin list" {
-  run hab pkg exec ${TEST_PKG_IDENT} coredns -plugins
+  run hab pkg exec ${TEST_PKG_IDENT} coredns -- -plugins
   [ $status -eq 0 ]
 }
 


### PR DESCRIPTION
Updated pkg_version 1.7.0 -> 1.8.3 in support of 2021 Q2 core plans refresh.