### PR TITLE
restic bumped from 0.12.0 to 0.12.1

### DIFF
--- a/restic/plan.sh
+++ b/restic/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=restic
 pkg_origin=core
-pkg_version="0.12.0"
+pkg_version="0.12.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("BSD-2-Clause")
 pkg_source="https://github.com/restic/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="39b615a36a5082209a049cce188f0654c6435f0bc4178b7663672334594f10fe"
+pkg_shasum="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb"
 pkg_build_deps=(
   core/go
 )


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4095
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>