### PR TITLE
Update Zookeeper Plan Package Version

### DIFF
--- a/zookeeper/plan.sh
+++ b/zookeeper/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=zookeeper
 pkg_origin=core
-pkg_version=3.6.2
+pkg_version=3.7.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications."
 pkg_upstream_url="https://zookeeper.apache.org"
 pkg_license=('Apache-2.0')
 pkg_source="https://downloads.apache.org/zookeeper/zookeeper-${pkg_version}/apache-zookeeper-${pkg_version}-bin.tar.gz"
 pkg_dirname="apache-${pkg_name}-${pkg_version}-bin"
-pkg_shasum="476f6fce10f9528e3a4ad00e6cd1714563f602dd4924db78e506c0df28fea1e5"
+pkg_shasum="2f265d27b40fcba5ccf6c56c4c38fb224e24e4155a0bea65ee681a7e20f7c215"
 pkg_build_deps=()
 pkg_deps=(
   core/bash-static


### PR DESCRIPTION
Updated pkg_version "3.6.2" -> "3.7.0" in support of 2021 Q2 core plans refresh