### PR TITLE
Foulkon Version Bump

### DIFF
--- a/foulkon/glide.patch
+++ b/foulkon/glide.patch
@@ -1,0 +1,13 @@
+diff --git a/foulkon/glide.sh b/foulkon/glide.sh
+index cc2a89fe..8fbd22ab 100644
+--- a/foulkon/glide.sh
++++ b/foulkon/glide.sh
+@@ -116,7 +116,7 @@ getFile() {
+ 
+ 
+ downloadFile() {
+-	get TAG https://glide.sh/version
++	TAG=v0.13.3
+ 	echo "TAG=$TAG"
+ 	GLIDE_DIST="glide-$TAG-$OS-$ARCH.tar.gz"
+ 	echo "GLIDE_DIST=$GLIDE_DIST"

--- a/foulkon/plan.sh
+++ b/foulkon/plan.sh
@@ -10,6 +10,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
+  core/patch
   # core/which # let's just ignore those errors. works fine without.
 )
 pkg_deps=(
@@ -50,7 +51,13 @@ do_download() {
 do_build() {
   pushd "$scaffolding_go_pkg_path"
     build_line "make deps generate"
-    make deps generate
+    # glide.sh is gone - install glide using the github repository and don't call 'make deps'
+    wget -O glide.sh https://raw.githubusercontent.com/Masterminds/glide.sh/master/get
+    patch <"$PLAN_CONTEXT/glide.patch"
+    bash <glide.sh
+    glide install
+    make generate
+    #make deps generate
 
     # Note: We don't do 'make bin', because it's only these two we need
     #       (It's not worth installing env, and fixing up paths etc...)


### PR DESCRIPTION
[One of the weirdest ones i've seen](https://github.com/Masterminds/glide/issues/1077) - glide's (a go package manager) website has disappeared. Install it by downloading the install script from source and patching it to hardcode the tag (it references glide.sh to get latest tag). It can then install from the source repository, and we can follow the rest of the install steps.

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>