### PR TITLE
Update pango Plan Package Version

### DIFF
--- a/pango/plan.sh
+++ b/pango/plan.sh
@@ -51,3 +51,11 @@ do_prepare() {
     ln -sv "$(pkg_path_for core/file)/bin/file" /usr/bin/file
   fi
 }
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  return 0
+}

--- a/pango/plan.sh
+++ b/pango/plan.sh
@@ -32,13 +32,16 @@ pkg_deps=(
   core/zlib
 )
 pkg_build_deps=(
+  core/cmake
   core/coreutils
   core/diffutils
   core/file
   core/gcc
-  core/make
+  core/git
+  core/meson
   core/perl
   core/pkg-config
+  core/util-linux
 )
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -53,9 +56,10 @@ do_prepare() {
 }
 
 do_build() {
-  return 0
+  meson _build -Dprefix="$pkg_prefix"
+  ninja -C _build
 }
 
 do_install() {
-  return 0
+  ninja -C _build install
 }

--- a/pango/plan.sh
+++ b/pango/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=pango
 pkg_origin=core
-pkg_version="1.40.13"
+pkg_version="1.48.4"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL')
 pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="f84e98db1078772ff4935b40a1629ff82ef0dfdd08d2cbcc0130c8c437857196"
+pkg_shasum="418913fb062071a075846244989d4a67aa5c80bf0eae8ee4555a092fd566a37a"
 pkg_upstream_url="http://www.pango.org"
 pkg_description="Pango is a library for laying out and rendering of text, with an emphasis on internationalization."
 pkg_deps=(


### PR DESCRIPTION
Updated pkg_version "1.40.13" -> "1.48.4" in support of 2021 Q2 core plans refresh.