### PR TITLE
Update lcms2 Plan Package Version

### DIFF
--- a/lcms2/plan.sh
+++ b/lcms2/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=lcms2
 pkg_origin=core
-pkg_version=2.8
+pkg_version=2.12
 pkg_description="Small-footprint color management engine, version 2"
 pkg_upstream_url=http://www.littlecms.com
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source=http://downloads.sourceforge.net/sourceforge/lcms/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22
+pkg_shasum=2257531baedea1a47570e42b92634398afaef5ad5341562b497100048453dd45
 pkg_deps=(
   core/glibc
   core/jbigkit

--- a/lcms2/plan.sh
+++ b/lcms2/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=http://www.littlecms.com
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source=http://downloads.sourceforge.net/sourceforge/lcms/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=2257531baedea1a47570e42b92634398afaef5ad5341562b497100048453dd45
+pkg_shasum=18663985e864100455ac3e507625c438c3710354d85e5cbb7cd4043e11fe10f5
 pkg_deps=(
   core/glibc
   core/jbigkit


### PR DESCRIPTION
Updated pkg_version 2.8 -> 2.12 in support of 2021 Q2 core plans refresh.