### PR TITLE
Fixing "default variable check" if sourcing Parent Plan

### DIFF
--- a/bin/ci/check-default-variables.sh
+++ b/bin/ci/check-default-variables.sh
@@ -16,12 +16,13 @@ required_variables=(
 )
 
 plan_path="$1"
+source "${plan_path}"/plan.sh
 
 retval=0
 
 echo "--- :open_book: [$plan_path] Checking for default variables"
 for var in "${required_variables[@]}"; do
-  if ! grep -Eq "^$var" "$plan_path/plan.sh"; then
+  if [ -z "${!var}" ]; then
     echo "    Unable to find '$var' in $*"
     retval=1
   fi


### PR DESCRIPTION
Plans such as [ffmpeg3](https://github.com/habitat-sh/core-plans/blob/e03f37dacf3d2da5891298422a4b3410ff9e4aa3/ffmpeg3/plan.sh) that source [a parent plan which defines the default variables](https://github.com/habitat-sh/core-plans/blob/master/ffmpeg/plan.sh#L4-L8) and omit inherited variables will result in a correct `MANIFEST` in the hart:
```
# cat MANIFEST
# core / ffmpeg3
A complete, cross-platform solution to record, convert and stream audio and video.

* __Maintainer__: The Habitat Maintainers <humans@habitat.sh>
* __Version__: 3.4.8
* __Release__: 20210819153846
* __Target__: x86_64-linux
* __Upstream URL__: [https://ffmpeg.org/](https://ffmpeg.org/)
* __License__: LGPL-2.1-or-later GPL-2.0-or-later
* __Source__: [https://ffmpeg.org/releases/ffmpeg-3.4.8.tar.gz](https://ffmpeg.org/releases/ffmpeg-3.4.8.tar.gz)
* __SHA__: `839af372d8e52b1998aa67a433615e7607519107367af89a2714fa56f53d3d70`
* __Path__: `/hab/pkgs/core/ffmpeg3/3.4.8/20210819153846`
* __Build Dependencies__: `core/diffutils core/expat core/gcc core/libpng core/libtasn1 core/make core/nettle core/p11-kit core/pkg-config core/yasm `
* __Dependencies__: `core/bzip2 core/fontconfig core/freetype core/glibc core/gnutls core/gmp core/libxext core/libdrm core/libwebp core/libxcb core/libxml2 core/openjpeg core/xz core/zlib core/avisynthplus core/libidn2 core/patch `
* __Interpreters__: no interpreters or undefined
...
```
but will fail the [current ci check](https://buildkite.com/chef-oss/habitat-sh-core-plans-master-verify/builds/4699#8cb68b64-19ee-4566-8b47-19edbf80849b/97). The CI can be modified to check the _value_ of the variable instead of grep'ing for it's existence, allowing these to be omitted from the plan when pulled from the parent:
```
bin/ci/check-default-variables.sh ffmpeg3
--- :open_book: [ffmpeg3] Checking for default variables
--- :closed_book: [ffmpeg3] Found all default variables
```