### PR TITLE
This will source the cacerts directories for ca certs; previous patch

### DIFF
--- a/openssl11/ca-dir.patch
+++ b/openssl11/ca-dir.patch
@@ -1,0 +1,68 @@
+diff --git a/apps/CA.pl.in b/apps/CA.pl.in
+index 7277eeca96..a1504cc53c 100644
+--- a/apps/CA.pl.in
++++ b/apps/CA.pl.in
+@@ -33,7 +33,7 @@ my $X509 = "$openssl x509";
+ my $PKCS12 = "$openssl pkcs12";
+ 
+ # default openssl.cnf file has setup as per the following
+-my $CATOP = "./demoCA";
++my $CATOP = "@cacerts_prefix@/ssl/certs";
+ my $CAKEY = "cakey.pem";
+ my $CAREQ = "careq.pem";
+ my $CACERT = "cacert.pem";
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index b3e7444e5f..9815655db9 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -15,7 +15,7 @@ oid_section		= new_oids
+ # To use this configuration file with the "-extfile" option of the
+ # "openssl x509" utility, name here the section containing the
+ # X.509v3 extensions to use:
+-# extensions		= 
++# extensions		=
+ # (Alternatively, use a configuration file that has only
+ # X.509v3 extensions in its main [= default] section.)
+ 
+@@ -39,7 +39,7 @@ default_ca	= CA_default		# The default ca section
+ ####################################################################
+ [ CA_default ]
+ 
+-dir		= ./demoCA		# Where everything is kept
++dir             = @cacerts_prefix@/ssl          # Where everything is kept
+ certs		= $dir/certs		# Where the issued certs are kept
+ crl_dir		= $dir/crl		# Where the issued crl are kept
+ database	= $dir/index.txt	# database index file.
+@@ -47,7 +47,7 @@ database	= $dir/index.txt	# database index file.
+ 					# several certs with same subject.
+ new_certs_dir	= $dir/newcerts		# default place for new certs.
+ 
+-certificate	= $dir/cacert.pem 	# The CA certificate
++certificate     = $certs/cacert.pem       # The CA certificate
+ serial		= $dir/serial 		# The current serial number
+ crlnumber	= $dir/crlnumber	# the current crl number
+ 					# must be commented out to leave a V1 CRL
+@@ -113,7 +113,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+ # input_password = secret
+ # output_password = secret
+ 
+-# This sets a mask for permitted string types. There are several options. 
++# This sets a mask for permitted string types. There are several options.
+ # default: PrintableString, T61String, BMPString.
+ # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+ # utf8only: only UTF8Strings (PKIX recommendation after 2004).
+diff --git a/crypto/include/internal/cryptlib.h b/crypto/include/internal/cryptlib.h
+index d42a134bdf..32094e1780 100644
+--- a/crypto/include/internal/cryptlib.h
++++ b/crypto/include/internal/cryptlib.h
+@@ -41,8 +41,8 @@ DEFINE_LHASH_OF(MEM);
+ 
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+-#  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_DIR           "@cacerts_prefix@/ssl"
++#  define X509_CERT_FILE          X509_CERT_DIR "/cert.pem"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/openssl11/ca-dir.patch
+++ b/openssl11/ca-dir.patch
@@ -15,15 +15,6 @@ diff --git a/apps/openssl.cnf b/apps/openssl.cnf
 index b3e7444e5f..9815655db9 100644
 --- a/apps/openssl.cnf
 +++ b/apps/openssl.cnf
-@@ -15,7 +15,7 @@ oid_section		= new_oids
- # To use this configuration file with the "-extfile" option of the
- # "openssl x509" utility, name here the section containing the
- # X.509v3 extensions to use:
--# extensions		= 
-+# extensions		=
- # (Alternatively, use a configuration file that has only
- # X.509v3 extensions in its main [= default] section.)
- 
 @@ -39,7 +39,7 @@ default_ca	= CA_default		# The default ca section
  ####################################################################
  [ CA_default ]
@@ -42,19 +33,10 @@ index b3e7444e5f..9815655db9 100644
  serial		= $dir/serial 		# The current serial number
  crlnumber	= $dir/crlnumber	# the current crl number
  					# must be commented out to leave a V1 CRL
-@@ -113,7 +113,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
- # input_password = secret
- # output_password = secret
- 
--# This sets a mask for permitted string types. There are several options. 
-+# This sets a mask for permitted string types. There are several options.
- # default: PrintableString, T61String, BMPString.
- # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
- # utf8only: only UTF8Strings (PKIX recommendation after 2004).
-diff --git a/crypto/include/internal/cryptlib.h b/crypto/include/internal/cryptlib.h
+diff --git a/include/internal/cryptlib.h b/include/internal/cryptlib.h
 index d42a134bdf..32094e1780 100644
---- a/crypto/include/internal/cryptlib.h
-+++ b/crypto/include/internal/cryptlib.h
+--- a/include/internal/cryptlib.h
++++ b/include/internal/cryptlib.h
 @@ -41,8 +41,8 @@ DEFINE_LHASH_OF(MEM);
  
  # ifndef OPENSSL_SYS_VMS

--- a/openssl11/plan.sh
+++ b/openssl11/plan.sh
@@ -38,6 +38,12 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 
 _common_prepare() {
   do_default_prepare
+  # Set CA dir to `$pkg_prefix/ssl` by default and use the cacerts from the
+  # `cacerts` package. Note that `patch(1)` is making backups because
+  # we need an original for the test suite.
+  sed -e "s,@cacerts_prefix@,$(pkg_path_for cacerts),g" \
+      "$PLAN_CONTEXT/ca-dir.patch" \
+      | patch -p1 --backup
 
   # The openssl build process hard codes /bin/rm in many places.
   if [[ ! -f "/bin/rm" ]]; then
@@ -66,7 +72,7 @@ do_build() {
     shared \
     disable-gost \
     --prefix="${pkg_prefix}" \
-    --openssldir=ssl \
+    --openssldir="$(pkg_path_for cacerts)/ssl" \
     linux-x86_64 \
 
   make CC= depend

--- a/openssl11/plan.sh
+++ b/openssl11/plan.sh
@@ -41,6 +41,7 @@ _common_prepare() {
   # Set CA dir to `$pkg_prefix/ssl` by default and use the cacerts from the
   # `cacerts` package. Note that `patch(1)` is making backups because
   # we need an original for the test suite.
+  # DO NOT REMOVE
   sed -e "s,@cacerts_prefix@,$(pkg_path_for cacerts),g" \
       "$PLAN_CONTEXT/ca-dir.patch" \
       | patch -p1 --backup

--- a/openssl11/tests/test.bats
+++ b/openssl11/tests/test.bats
@@ -1,6 +1,15 @@
 TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+HAB_PKGS_PATH="/hab/pkgs"
+CORE_CACERTS_IDENT="$(grep 'core/cacerts' "${HAB_PKGS_PATH}/${TEST_PKG_IDENT}/TDEPS")"
+CORE_CACERTS_SSL_PATH="${HAB_PKGS_PATH}/${CORE_CACERTS_IDENT}/ssl"
+
 
 @test "Version matches" {
   result="$(hab pkg exec "${TEST_PKG_IDENT}" openssl version | awk '{print $2}')"
   [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "OPENSSLDIR set to core/cacerts" {
+  result=$(hab pkg exec "${TEST_PKG_IDENT}" openssl version -a | grep 'OPENSSLDIR:' | sed 's/.*\"\(.*\)\"$/\1/' )
+  [ "$result" = "${CORE_CACERTS_SSL_PATH}" ]
 }

--- a/openssl11/tests/test.sh
+++ b/openssl11/tests/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #/ Usage: test.sh <pkg_ident>
 #/
 #/ Example: test.sh origin/package/1.2.3/20181108151533


### PR DESCRIPTION
#3751 - fixes a regression from the removal of the sed

This will source the cacerts directories for ca certs; previous patch left empty directory in openssl pkg path
also added a test to the run.

Signed-off-by: Jeff Stasko <jeff.stasko@progress.com>

prior to openssl11 change - these ssl directories are empty

```bash
hab pkg exec y-me-y/python/3.7.11/20210920224958 python -c "import ssl; print(ssl.get_default_verify_paths())"
DefaultVerifyPaths(cafile=None, capath='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/certs', openssl_cafile_env='SSL_CERT_FILE', openssl_cafile='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/cert.pem', openssl_capath_env='SSL_CERT_DIR', openssl_capath='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/certs')
```

corresponding python package is sourced using this plan file as a template

https://github.com/rsertelon/rsertelon-plans/blob/master/deluge/plan.sh - replacing pkg_deps

```bash
pkg_deps=(
  core/glibc
  core/libffi
  core/openssl
  core/zlib
  rsertelon/libtorrent
  rsertelon/python # Has lzma support
)
```

```bash
pkg_deps=(
  core/cacerts
  core/glibc
  core/libffi
  core/openssl11
  core/zlib
  rsertelon/libtorrent
  y-me-y/python/3.7.11/20210920224958 # Has lzma support
)
```

I added an `attach` to the `do_install` phase prior `python setup.py install` - I get an error stating ssl certificate verify failed

```raw
Installed /hab/pkgs/y-me-y/deluge/2.0.3/20210921200353/lib/python3.7/site-packages/deluge-2.0.3-py3.7.egg
Processing dependencies for deluge==2.0.3
Searching for zope.interface
Reading https://pypi.org/simple/zope.interface/
Download error on https://pypi.org/simple/zope.interface/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1091) -- Some packages may not be found!
Couldn't find index page for 'zope.interface' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.org/simple/
Download error on https://pypi.org/simple/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1091) -- Some packages may not be found!
No local packages or working download links found for zope.interface
error: Could not find suitable distribution for Requirement.parse('zope.interface')
[2] deluge(do_install)> hab pkg exec y-me-y/python/3.7.11/20210920224958 python -c "import ssl; print(ssl.get_default_verify_paths())"
DefaultVerifyPaths(cafile=None, capath='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/certs', openssl_cafile_env='SSL_CERT_FILE', openssl_cafile='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/cert.pem', openssl_capath_env='SSL_CERT_DIR', openssl_capath='/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/certs')
[3] deluge(do_install)> ls /hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/cert.pem 
ls: cannot access '/hab/pkgs/core/openssl11/1.1.1j/20210826185634/ssl/cert.pem': No such file or directory
[4] deluge(do_install)> 
```

after openssl11 changes 

```bash
hab pkg exec y-me-y/python/3.7.11/20210921192559 python -c "import ssl; print(ssl.get_default_verify_paths())"
DefaultVerifyPaths(cafile='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem', capath='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl', openssl_cafile_env='SSL_CERT_FILE', openssl_cafile='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem', openssl_capath_env='SSL_CERT_DIR', openssl_capath='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl')
```
corresponding python and updated openssl package is sourced using this plan file as a template
https://github.com/rsertelon/rsertelon-plans/blob/master/deluge/plan.sh - replacing pkg_deps

```bash
pkg_deps=(
  core/glibc
  core/libffi
  core/openssl
  core/zlib
  rsertelon/libtorrent
  rsertelon/python # Has lzma support
)
```

```bash
pkg_deps=(
  core/cacerts
  core/glibc
  core/libffi
  core/zlib
  rsertelon/libtorrent
  y-me-y/openssl11/1.1.0l/20210921192013
  y-me-y/python/3.7.11/20210921192559 # Has lzma support
)
```

```raw
Installed /hab/pkgs/y-me-y/deluge/2.0.3/20210921200941/lib/python3.7/site-packages/pycparser-2.20-py3.7.egg
Searching for setuptools==58.0.4
Best match: setuptools 58.0.4
Adding setuptools 58.0.4 to easy-install.pth file

Using /hab/pkgs/y-me-y/deluge/2.0.3/20210921200941/lib/python3.7/site-packages
Finished processing dependencies for deluge==2.0.3
[2] deluge(do_install)> hab pkg exec y-me-y/python/3.7.11/20210921192559 python -c "import ssl; print(ssl.get_default_verify_paths())"
DefaultVerifyPaths(cafile='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem', capath='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl', openssl_cafile_env='SSL_CERT_FILE', openssl_cafile='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem', openssl_capath_env='SSL_CERT_DIR', openssl_capath='/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl')
[3] deluge(do_install)> ls /hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem
/hab/pkgs/core/cacerts/2021.07.05/20210826061343/ssl/cert.pem
[4] deluge(do_install)> 
```