### PR TITLE
Issue 4123: [fish from 2.7.0 to 2.7.1  & filebeat from 7.12.0 to 7.15.2 bumped]

### DIFF
--- a/filebeat/plan.sh
+++ b/filebeat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=filebeat
 pkg_origin=core
-pkg_version=7.12.0
+pkg_version=7.15.2
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/glibc)

--- a/fish/plan.sh
+++ b/fish/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=fish
 pkg_origin=core
-pkg_version="2.7.0"
+pkg_version="2.7.1"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'LGPL-2.0' 'ISC' 'BSD-2-Clause-NetBSD' 'BSD-3-Clause')
 pkg_source="https://github.com/fish-shell/fish-shell/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=3a76b7cae92f9f88863c35c832d2427fb66082f98e92a02203dc900b8fa87bcb
+pkg_shasum=e42bb19c7586356905a58578190be792df960fa81de35effb1ca5a5a981f0c5a
 pkg_deps=(
   core/bc
   core/coreutils


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4123
fish from 2.7.0 to 2.7.1
filebeat from 7.12.0 to 7.15.2
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>