### PR TITLE
R version bump

### DIFF
--- a/R/plan.sh
+++ b/R/plan.sh
@@ -15,6 +15,7 @@ pkg_build_deps=(
   core/perl
   core/pkg-config
   core/texinfo
+  core/which
 )
 pkg_deps=(
   core/bzip2

--- a/R/plan.sh
+++ b/R/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=R
 pkg_origin=core
-pkg_version="3.5.0"
+pkg_version="3.6.3"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-or-later')
 pkg_source="https://cran.r-project.org/src/base/R-3/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="fd1725535e21797d3d9fea8963d99be0ba4c3aecadcf081b43e261458b416870"
+pkg_shasum="89302990d8e8add536e12125ec591d6951022cf8475861b3690bc8bf1cefaa8f"
 pkg_upstream_url="https://www.r-project.org"
 pkg_description="R is a free software environment for statistical computing and graphics."
 pkg_build_deps=(

--- a/R/tests/test.bats
+++ b/R/tests/test.bats
@@ -1,21 +1,21 @@
 expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f 3)"
 @test "R runs" {
-  run hab pkg exec $TEST_PKG_IDENT R --version
+  run hab pkg exec $TEST_PKG_IDENT R -- --version
   [ $status -eq 0 ]
 }
 
 @test "R is expected version $expected_version" {
-  version="$(hab pkg exec $TEST_PKG_IDENT R --version | head -1 | cut -d\  -f3)"
+  version="$(hab pkg exec $TEST_PKG_IDENT R -- --version | head -1 | cut -d\  -f3)"
   [ "$version" = "$expected_version" ]
 }
 
 @test "Rscript runs" {
-  run hab pkg exec $TEST_PKG_IDENT Rscript --version
+  run hab pkg exec $TEST_PKG_IDENT Rscript -- --version
   [ $status -eq 0 ]
 }
 
 @test "Rscript is expected version $expected_version" {
   # Rscript reports version to stderr so 2>&1 is used.
-  actual_version="$(hab pkg exec $TEST_PKG_IDENT Rscript --version 2>&1 | gawk '{ if (match($0,/[0-9]+\.[0-9]+\.[0-9]+/,m)) print m[0] }')"
+  actual_version="$(hab pkg exec $TEST_PKG_IDENT Rscript -- --version 2>&1 | gawk '{ if (match($0,/[0-9]+\.[0-9]+\.[0-9]+/,m)) print m[0] }')"
   [ "$actual_version" = $expected_version ]
 }


### PR DESCRIPTION
Skipped from refresh 2021q2 plan. But we can fix and update outside refresh, and if needed in next refresh cycle
we can continue from here. Hence creating a pull request.