### PR TITLE
Update clang Plan Package Version

### DIFF
--- a/clang/plan.sh
+++ b/clang/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=clang
 pkg_origin=core
-pkg_version=7.0.1
+pkg_version=7.1.0
 pkg_license=('NCSA')
 pkg_description="LLVM native C/C++/Objective-C compiler"
 pkg_upstream_url="http://clang.llvm.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_filename="cfe-${pkg_version}.src.tar.xz"
 pkg_source="http://llvm.org/releases/${pkg_version}/cfe-${pkg_version}.src.tar.xz"
-pkg_shasum="a45b62dde5d7d5fdcdfa876b0af92f164d434b06e9e89b5d0b1cbc65dfe3f418"
-clang_tools_extra_shasum="937c5a8c8c43bc185e4805144744799e524059cac877a44d9063926cd7a19dbe"
+pkg_shasum="e97dc472aae52197a4d5e0185eb8f9e04d7575d2dc2b12194ddc768e0f8a846d"
+clang_tools_extra_shasum="1ce0042c48ecea839ce67b87e9739cf18e7a5c2b3b9a36d177d00979609b6451"
 pkg_deps=(
   core/coreutils
   core/gcc-libs


### PR DESCRIPTION
Updated pkg_version 7.0.1 -> 7.1.0 in support of 2021 Q2 core plans refresh.