### PR TITLE
Adds kernel2 bldr target for ruby30 plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1372,6 +1372,10 @@ plan_path = "ruby30"
 paths = [
   "ruby/*"
 ]
+build_targets = [
+  "x86_64-linux",
+  "x86_64-linux-kernel2"
+]
 [runc]
 plan_path = "runc"
 [runit]


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

Adds kernel2 target for package `core/ruby30` to support additional deployment targets.
This is to support adding kernel2 support with `core/ruby30` for `chef/chef-infra-client`