### PR TITLE
Update postgresql-client Plan Package Version

### DIFF
--- a/postgresql-client/plan.ps1
+++ b/postgresql-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql-client"
 $pkg_origin="core"
-$pkg_version="9.6.11"
+$pkg_version="9.6.21"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
-$pkg_shasum="39df7a8212df8ce86ebae7f728cac7327a5e9ab821e351ac623ce33de6ed2b1a"
+$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-2-windows-x64-binaries.zip"
+$pkg_shasum="f12d8c7e7760096b0a263109c9e87bc76ef3f580ed1a2292ae9b115ef7545181"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"


### PR DESCRIPTION
Updated pkg_version "9.6.11" -> "9.6.21" in support of 2021 Q2 core plans refresh.