### PR TITLE
Issue4100 [packer and pax-utils bumped]

### DIFF
--- a/packer/plan.sh
+++ b/packer/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=packer
 pkg_origin=core
-pkg_version=1.7.0
+pkg_version=1.7.8
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MPL2')
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=935e81c07381a964bdbaddde2d890c91d52e88b9e5375f3882840925f6a96893
+pkg_shasum=8a94b84542d21b8785847f4cccc8a6da4c7be5e16d4b1a2d0a5f7ec5532faec0
 pkg_description="Packer is a tool for creating machine and container images for multiple platforms from a single source configuration."
 pkg_upstream_url=https://packer.io
 pkg_build_deps=(core/unzip)

--- a/pax-utils/plan.sh
+++ b/pax-utils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=pax-utils
-pkg_version=1.3.2
+pkg_version=1.3.3
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL')
@@ -7,7 +7,7 @@ pkg_description="ELF related utils for ELF 32/64 binaries that can check files
   for security relevant properties"
 pkg_upstream_url='http://hardened.gentoo.org/pax-utils.xml'
 pkg_source="http://distfiles.gentoo.org/distfiles/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="02eba0c305ad349ad6ff1f30edae793061ce95680fd5bdee0e14caf731dee1e7"
+pkg_shasum="eeca7fbd98bc66bead4a77000c2025d9f17ea8201b84245882406ce00b9b6b14"
 pkg_deps=(
   core/bash
   core/glibc


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4100

packer bumped from 1.7.0 to 1.7.8
pax-utils bumped from 1.3.2 to 1.3.3