### PR TITLE
asciinema Version Bump

### DIFF
--- a/asciinema/plan.sh
+++ b/asciinema/plan.sh
@@ -1,4 +1,5 @@
 pkg_name=asciinema
+pkg_version=2.0.2
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
@@ -7,14 +8,6 @@ pkg_upstream_url=https://github.com/asciinema/asciinema
 pkg_build_deps=(core/gawk)
 pkg_deps=(core/python)
 pkg_bin_dirs=(bin)
-pkg_version() {
-  export LC_ALL=en_US LANG=en_US
-  pip search --disable-pip-version-check "${pkg_name}" | grep "^${pkg_name} (" | awk -F'[()]' '{print $2}'
-}
-
-do_before() {
-  update_pkg_version
-}
 
 do_prepare() {
   python -m venv "${pkg_prefix}"

--- a/asciinema/tests/test.bats
+++ b/asciinema/tests/test.bats
@@ -1,7 +1,7 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec "${TEST_PKG_IDENT}" asciinema --version | awk '{print $2}')"
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" asciinema -- --version | awk '{print $2}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 


### PR DESCRIPTION
Version bump & set version explicitly due to `pip search` now being deprecated/disabled:
```
ERROR: XMLRPC request failed [code: -32500]
RuntimeError: PyPI's XMLRPC API is currently disabled due to unmanageable load and will be deprecated in the near future. See https://status.python.org/ for more information.
```

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>