### PR TITLE
Update drupal Plan Package Version

### DIFF
--- a/drupal/plan.sh
+++ b/drupal/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=drupal
 pkg_origin=core
-pkg_version="8.3.2"
+pkg_version="8.9.13"
 pkg_license=('gplv2+')
 pkg_deps=(core/mysql-client core/drush core/nginx core/php)
 pkg_binds=(


### PR DESCRIPTION
Updated pkg_version "8.3.2" -> "8.9.13" in support of 2021 Q2 core plans refresh.