### PR TITLE
Adding cacerts to build_deps ruby26, export SSL_CERT_FILE for gem update/install

### DIFF
--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -9,8 +9,8 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
 pkg_shasum=364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291
-pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
-pkg_build_deps=(core/cacerts core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_deps=(core/cacerts core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
@@ -19,7 +19,8 @@ pkg_dirname="ruby-$pkg_version"
 
 do_setup_environment() {
   SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
-  export SSL_CERT_FILE
+  set_runtime_env SSL_CERT_FILE "${SSL_CERT_FILE}"
+  set_buildtime_env SSL_CERT_FILE "${SSL_CERT_FILE}"
 }
 
 do_prepare() {

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -10,12 +10,16 @@ pkg_source=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
 pkg_shasum=364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_build_deps=(core/cacerts core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/ruby)
 pkg_dirname="ruby-$pkg_version"
+
+do_setup_environment() {
+  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+}
 
 do_prepare() {
   export CFLAGS="${CFLAGS} -O3 -g -pipe"

--- a/ruby26/plan.sh
+++ b/ruby26/plan.sh
@@ -18,7 +18,8 @@ pkg_interpreters=(bin/ruby)
 pkg_dirname="ruby-$pkg_version"
 
 do_setup_environment() {
-  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+  SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+  export SSL_CERT_FILE
 }
 
 do_prepare() {


### PR DESCRIPTION
Fixes SSL error in refresh env

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>