### PR TITLE
Update ocaml Plan Package Version

### DIFF
--- a/ocaml/plan.sh
+++ b/ocaml/plan.sh
@@ -13,7 +13,7 @@ pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)
 
 do_build() {
-  ./configure --prefix "${pkg_prefix}" -no-graph && make world.opt
+  ./configure --prefix "${pkg_prefix}" && make world.opt
 }
 
 do_check() {

--- a/ocaml/plan.sh
+++ b/ocaml/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ocaml
 pkg_origin=core
-pkg_version="4.07.0"
+pkg_version="4.12.0"
 pkg_description="The OCAML compiler"
 pkg_upstream_url="https://ocaml.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-2.0')
 pkg_source="https://github.com/ocaml/ocaml/archive/${pkg_version}.tar.gz"
-pkg_shasum="8dd39da81beaad53a158e71c428f902b609d8f7f33fedf37f15c56be6c4cf840"
+pkg_shasum="adc07a3995362403f3cb11085a86354de08e5a7f9eb3c09be7bbcc38a3a26744"
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/make core/gcc)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Updated pkg_version "4.07.0" -> "4.12.0" in support of 2021 Q2 core plans refresh.