### PR TITLE
Update postgresql11-client Plan Package Version

### DIFF
--- a/postgresql11-client/plan.ps1
+++ b/postgresql11-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql11-client"
 $pkg_origin="core"
-$pkg_version="11.8"
+$pkg_version="11.11"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="68fe81cdaeb8befbfb0b32a4ef6a374e478ec8c1cc2c28dab965e72780b1f4dc"
+$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-3-windows-x64-binaries.zip"
+$pkg_shasum="1a89a89cc9b091a3d391a25b8e2ce3184d23562eda75e6fcb8350f00af224710"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"


### PR DESCRIPTION
Updated pkg_version "11.8" -> "11.11" in support of 2021 Q2 core plans refresh.