### PR TITLE
Update nginx Plan Package Version

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.18.0"
+$pkg_version="1.20.0"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="a505a776eaf869b09f15e0e588c18784f036720de8518346668f20f2866a71d5"
+$pkg_shasum="bb2844c0572c05b077f7ebc0f5e3571c819fe5151661bc5fe624798c93d1712c"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port ="http.listen.port"}
 $pkg_exposes=@('port')


### PR DESCRIPTION
Updated pkg_version "1.18.0" -> "1.20.0" in support of 2021 Q2 core plans refresh.