### PR TITLE
dcrpm Version Bump

### DIFF
--- a/dcrpm/plan.sh
+++ b/dcrpm/plan.sh
@@ -1,4 +1,5 @@
 pkg_name=dcrpm
+pkg_version=0.6.2
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-only')
@@ -15,15 +16,6 @@ pkg_deps=(
   core/rpm
 )
 pkg_bin_dirs=(bin)
-
-pkg_version() {
-  export LC_ALL=en_US LANG=en_US
-  pip search --disable-pip-version-check $pkg_name | grep "^$pkg_name (" | awk -F'[()]' '{print $2}'
-}
-
-do_before() {
-  update_pkg_version
-}
 
 do_prepare() {
   python -m venv "$pkg_prefix"

--- a/dcrpm/tests/test.bats
+++ b/dcrpm/tests/test.bats
@@ -1,7 +1,7 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
 
 @test "Version matches" {
-  result="$(hab pkg exec "${TEST_PKG_IDENT}" dcrpm --version | awk '{print $2}')"
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" dcrpm -- --version | awk '{print $2}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
 }
 


### PR DESCRIPTION
Version bump & set version explicitly due to pip search now being deprecated/disabled:

```
xmlrpc.client.Fault: <Fault -32500: "RuntimeError: PyPI's XMLRPC API is currently disabled due to unmanageable load and will be deprecated in the near future. See https://status.python.org/ for more information.">
```

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>