### PR TITLE
Update libimagequant Plan Package Version

### DIFF
--- a/libimagequant/plan.sh
+++ b/libimagequant/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libimagequant
 pkg_origin=core
-pkg_version=2.12.5
+pkg_version=2.14.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
 pkg_description="Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images."
 pkg_upstream_url="https://pngquant.org/lib"
 pkg_source="https://github.com/ImageOptim/${pkg_name}/archive/${pkg_version}.tar.gz"
-pkg_shasum=9dc07f3bf6efaf03241fd514e62108be484a373871e2e02c117e6efb49d26293
+pkg_shasum=b5fa27da1f3cf3e8255dd02778bb6a51dc71ce9f99a4fc930ea69b83200a7c74
 pkg_deps=(core/coreutils)
 pkg_build_deps=(
   core/make


### PR DESCRIPTION
Updated pkg_version 2.12.5 -> 2.14.1 in support of 2021 Q2 core plans refresh.