### PR TITLE
Update dotnet-core Plan Package Version

### DIFF
--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="dotnet-core"
 $pkg_origin="core"
-$pkg_version="3.1.0"
+$pkg_version="3.1.14"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
@@ -8,7 +8,7 @@ $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://download.visualstudio.microsoft.com/download/pr/31b707c9-0484-48b5-b248-7f22946f88b5/a998787f1b26a7f742c84cbec7f145d2/dotnet-runtime-$pkg_version-win-x86.zip"
-$pkg_shasum="1b3cbe6bca79865a2a9ad0f716cab0754a9a4e8f43cb367e64a365949c47d86a"
+$pkg_shasum="aaca27f71c35cea5585e3b4ef521d8ef9f7b505a26c8979564c4cb77886fbfa2"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 

--- a/dotnet-core/plan.ps1
+++ b/dotnet-core/plan.ps1
@@ -7,8 +7,8 @@ $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/31b707c9-0484-48b5-b248-7f22946f88b5/a998787f1b26a7f742c84cbec7f145d2/dotnet-runtime-$pkg_version-win-x86.zip"
-$pkg_shasum="aaca27f71c35cea5585e3b4ef521d8ef9f7b505a26c8979564c4cb77886fbfa2"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/d88fda36-5e76-447e-8ed4-c3bd4151663c/c2d1485326cdeaab2168ee1d0ced1e0a/dotnet-runtime-$pkg_version-win-x64.zip"
+$pkg_shasum="18abe372088ffe1e0b7479440254eff4901bfa262a35c4ed2971cdfe58159fc1"
 $pkg_filename="dotnet-win-x64.$pkg_version.zip"
 $pkg_bin_dirs=@("bin")
 


### PR DESCRIPTION
Updated pkg_version "3.1.0" -> "3.1.14" in support of 2021 Q2 core plans refresh.