### PR TITLE
Update python36 Plan Package Version

### DIFF
--- a/python36/plan.ps1
+++ b/python36/plan.ps1
@@ -1,7 +1,7 @@
 . ../python/plan.ps1
 
 $pkg_name="python36"
-$pkg_version="3.6.13"
+$pkg_version="3.6.8"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')

--- a/python36/plan.ps1
+++ b/python36/plan.ps1
@@ -1,7 +1,7 @@
 . ../python/plan.ps1
 
 $pkg_name="python36"
-$pkg_version="3.6.6"
+$pkg_version="3.6.13"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')


### PR DESCRIPTION
Updated pkg_version "3.6.6" -> "3.6.13" in support of 2021 Q2 core plans refresh.