### PR TITLE
Update doxygen Plan Package Version

### DIFF
--- a/doxygen/plan.sh
+++ b/doxygen/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=doxygen
 pkg_origin=core
-pkg_version=1.8.17
+pkg_version=1.9.1
 pkg_license=('GPL-2.0')
 pkg_description="Generate documentation for several programming languages"
 pkg_upstream_url="http://www.doxygen.nl/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://sourceforge.net/projects/doxygen/files/rel-${pkg_version}/${pkg_name}-${pkg_version}.src.tar.gz"
-pkg_shasum=2cba988af2d495541cbbe5541b3bee0ee11144dcb23a81eada19f5501fd8b599
+pkg_shasum=67aeae1be4e1565519898f46f1f7092f1973cce8a767e93101ee0111717091d1
 pkg_build_deps=(
   core/bison
   core/cmake


### PR DESCRIPTION
Updated pkg_version 1.8.17 -> 1.9.1 in support of 2021 Q2 core plans refresh.