### PR TITLE
Update shellcheck Plan Package Version

### DIFF
--- a/shellcheck/plan.ps1
+++ b/shellcheck/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="shellcheck"
 $hkg_name="ShellCheck"
 $pkg_origin="core"
-$pkg_version="0.7.0"
+$pkg_version="0.7.2"
 $pkg_license=@("GPL-3")
 $pkg_upstream_url="http://www.shellcheck.net/"
 $pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-$pkg_shasum="3af93f97750fe896b5e9c5247b84f1a99e34293992bb0e9001b0cc725949a8ef"
+$pkg_shasum="ff7534d80c3dc8817c0794a76f432979a7d5c2e537ee5a7c19b424aca41d8472"
 $pkg_dirname="${hkg_name}-${pkg_version}"
 
 


### PR DESCRIPTION
Updated pkg_version "0.7.0" -> "0.7.2" in support of 2021 Q2 core plans refresh.