### PR TITLE
Update python37 Plan Package Version

### DIFF
--- a/python37/plan.ps1
+++ b/python37/plan.ps1
@@ -1,7 +1,7 @@
 . ../python/plan.ps1
 
 $pkg_name="python37"
-$pkg_version="3.7.10"
+$pkg_version="3.7.9"
 $pkg_origin="core"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Python-2.0')


### PR DESCRIPTION
Updated pkg_version "3.7.3" -> "3.7.10" in support of 2021 Q2 core plans refresh.