### PR TITLE
Issue4101 [openssl11, openldap, opa and oniguruma bumped]

### DIFF
--- a/oniguruma/plan.sh
+++ b/oniguruma/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=oniguruma
 pkg_origin=core
-pkg_version=6.9.6
+pkg_version=6.9.7.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Oniguruma is a modern and flexible regular expressions library"
 pkg_upstream_url="https://github.com/kkos/oniguruma"
 pkg_license=("BSD-2-Clause")
 pkg_source="https://github.com/kkos/oniguruma/archive/v${pkg_version}.tar.gz"
-pkg_shasum=aec9f6902ad8b7bb53b2c55d04686ea75da89a06694836b0362cb206578dfe89
+pkg_shasum=8f9a75b7d90dde0942c30a8b3c17889b2fecf190690988cc381c4e525cbbd22b
 pkg_deps=(
   core/glibc
   core/coreutils

--- a/opa/plan.sh
+++ b/opa/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=opa
 pkg_description="Open Policy Agent (OPA) is a lightweight general-purpose policy engine that can be co-located with your service."
 pkg_origin=core
-pkg_version="0.27.1"
+pkg_version="0.34.2"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/open-policy-agent/opa/archive/v${pkg_version}.tar.gz"
@@ -19,7 +19,7 @@ pkg_build_deps=(
 pkg_deps=(
     core/gcc
 )
-pkg_shasum=d1f3cee2261adc83df54fba2d62b045549d064ac14b7683031ec3897c2bdbd44
+pkg_shasum=99799081fb227ef79255c04b8c49d299bfd57c277105092e406d7be3331c1581
 
 do_prepare() {
   sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" -i build/*.sh

--- a/openldap/plan.sh
+++ b/openldap/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=openldap
-pkg_version=2.4.58
+pkg_version=2.6.0
 pkg_description="Community developed LDAP software"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("OLDAP-2.8")
 pkg_upstream_url=http://www.openldap.org/
 pkg_source=https://www.openldap.org/software/download/OpenLDAP/${pkg_name}-release/${pkg_name}-${pkg_version}.tgz
-pkg_shasum=57b59254be15d0bf6a9ab3d514c1c05777b02123291533134a87c94468f8f47b
-pkg_deps=(core/glibc core/libtool core/db core/openssl core/cyrus-sasl)
+pkg_shasum=b71c580eac573e9aba15d95f33dd4dd08f2ed4f0d7fc09e08ad4be7ed1e41a4f
+pkg_deps=(core/glibc core/libtool core/db core/openssl11 core/cyrus-sasl)
 pkg_build_deps=(core/gcc core/make core/groff)
 pkg_bin_dirs=(bin sbin libexec)
 pkg_include_dirs=(include)

--- a/openssl11/plan.sh
+++ b/openssl11/plan.sh
@@ -2,7 +2,7 @@ pkg_name=openssl11
 _distname=openssl
 pkg_origin=core
 _version=1.1.1
-_revision=j
+_revision=k
 pkg_version="${_version}${_revision}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
@@ -14,7 +14,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://www.openssl.org/source/old/${_version}/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum="aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf"
+pkg_shasum="892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
opensll11 bumped from 1.1.1j to 1.1.1k
openldap bumped from 2.4.58 to 2.6.0 and requires openssl11 to build
opa bumped from 0.27.1 to 0.34.2
oniguruma bumped from 6.9.6 to 6.9.7.1