### PR TITLE
Issue 4113 [jfrog-cli and kmod bumped]

### DIFF
--- a/jfrog-cli/plan.sh
+++ b/jfrog-cli/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=jfrog-cli
 pkg_description="jfrog CLI"
 pkg_origin=core
-pkg_version=1.43.2
+pkg_version=1.52.0
 pkg_license=('apachev2')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=https://jfrog.bintray.com/jfrog-cli-go/${pkg_version}/jfrog-cli-linux-amd64/jfrog
-pkg_shasum=cb53b4e733cc67614ea2b2e06c87503b76c157fbc6860fdde40f7b6a80f5891f
+pkg_source=https://github.com/jfrog/jfrog-cli/archive/refs/tags/v${pkg_version}.tar.gz
+pkg_shasum=05f822723f8d31b15d4a3acfdfa51757d69a41ef109cf61f98a2ab0041412396
 pkg_deps=(core/glibc core/busybox-static core/cacerts)
 pkg_build_deps=(core/coreutils)
 pkg_bin_dirs=(bin)

--- a/kmod/plan.sh
+++ b/kmod/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=kmod
 pkg_origin=core
-pkg_version="28"
+pkg_version="29"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-2.1')
 pkg_source="https://www.kernel.org/pub/linux/utils/kernel/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum="3969fc0f13daa98084256337081c442f8749310089e48aa695c9b4dfe1b3a26c"
+pkg_shasum="0b80eea7aa184ac6fd20cafa2a1fdf290ffecc70869a797079e2cc5c6225a52a"
 pkg_deps=(core/glibc core/xz core/zlib)
 pkg_build_deps=(core/make core/gcc core/pkg-config core/file core/sed core/diffutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4113
jfrog-cli from 1.43.2 to 1.52.0
kmod from 28 to 29
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>