### PR TITLE
Update kubernetes-proxy Plan Package Version

### DIFF
--- a/kubernetes-proxy/plan.sh
+++ b/kubernetes-proxy/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.11.2
-pkg_deps=("core/kubernetes/1.11.2")
+pkg_version=1.20.5
+pkg_deps=("core/kubernetes/1.20.5")
 pkg_svc_user="root"
 pkg_svc_group="${pkg_svc_user}"
 


### PR DESCRIPTION
Updated pkg_version 1.11.2 -> 1.20.5 in support of 2021 Q2 core plans refresh.