### PR TITLE
Update dotnet-5-runtime Plan Package Version

### DIFF
--- a/dotnet-5-runtime/plan.ps1
+++ b/dotnet-5-runtime/plan.ps1
@@ -6,7 +6,7 @@ $pkg_upstream_url="https://dotnet.microsoft.com/"
 $pkg_description=".NET is a free, cross-platform, open-source developer platform for building many different types of applications."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://dotnetcli.azureedge.net/dotnet/Runtime/$pkg_version/dotnet-runtime-$pkg_version-win-x64.zip"
-$pkg_shasum=""62464751fb0744e85acca14f14304ed21f0ab11b38ba16e43072cb3fc6ca16f7
+$pkg_shasum="62464751fb0744e85acca14f14304ed21f0ab11b38ba16e43072cb3fc6ca16f7"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {

--- a/dotnet-5-runtime/plan.ps1
+++ b/dotnet-5-runtime/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="dotnet-5-runtime"
 $pkg_origin="core"
-$pkg_version="5.0.0"
+$pkg_version="5.0.6"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://dotnet.microsoft.com/"
 $pkg_description=".NET is a free, cross-platform, open-source developer platform for building many different types of applications."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://dotnetcli.azureedge.net/dotnet/Runtime/$pkg_version/dotnet-runtime-$pkg_version-win-x64.zip"
-$pkg_shasum="8c38f4bf443bcccce00143c5aee7ca357502fd4a2515da2ce1a0295136978b14"
+$pkg_shasum=""62464751fb0744e85acca14f14304ed21f0ab11b38ba16e43072cb3fc6ca16f7
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {


### PR DESCRIPTION
Updated pkg_version "5.0.0" -> "5.0.6" in support of 2021 Q2 core plans refresh.