### PR TITLE
Update ffmpeg Plan Package Version

### DIFF
--- a/ffmpeg/plan.sh
+++ b/ffmpeg/plan.sh
@@ -37,6 +37,7 @@ pkg_deps=(
   core/openjpeg
   core/xz
   core/zlib
+  core/avisynthplus
 )
 
 do_build() {

--- a/ffmpeg/plan.sh
+++ b/ffmpeg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ffmpeg
 pkg_origin=core
-pkg_version=4.2.2
+pkg_version=4.3.2
 pkg_description="A complete, cross-platform solution to record, convert and stream audio and video."
 pkg_upstream_url=https://ffmpeg.org/
 pkg_license=('LGPL-2.1-or-later' 'GPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ffmpeg.org/releases/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=83f9a9aa0acf8036daf47494d99a8c31154a18ebb6841d89878ba47783559bd0
+pkg_shasum=b4701d5d1220cfa2f140090a0ae349cd76dafe335e60227d1e3f8301998634c9
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)

--- a/ffmpeg/plan.sh
+++ b/ffmpeg/plan.sh
@@ -38,6 +38,7 @@ pkg_deps=(
   core/xz
   core/zlib
   core/avisynthplus
+  core/libidn2
 )
 
 do_build() {


### PR DESCRIPTION
Updated pkg_version 4.2.2 -> 4.3.2 in support of 2021 Q2 core plans refresh.