### PR TITLE
Update Ruby 2.6.6 to 2.6.7

### DIFF
--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=ruby26
 pkg_origin=core
-pkg_version=2.6.6
+pkg_version=2.6.7
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -8,7 +8,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291
+pkg_shasum=e4227e8b7f65485ecb73397a83e0d09dcd39f25efd411c782b69424e55c7a99e
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
This includes critical CVE fixes

Signed-off-by: Tim Smith <tsmith@chef.io>