### PR TITLE
Issue4120 [gifsicle bumped from 1.92 to 1.93]

### DIFF
--- a/gifsicle/plan.sh
+++ b/gifsicle/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=gifsicle
 pkg_origin=core
-pkg_version=1.92
+pkg_version=1.93
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-only')
 pkg_description="Gifsicle is a command-line tool for creating, editing, and getting information about GIF images and animations."
 pkg_upstream_url="https://www.lcdf.org/gifsicle/"
 pkg_source="https://www.lcdf.org/gifsicle/gifsicle-${pkg_version}.tar.gz"
-pkg_shasum=5ab556c01d65fddf980749e3ccf50b7fd40de738b6df679999294cc5fabfce65
+pkg_shasum=92f67079732bf4c1da087e6ae0905205846e5ac777ba5caa66d12a73aa943447
 pkg_bin_dirs=(bin)
 pkg_deps=(
   core/zlib


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4120
gifsicle bumped from 1.92 to 1.93
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>