### PR TITLE
Adding cacerts to build_deps, export SSL_CERT_FILE for gem update/install

### DIFF
--- a/ruby25/plan.sh
+++ b/ruby25/plan.sh
@@ -10,12 +10,17 @@ pkg_source=https://cache.ruby-lang.org/pub/ruby/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
 pkg_shasum=6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
-pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_build_deps=(core/cacerts core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_bin_dirs=(bin)
 pkg_interpreters=(bin/ruby)
 pkg_dirname="ruby-$pkg_version"
+
+do_setup_environment() {
+  SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+  export SSL_CERT_FILE
+}
 
 do_prepare() {
   export CFLAGS="${CFLAGS} -O3 -g -pipe"


### PR DESCRIPTION
Fixes SSL issues in refresh env

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>