### PR TITLE
Update dotnet-core-sdk Plan Package Version

### DIFF
--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -7,7 +7,7 @@ $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-$pkg_version-win-x64.zip"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/2436ee79-1fbc-4f6a-94b4-e6fe6aafde13/abbd1ab0ca754adce35a6fd83f85dd2f/dotnet-sdk-$pkg_version-win-x64.zip"
 $pkg_shasum="ca60e96b0f68e84424d4c76b3864abe9a4e675ee9fddca09fdf2989a5fadc0b4"
 $pkg_bin_dirs=@("bin")
 

--- a/dotnet-core-sdk/plan.ps1
+++ b/dotnet-core-sdk/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="dotnet-core-sdk"
 $pkg_origin="core"
-$pkg_version="3.1.100"
+$pkg_version="3.1.408"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://www.microsoft.com/net/core"
 $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
@@ -8,7 +8,7 @@ $pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   Linux and Mac."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-$pkg_version-win-x64.zip"
-$pkg_shasum="abcd034b230365d9454459e271e118a851969d82516b1529ee0bfea07f7aae52"
+$pkg_shasum="ca60e96b0f68e84424d4c76b3864abe9a4e675ee9fddca09fdf2989a5fadc0b4"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-SetupEnvironment {

--- a/dotnet-core-sdk/tests/test.bats
+++ b/dotnet-core-sdk/tests/test.bats
@@ -1,11 +1,11 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec ${TEST_PKG_IDENT} dotnet --version)"
+  result="$(hab pkg exec ${TEST_PKG_IDENT} dotnet -- --version)"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 
 @test "Info command" {
-  run hab pkg exec ${TEST_PKG_IDENT} dotnet --info
+  run hab pkg exec ${TEST_PKG_IDENT} dotnet -- --info
   [ $status -eq 0 ]
 }


### PR DESCRIPTION
Updated pkg_version "3.1.100" -> "3.1.408" in support of 2021 Q2 core plans refresh.