### PR TITLE
Issue 4108 [libssh2 and libtalloc bumped]

### DIFF
--- a/libssh2/plan.sh
+++ b/libssh2/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libssh2
 pkg_origin=core
-pkg_version=1.9.0
+pkg_version=1.10.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="libssh2 is a client-side C library implementing the SSH2 protocol"
 pkg_upstream_url="https://libssh2.org/"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://libssh2.org/download/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
+pkg_shasum="2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 pkg_deps=(
   core/glibc
   core/openssl

--- a/libtalloc/plan.sh
+++ b/libtalloc/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libtalloc
 pkg_origin=core
-pkg_version="2.3.2"
+pkg_version="2.3.3"
 pkg_upstream_url=https://talloc.samba.org
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Talloc is a hierarchical, reference counted memory pool system with destructors. It is the core memory allocator used in Samba."
 pkg_license=("GPL-3.0")
 pkg_source="https://www.samba.org/ftp/talloc/talloc-${pkg_version}.tar.gz"
 pkg_dirname="talloc-${pkg_version}"
-pkg_shasum="27a03ef99e384d779124df755deb229cd1761f945eca6d200e8cfd9bf5297bd7"
+pkg_shasum="6be95b2368bd0af1c4cd7a88146eb6ceea18e46c3ffc9330bf6262b40d1d8aaa"
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4108
libssh2 from 1.9.0 to 1.10.0
libtalloc from 2.3.2 to 2.3.3 bumped
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>