### PR TITLE
Issue 4105 [monit, mono5 and nats-streaming-server bumped]

### DIFF
--- a/monit/plan.sh
+++ b/monit/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=monit
 pkg_origin=core
-pkg_version="5.27.2"
+pkg_version="5.29.0"
 pkg_upstream_url="https://mmonit.com/monit"
 pkg_description="Monit. Barking at daemons"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('AGPL-3.0')
 pkg_source="https://mmonit.com/monit/dist/monit-${pkg_version}.tar.gz"
-pkg_shasum="d8809c78d5dc1ed7a7ba32a5a55c5114855132cc4da4805f8d3aaf8cf46eaa4c"
+pkg_shasum="f665e6dd1f26a74b5682899a877934167de2b2582e048652ecf036318477885f"
 pkg_deps=(
   core/bash
   core/glibc

--- a/mono5/plan.sh
+++ b/mono5/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=mono5
 pkg_origin=core
-pkg_version="5.10.1.47"
+pkg_version="5.20.1.34"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Microsoft-Patent-Promise-for-Mono')
 pkg_description="Mono 5.x open source ECMA CLI, C# and .NET implementation."
@@ -8,7 +8,7 @@ pkg_upstream_url="https://www.mono-project.com"
 pkg_dirname="mono-${pkg_version}"
 pkg_filename="${pkg_dirname}.tar.bz2"
 pkg_source="https://download.mono-project.com/sources/mono/${pkg_filename}"
-pkg_shasum="90c237b5288f95f6fdab4ace1e36ab64a6369e2c9fddd462d604fd788e2545da"
+pkg_shasum="cd91d44cf62515796ba90dfdc274bb33471c25a2f1a262689a3bdc0a672b7c8b"
 pkg_deps=(
   core/gcc-libs
   core/glibc
@@ -36,4 +36,11 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 
 do_prepare() {
   export with_gnu_ld="yes"
+}
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-minimal=aot
+    make
 }

--- a/nats-streaming-server/plan.sh
+++ b/nats-streaming-server/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nats-streaming-server
 pkg_origin=core
-pkg_version=0.21.1
+pkg_version=0.23.1
 pkg_description="NATS Streaming is an extremely performant, lightweight reliable streaming platform built on NATS."
 pkg_upstream_url=https://github.com/nats-io/nats-streaming-server
 pkg_license=('MIT')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://github.com/nats-io/nats-streaming-server/archive/v${pkg_version}.tar.gz
-pkg_shasum=69dc0d80d4e494f63b8110cfbd779c3c58f4e4af2c27eb87b8cc8599e43859c9
+pkg_shasum=bf25c099239f1d43a316d63d79f552dbd86f1b23bcb8e647d11d07d231be5dfd
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/go core/coreutils core/gcc core/make)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4105
monit from 5.27.2 to 5.29.0 and 
mono5 from 5.10.1.47 to 5.20.1.34 and
nats-streaming-server from 0.21.1 to 0.23.1 bumped

Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>