### PR TITLE
Update dpkg Plan Package Version

### DIFF
--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dpkg
 pkg_origin=core
-pkg_version=1.20.7.1
+pkg_version=1.19.7
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-or-later')
 pkg_upstream_url="https://wiki.debian.org/dpkg"
 pkg_description="dpkg is a package manager for Debian-based systems"
 pkg_source="http://http.debian.net/debian/pool/main/d/${pkg_name}/${pkg_name}_${pkg_version}.tar.xz"
-pkg_shasum="0aad2de687f797ef8ebdabc7bafd16dc1497f1ce23bd9146f9aa73f396a5636f"
+pkg_shasum="4c27fededf620c0aa522fff1a48577ba08144445341257502e7730f2b1a296e8"
 pkg_deps=(
   core/bzip2
   core/glibc

--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dpkg
 pkg_origin=core
-pkg_version=1.19.7
+pkg_version=1.20.7.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-or-later')
 pkg_upstream_url="https://wiki.debian.org/dpkg"
 pkg_description="dpkg is a package manager for Debian-based systems"
 pkg_source="http://http.debian.net/debian/pool/main/d/${pkg_name}/${pkg_name}_${pkg_version}.tar.xz"
-pkg_shasum="4c27fededf620c0aa522fff1a48577ba08144445341257502e7730f2b1a296e8"
+pkg_shasum="0aad2de687f797ef8ebdabc7bafd16dc1497f1ce23bd9146f9aa73f396a5636f"
 pkg_deps=(
   core/bzip2
   core/glibc

--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -24,7 +24,6 @@ pkg_build_deps=(
   core/gettext
   core/libtool
   core/patch
-  core/make
   core/perl
   core/pkg-config
   core/xz
@@ -35,6 +34,10 @@ pkg_bin_dirs=(bin sbin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+do_prepare() {
+  export LDFLAGS="$LDFLAGS -Wl,--copy-dt-needed-entries"
+}
+
 do_check() {
-	make check
+  make check
 }

--- a/dpkg/tests/test.bats
+++ b/dpkg/tests/test.bats
@@ -1,6 +1,6 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec $TEST_PKG_IDENT dpkg --version | head -1 | awk '{print $7}')"
+  result="$(hab pkg exec $TEST_PKG_IDENT dpkg -- --version | head -1 | awk '{print $7}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }


### PR DESCRIPTION
Updated pkg_version 1.19.7 -> 1.20.7.1 in support of 2021 Q2 core plans refresh.