### PR TITLE
[composer] bump version 1.10.20 -> 2.1.9

### DIFF
--- a/composer/plan.sh
+++ b/composer/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=composer
 pkg_origin=core
-pkg_version=1.10.20
+pkg_version=2.1.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_upstream_url=https://getcomposer.org/
 pkg_description="Dependency Manager for PHP"
 pkg_source="https://getcomposer.org/download/${pkg_version}/${pkg_name}.phar"
 pkg_filename="${pkg_name}.phar"
-pkg_shasum=e70b1024c194e07db02275dd26ed511ce620ede45c1e237b3ef51d5f8171348d
+pkg_shasum=4d00b70e146c17d663ad2f9a21ebb4c9d52b021b1ac15f648b4d371c04d648ba
 pkg_deps=(
   core/php
   core/git


### PR DESCRIPTION
Should not be a breaking change for anyone. Packagist has started forcing deprecation of composer 1.x