### PR TITLE
Issue4127 [dpkg to 1.20.9, e2fsprogs to 1.46.4 and lttng-ust to 2.13.0 bumped]

### DIFF
--- a/dpkg/plan.sh
+++ b/dpkg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=dpkg
 pkg_origin=core
-pkg_version=1.19.7
+pkg_version=1.20.9
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0-or-later')
 pkg_upstream_url="https://wiki.debian.org/dpkg"
 pkg_description="dpkg is a package manager for Debian-based systems"
 pkg_source="http://http.debian.net/debian/pool/main/d/${pkg_name}/${pkg_name}_${pkg_version}.tar.xz"
-pkg_shasum="4c27fededf620c0aa522fff1a48577ba08144445341257502e7730f2b1a296e8"
+pkg_shasum="5ce242830f213b5620f08e6c4183adb1ef4dc9da28d31988a27c87c71fe534ce"
 pkg_deps=(
   core/bzip2
   core/glibc

--- a/e2fsprogs/plan.sh
+++ b/e2fsprogs/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=e2fsprogs
 pkg_origin=core
-pkg_version=1.46.2
+pkg_version=1.46.4
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Ext2/3/4 filesystem userspace utilities"
 pkg_license=('GPL-2.0')
 pkg_upstream_url="http://e2fsprogs.sourceforge.net/"
 pkg_source="https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-${pkg_version}.tar.gz"
-pkg_shasum=f1ef0161aa8918182d088c4b576a5485a60aa3aff3e16cf10824698af5d34dcf
+pkg_shasum=c011bf3bf4ae5efe9fa2b0e9b0da0c14ef4b79c6143c1ae6d9f027931ec7abe1
 pkg_deps=(
   core/glibc
 )

--- a/lttng-ust/plan.sh
+++ b/lttng-ust/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=lttng-ust
-pkg_version=2.12.1
+pkg_version=2.13.0
 pkg_description="LTTng is an open source tracing framework for Linux."
 pkg_upstream_url=http://lttng.org/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0' 'MIT')
 pkg_source=$pkg_upstream_url/files/$pkg_name/$pkg_name-$pkg_version.tar.bz2
-pkg_shasum=48a3948b168195123a749d22818809bd25127bb5f1a66458c3c012b210d2a051
+pkg_shasum=54e4c933679cf6a07971dc5861ce57fc4876ab740ab612407b30b5fc85371750
 pkg_deps=(
   core/coreutils
   core/gcc-libs
@@ -14,6 +14,7 @@ pkg_deps=(
   core/numactl
   core/python2
   core/userspace-rcu
+  core/pkg-config
 )
 pkg_build_deps=(
   core/gcc


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4127
dpkg from 1.19.7 to 1.20.9
e2fsprogs from 1.46.2 to to 1.46.4
lttng-ust from 2.12.1 to 2.13.0
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>