### PR TITLE
Bumped version 2.4.2 -> 2.5.5

### DIFF
--- a/libassuan/plan.sh
+++ b/libassuan/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libassuan
 pkg_origin=core
-pkg_version=2.4.2
+pkg_version=2.5.5
 pkg_license=('LGPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="ftp://ftp.gnupg.org/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"
 pkg_description="Libassuan is a small library implementing the so-called Assuan protocol. "
 pkg_upstream_url=https://www.gnupg.org/software/libassuan/index.html
-pkg_shasum=bb06dc81380b74bf1b64d5849be5c0409a336f3b4c45f20ac688e86d1b5bcb20
+pkg_shasum=8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4
 pkg_deps=(core/glibc core/libgpg-error)
 pkg_build_deps=(core/gcc core/coreutils core/sed core/bison core/flex core/grep core/bash core/gawk core/libtool core/diffutils core/findutils core/xz core/gettext core/gzip core/make core/patch core/texinfo core/util-linux)
 pkg_bin_dirs=(bin)

--- a/libksba/plan.sh
+++ b/libksba/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libksba
 pkg_origin=core
-pkg_version=1.3.3
+pkg_version=1.5.1
 pkg_license=('LGPL-3.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=ftp://ftp.gnupg.org/gcrypt/"${pkg_name}"/"${pkg_name}"-"${pkg_version}".tar.bz2
 pkg_upstream_url="https://www.gnupg.org/software/libksba/index.html"
 pkg_description="Libksba is a library to make the tasks of working with X.509 certificates, CMS data and related objects more easy."
-pkg_shasum=0c7f5ffe34d0414f6951d9880a46fcc2985c487f7c36369b9f11ad41131c7786
+pkg_shasum=b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921
 pkg_deps=(
   core/glibc
   core/libgpg-error


### PR DESCRIPTION
Please review. For gpgme package, We need libassuan min version of 2.5.0 and libksba min version 1.3.5

Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>
