### PR TITLE
Fixing DSO missing from command line using --copy-dt-needed-entries

### DIFF
--- a/nload/plan.sh
+++ b/nload/plan.sh
@@ -12,5 +12,7 @@ pkg_deps=(core/glibc core/gcc-libs core/ncurses)
 pkg_bin_dirs=(bin)
 
 do_prepare() {
+  autoupdate
+  export LDFLAGS="$LDFLAGS -Wl,--copy-dt-needed-entries"
   ./run_autotools
 }


### PR DESCRIPTION
Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>