### PR TITLE
envdir Version Bump

### DIFF
--- a/envdir/plan.sh
+++ b/envdir/plan.sh
@@ -22,7 +22,7 @@ do_unpack() {
 }
 
 do_prepare() {
-  pyvenv "$pkg_prefix"
+  python -m venv "$pkg_prefix"
   source "$pkg_prefix/bin/activate"
 }
 


### PR DESCRIPTION
Fixing deprecated usage of `pyvenv`, using `python -m venv` instead

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>