### PR TITLE
[Habitat Packages Version Tracker] - meson version bump

### DIFF
--- a/meson/plan.sh
+++ b/meson/plan.sh
@@ -6,7 +6,7 @@ pkg_upstream_url="http://mesonbuild.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/mesonbuild/${pkg_name}/archive/${pkg_version}.tar.gz"
-pkg_shasum=0c043c9b5350e9087cd4f6becf6c0d10b1d618ca3f919e0dcca2cdf342360d5d
+pkg_shasum=b06f7d621b90e094be0ea2157fa435648e069f19182d8d9402aa039727652b0c
 pkg_deps=(
   # https://github.com/mesonbuild/meson/issues/7999
   # Doesn't seem to work against 3.9


### PR DESCRIPTION
Bumping package version from 0.57.1 to 0.60.1