### PR TITLE
Update buildkite-agent Plan Package Version

### DIFF
--- a/buildkite-agent/plan.ps1
+++ b/buildkite-agent/plan.ps1
@@ -6,7 +6,7 @@ $pkg_license=@("MIT")
 $pkg_description="The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
 $pkg_source="https://github.com/buildkite/agent/releases/download/v${pkg_version}/buildkite-agent-windows-amd64-${pkg_version}.zip"
 $pkg_filename="buildkite-agent-windows-amd64-${pkg_version}.zip"
-$pkg_shasum="b46203b515288982b476898f24904244063b7869be4df494d63d7243d915773c"
+$pkg_shasum="24c4aae7079aaf84e82679d963d301f56ea5e775646d29cae5995381c352e8e6"
 $pkg_upstream_url="https://buildkite.com"
 $pkg_bin_dirs=@("bin")
 

--- a/buildkite-agent/plan.ps1
+++ b/buildkite-agent/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="buildkite-agent"
 $pkg_origin="core"
-$pkg_version="3.9.1"
+$pkg_version="3.29.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("MIT")
 $pkg_description="The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."


### PR DESCRIPTION
Updated pkg_version "3.9.1" -> "3.29.0" in support of 2021 Q2 core plans refresh.