### PR TITLE
Issue 4109 [libpcap and libpq bumped]

### DIFF
--- a/libpcap/plan.sh
+++ b/libpcap/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libpcap
 pkg_origin=core
-pkg_version=1.10.0
+pkg_version=1.10.1
 pkg_description="A portable C/C++ library for network traffic capture."
 pkg_upstream_url="http://www.tcpdump.org/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="http://www.tcpdump.org/release/libpcap-${pkg_version}.tar.gz"
-pkg_shasum=8d12b42623eeefee872f123bd0dc85d535b00df4d42e865f993c40f7bfc92b1e
+pkg_shasum=ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/flex core/bison core/m4)
 pkg_include_dirs=(include)

--- a/libpq/plan.sh
+++ b/libpq/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=libpq
 pkg_origin=core
-pkg_version=9.6.21
+pkg_version=9.6.24
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="LibPQ is the client side library for PostgreSQL, a powerful, open source object-relational database system."
 pkg_upstream_url="https://www.postgresql.org/"
 pkg_license=('PostgreSQL')
 pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/postgresql-${pkg_version}.tar.bz2"
 pkg_dirname="postgresql-${pkg_version}"
-pkg_shasum="930feaef28885c97ec40c26ab6221903751eeb625de92b22602706d7d47d1634"
+pkg_shasum="aeb7a196be3ebed1a7476ef565f39722187c108dd47da7489be9c4fcae982ace"
 
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4109
libpcap from 1.10.0 to 1.10.1
libpq from 9.6.21 to 9.6.24
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>