### PR TITLE
Update sbt Plan Package Version

### DIFF
--- a/sbt/plan.sh
+++ b/sbt/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=sbt
-pkg_version=1.3.12
+pkg_version=1.4.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A build tool for Scala, Java, and more"
 pkg_upstream_url="https://www.scala-sbt.org"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/sbt/sbt/releases/download/v${pkg_version}/sbt-${pkg_version}.tgz"
-pkg_shasum=b4e72bb95f5be8f6a83451ef254c2bff008204456cadfcdd6d1ca4b981c58d57
+pkg_shasum=95468119f7641499367330a60a4b8a6211e6ea7f8bde7d647c67b19dd8fddb6e
 pkg_deps=(
   core/coreutils
   core/openjdk11


### PR DESCRIPTION
Updated pkg_version 1.3.12 -> 1.4.9 in support of 2021 Q2 core plans refresh.