### PR TITLE
Issue4149 [libksba, libgcrypt and gnupg2 bumped]

### DIFF
--- a/gnupg2/plan.sh
+++ b/gnupg2/plan.sh
@@ -1,13 +1,13 @@
 pkg_distname=gnupg
 pkg_name=gnupg2
 pkg_origin=core
-pkg_version=2.2.27
+pkg_version=2.2.32
 pkg_license=('GPL-3.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP)"
 pkg_upstream_url="https://gnupg.org/"
 pkg_source=https://gnupg.org/ftp/gcrypt/${pkg_distname}/${pkg_distname}-${pkg_version}.tar.bz2
-pkg_shasum=34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399
+pkg_shasum=b2571b35f82c63e7d278aa6a1add0d73453dc14d3f0854be490c844fca7e0614
 pkg_deps=(core/glibc core/zlib core/bzip2 core/readline core/libgpg-error core/libgcrypt core/libassuan core/libksba core/npth)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed core/findutils)
 pkg_bin_dirs=(bin)

--- a/libgcrypt/plan.sh
+++ b/libgcrypt/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=libgcrypt
 pkg_origin=core
-pkg_version=1.9.2
+pkg_version=1.9.4
 pkg_license=('LGPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="ftp://ftp.gnupg.org/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum=b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a
+pkg_shasum=ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7
 pkg_deps=(
   core/glibc
   core/libgpg-error

--- a/libksba/plan.sh
+++ b/libksba/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libksba
 pkg_origin=core
-pkg_version=1.5.1
+pkg_version=1.6.0
 pkg_license=('LGPL-3.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=ftp://ftp.gnupg.org/gcrypt/"${pkg_name}"/"${pkg_name}"-"${pkg_version}".tar.bz2
 pkg_upstream_url="https://www.gnupg.org/software/libksba/index.html"
 pkg_description="Libksba is a library to make the tasks of working with X.509 certificates, CMS data and related objects more easy."
-pkg_shasum=b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921
+pkg_shasum=dad683e6f2d915d880aa4bed5cea9a115690b8935b78a1bbe01669189307a48b
 pkg_deps=(
   core/glibc
   core/libgpg-error


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4149

libksba bumped from 1.5.1 to 1.6.0
libgcrypt bumped from 1.9.2 to 1.9.4
gnupg2 bumped from 2.2.27 to 2.2.32 