### PR TITLE
Update postgresql95-client Plan Package Version

### DIFF
--- a/postgresql95-client/plan.ps1
+++ b/postgresql95-client/plan.ps1
@@ -2,10 +2,10 @@
 
 $pkg_name="postgresql95-client"
 $pkg_origin="core"
-$pkg_version="9.5.13"
+$pkg_version="9.5.25"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="6e2ba4cb017cc1cb2b954a0776124ac5af1b488d78cdf12a1c9b5eac98c8b2c9"
+$pkg_shasum="663fdc5d70f1ea4b3a3f158e362c640db11664a9d6b36ec0982e7b502dec407b"


### PR DESCRIPTION
Updated pkg_version "9.5.13" -> "9.5.25" in support of 2021 Q2 core plans refresh.