### PR TITLE
Add LZMA support to the python package

### DIFF
--- a/.deprecated/python/plan.sh
+++ b/.deprecated/python/plan.sh
@@ -27,6 +27,7 @@ pkg_deps=(
   core/openssl
   core/readline
   core/sqlite
+  core/xz
   core/zlib
 )
 


### PR DESCRIPTION
This activates the `lzma` [module](https://docs.python.org/3/library/lzma.html) of python, for python programs that need it (in my case, it was [deluge](https://www.deluge-torrent.org).