### PR TITLE
Update opam Plan Package Version

### DIFF
--- a/opam/plan.sh
+++ b/opam/plan.sh
@@ -2,11 +2,11 @@ pkg_name=opam
 pkg_origin=core
 pkg_description="opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow."
 pkg_upstream_url="https://opam.ocaml.org/"
-pkg_version="1.2.2"
+pkg_version="1.3.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL')
 pkg_source="https://github.com/ocaml/opam/releases/download/${pkg_version}/opam-full-${pkg_version}.tar.gz"
-pkg_shasum="15e617179251041f4bf3910257bbb8398db987d863dd3cfc288bdd958de58f00"
+pkg_shasum="0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 pkg_dirname="opam-full-${pkg_version}"
 pkg_deps=(
   core/aspcud


### PR DESCRIPTION
Updated pkg_version "1.2.2" -> "1.3.0" in support of 2021 Q2 core plans refresh.