### PR TITLE
Update rabbitmq Plan Package Version

### DIFF
--- a/rabbitmq/plan.sh
+++ b/rabbitmq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=rabbitmq
 pkg_distname="${pkg_name}-server"
 pkg_origin=core
-pkg_version=3.8.3
+pkg_version=3.8.14
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL')
 pkg_description="Open source multi-protocol messaging broker"
 pkg_upstream_url="https://www.rabbitmq.com"
 pkg_source="https://github.com/rabbitmq/rabbitmq-server/releases/download/v${pkg_version}/rabbitmq-server-${pkg_version}.tar.xz"
-pkg_shasum=aedc8458701a80167b35958c10090d468c3de11984510b49ec02e777c51b1aba
+pkg_shasum=344bfd479de67d54a4cb9b84a77507c4b7bd0738e5ff99b8219f5ec7302beb0f
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/coreutils


### PR DESCRIPTION
Updated pkg_version 3.8.3 -> 3.8.14 in support of 2021 Q2 core plans refresh.