### PR TITLE
Issue 4107 [libzip and userspace-rcu bumped]

### DIFF
--- a/libzip/plan.sh
+++ b/libzip/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libzip
 pkg_origin=core
-pkg_version=1.7.3
+pkg_version=1.8.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A C library for reading, creating, and modifying zip archives"
 pkg_upstream_url="https://libzip.org/"
 pkg_license=('BSD-3-Clause')
 pkg_source="${pkg_upstream_url}/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc
+pkg_shasum=30ee55868c0a698d3c600492f2bea4eb62c53849bcf696d21af5eb65f3f3839e
 pkg_deps=(
   core/bzip2-musl
   core/openssl

--- a/userspace-rcu/plan.sh
+++ b/userspace-rcu/plan.sh
@@ -1,6 +1,6 @@
 pkg_origin=core
 pkg_name=userspace-rcu
-pkg_version=0.12.2
+pkg_version=0.13.0
 pkg_description="liburcu is a LGPLv2.1 userspace RCU (read-copy-update) library.
   This data synchronization library provides read-side access which scales
   linearly with the number of cores."
@@ -8,7 +8,7 @@ pkg_upstream_url=http://liburcu.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-2.1')
 pkg_source=http://www.lttng.org/files/urcu/$pkg_name-$pkg_version.tar.bz2
-pkg_shasum=4eefc11e4f6c212fc7d84d871e1cc139da0669a46ff3fda557a6fdd4d74ca67b
+pkg_shasum=cbb20dbe1a892c2a4d8898bac4316176e585392693d498766ccbbc68cf20ba20
 pkg_deps=(
   core/gcc-libs
   core/glibc


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4107
libzip from 1.7.3 to 1.8.0 bumped 
userspace-rcu from 0.12.3 to 0.13.0 bumped
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>