### PR TITLE
Update bash-completion Plan Package Version

### DIFF
--- a/bash-completion/plan.sh
+++ b/bash-completion/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=https://github.com/scop/bash-completion
 pkg_description="Programmable completion functions for bash"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/scop/bash-completion/releases/download/${pkg_version}/bash-completion-${pkg_version}.tar.xz"
-pkg_shasum=f13188a0f324d774f375f0e4c4894e87b61aedcb914e1147c9b2b372c8970fc0
+pkg_shasum=73a8894bad94dee83ab468fa09f628daffd567e8bef1a24277f1e9a0daf911ac
 pkg_deps=(
   core/bash
 )

--- a/bash-completion/plan.sh
+++ b/bash-completion/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=bash-completion
 pkg_origin=core
-pkg_version=2.9
+pkg_version=2.11
 pkg_license=("GPL-2.0")
 pkg_upstream_url=https://github.com/scop/bash-completion
 pkg_description="Programmable completion functions for bash"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/scop/bash-completion/releases/download/${pkg_version}/bash-completion-${pkg_version}.tar.xz"
-pkg_shasum=d48fe378e731062f479c5f8802ffa9d3c40a275a19e6e0f6f6cc4b90fa12b2f5
+pkg_shasum=f13188a0f324d774f375f0e4c4894e87b61aedcb914e1147c9b2b372c8970fc0
 pkg_deps=(
   core/bash
 )


### PR DESCRIPTION
Updated pkg_version 2.9 -> 2.11 in support of 2021 Q2 core plans refresh.