### PR TITLE
Update clojure Plan Package Version

### DIFF
--- a/clojure/plan.sh
+++ b/clojure/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url=https://clojure.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("EPL-1.0")
 pkg_source=https://download.${pkg_name}.org/install/${pkg_name}-tools-${pkg_version}.tar.gz
-pkg_shasum=9c3298d9c25de1d22a3ec8a6c3639035c2bba10945ae9007ab0dc9136766b95d2161f354e62a4d101c1f8aae866ff28e73d3478bdaaa8df00386ef3b5a9cf790
+pkg_shasum=2a3ec8a6c3639035c2bba10945ae9007ab0dc9136766b95d2161f354e62a4d10
 pkg_deps=(
   core/bash
   core/coreutils

--- a/clojure/plan.sh
+++ b/clojure/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=clojure
-pkg_version=1.10.0.442
+pkg_version=1.10.1.763
 pkg_description="The Clojure programming language"
 pkg_upstream_url=https://clojure.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("EPL-1.0")
 pkg_source=https://download.${pkg_name}.org/install/${pkg_name}-tools-${pkg_version}.tar.gz
-pkg_shasum=9c3298d9c25de1d21c1f8aae866ff28e73d3478bdaaa8df00386ef3b5a9cf790
+pkg_shasum=9c3298d9c25de1d22a3ec8a6c3639035c2bba10945ae9007ab0dc9136766b95d2161f354e62a4d101c1f8aae866ff28e73d3478bdaaa8df00386ef3b5a9cf790
 pkg_deps=(
   core/bash
   core/coreutils


### PR DESCRIPTION
Updated pkg_version 1.10.0.442 -> 1.10.1.763 in support of 2021 Q2 core plans refresh.