### PR TITLE
Update leproxy Plan Package Version

### DIFF
--- a/leproxy/plan.sh
+++ b/leproxy/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=leproxy
 pkg_origin=core
-pkg_version="20180113"
+pkg_version="20191014"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("MIT")
 pkg_source="https://github.com/artyom/${pkg_name}/releases/download/${pkg_version}/leproxy-linux-amd64.tar.gz"
-pkg_shasum="c8a7ee698c8f4b4f828905d13978de30a79d6d394f992d8b1a170469c8e0d148"
+pkg_shasum="21f04ed32f51b90854d899b653b52ee05cd1319310a9e8bc52c48e6e28859ef7"
 pkg_bin_dirs=(bin)
 pkg_description="https reverse proxy with automatic Letsencrypt usage for multiple hostnames/backends"
 pkg_upstream_url="https://github.com/artyom/leproxy"


### PR DESCRIPTION
Updated pkg_version "20180113" -> "20191014" in support of 2021 Q2 core plans refresh.