### PR TITLE
Issue 4104: [ncdu and netcat-openbsd bumped]

### DIFF
--- a/ncdu/plan.sh
+++ b/ncdu/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ncdu
 pkg_origin=core
-pkg_version=1.15
+pkg_version=1.16
 pkg_license=('MIT')
 pkg_description="Ncdu is a disk usage analyzer with an ncurses interface"
 pkg_upstream_url=https://dev.yorhel.nl/ncdu
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://dev.yorhel.nl/download/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=4a593dc5cceb2492a9669f5f5d69d0e517de457a11036788ea4591f33c5297fb
+pkg_shasum=2b915752a183fae014b5e5b1f0a135b4b408de7488c716e325217c2513980fd4
 pkg_deps=(core/glibc core/ncurses)
 pkg_build_deps=(core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)

--- a/netcat-openbsd/plan.sh
+++ b/netcat-openbsd/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=netcat-openbsd
 pkg_origin=core
-pkg_version=1.217
+pkg_version=1.218
 pkg_description="TCP/IP swiss army knife, OpenBSD variant"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url=https://tracker.debian.org/pkg/netcat
 pkg_license=('BSD-3-Clause')
 pkg_source=http://ftp.debian.org/debian/pool/main/n/${pkg_name}/${pkg_name}_${pkg_version}.orig.tar.gz
-pkg_shasum=fcb551d9987fd51d020c62b6d81df0c2bb17ce1887bbc3fda4d28313791cc0f5
+pkg_shasum=a28a5d39abaf481747b1e78b4b50e96d0cdab0ffef289cba156dc11941c64857
 pkg_deps=(core/glibc core/libbsd)
 pkg_build_deps=(
   core/gcc
@@ -21,7 +21,7 @@ do_download() {
 
   # Download patches to apply on top of the BSD code
   build_line "Downloading patches series file..."
-  local patch_base_url=https://sources.debian.net/data/main/n/${pkg_name}/${pkg_version}-3/debian/patches
+  local patch_base_url=https://sources.debian.net/data/main/n/${pkg_name}/${pkg_version}-2/debian/patches
 
   download_file $patch_base_url/series series
 


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4104
ncdu from 1.15 to 1.16
netcat-openbsd from 1.217 to 1.218
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>