### PR TITLE
Update raml2html Plan Package Version

### DIFF
--- a/raml2html/plan.ps1
+++ b/raml2html/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="raml2html"
 $pkg_origin="core"
-$pkg_version="6.3.0"
+$pkg_version="6.7.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('MIT')
 $pkg_deps=@('core/node')


### PR DESCRIPTION
Updated pkg_version "6.3.0" -> "6.7.0" in support of 2021 Q2 core plans refresh.