### PR TITLE
Bumped 'cabal-install' version 2.0.0.0 -> 3.4.0.0 for windows

### DIFF
--- a/cabal-install/plan.ps1
+++ b/cabal-install/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="cabal-install"
 $pkg_origin="core"
-$pkg_version="3.0.0.0"
+$pkg_version="3.4.0.0"
 $pkg_license=@("BSD-3-Clause")
 $pkg_upstream_url="https://www.haskell.org/cabal/"
 $pkg_description="Command-line interface for Cabal and Hackage"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-${pkg_version}-x86_64-unknown-mingw32.zip"
-$pkg_shasum="8889963ebef5e829d86329fdb59832c107efd117cf7862a605f2fe2d2360de1f"
+$pkg_source="https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-${pkg_version}-x86_64-windows.zip"
+$pkg_shasum="860fff2d39a82d1dc0ca924a77164d0988af49c2c5f45e15d615144122beb647"
 
 $pkg_bin_dirs=@("bin")
 


### PR DESCRIPTION
Signed-off-by: Ravi Duddela <rduddela@progress.com>