### PR TITLE
Update wix Plan Package Version

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1539,6 +1539,8 @@ paths = [
 plan_path = "which"
 [windows-10-sdk]
 plan_path = "windows-10-sdk"
+[wix]
+plan_path = "wix"
 [wordpress]
 plan_path = "wordpress"
 [wordpress-proxy]

--- a/wix/plan.ps1
+++ b/wix/plan.ps1
@@ -1,17 +1,19 @@
 $pkg_name="wix"
 $pkg_origin="core"
-$pkg_version="3.10.3"
+$_base_version="3.11"
+$pkg_version="${_base_version}.2"
 $pkg_license=('MS-RL')
 $pkg_upstream_url="http://wixtoolset.org/"
 $pkg_description="The most powerful set of tools available to create your windows installation experience."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://wix.codeplex.com/downloads/get/1587180"
-$pkg_shasum="493145b3fac22bdf8c55142a9f96ef8136d56b38d78a2322f13f1ba11f9cf2f8"
+$pkg_filename=$pkg_name + ($_base_version).Replace(".", "") + "-binaries.zip"
+$_release_name=$pkg_name + ($pkg_version).Replace(".", "") + "rtm"
+$pkg_source="https://github.com/wixtoolset/wix3/releases/download/${_release_name}/${pkg_filename}"
+$pkg_shasum="9685c25985fa48741e1a3ca0b164b2c71260703fea6a3f1c8e5408856345fc16"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {
-    Move-Item "$HAB_CACHE_SRC_PATH/1587180" "$HAB_CACHE_SRC_PATH/wix310-binaries.zip"
-    Expand-Archive -Path "$HAB_CACHE_SRC_PATH/wix310-binaries.zip" -DestinationPath "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Expand-Archive -Path "$HAB_CACHE_SRC_PATH/${pkg_filename}" -DestinationPath "$HAB_CACHE_SRC_PATH/$pkg_dirname"
 }
 
 function Invoke-Install {

--- a/wix/plan.ps1
+++ b/wix/plan.ps1
@@ -9,7 +9,7 @@ $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_filename=$pkg_name + ($_base_version).Replace(".", "") + "-binaries.zip"
 $_release_name=$pkg_name + ($pkg_version).Replace(".", "") + "rtm"
 $pkg_source="https://github.com/wixtoolset/wix3/releases/download/${_release_name}/${pkg_filename}"
-$pkg_shasum="9685c25985fa48741e1a3ca0b164b2c71260703fea6a3f1c8e5408856345fc16"
+$pkg_shasum="2c1888d5d1dba377fc7fa14444cf556963747ff9a0a289a3599cf09da03b9e2e"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {


### PR DESCRIPTION
Updated pkg_version "3.10.3" -> "${_base_version}.2" in support of 2021 Q2 core plans refresh.