### PR TITLE
Issue4131 [curator to 5.8.4, curl-static-musl to 7.80.0 and valgrind to 3.18.1 bumped]

### DIFF
--- a/curator/plan.sh
+++ b/curator/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=curator
 pkg_origin=core
-pkg_version=5.8.3
+pkg_version=5.8.4
 pkg_description="Elasticsearch Curator helps you curate, or manage your indices."
 pkg_upstream_url=https://github.com/elastic/curator
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"

--- a/curl-static-musl/plan.sh
+++ b/curl-static-musl/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=curl-static-musl
 pkg_distname=curl
 pkg_origin=core
-pkg_version=7.75.0
+pkg_version=7.80.0
 pkg_description="curl is an open source command line tool and library for
   transferring data with URL syntax."
 pkg_upstream_url=https://curl.haxx.se/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('curl')
 pkg_source="https://curl.haxx.se/download/${pkg_distname}-${pkg_version}.tar.gz"
-pkg_shasum=4d51346fe621624c3e4b9f86a8fd6f122a143820e17889f59c18f245d2d8e7a6
+pkg_shasum=dab997c9b08cb4a636a03f2f7f985eaba33279c1c52692430018fae4a4878dc7
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(
   core/cacerts

--- a/valgrind/plan.sh
+++ b/valgrind/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=valgrind
 pkg_origin=core
-pkg_version=3.17.0
+pkg_version=3.18.1
 pkg_description="An instrumentation framework for building dynamic analysis tools"
 pkg_upstream_url="http://www.valgrind.org/"
 pkg_license=('GPL-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://sourceware.org/pub/valgrind/valgrind-${pkg_version}.tar.bz2"
-pkg_shasum=ad3aec668e813e40f238995f60796d9590eee64a16dff88421430630e69285a2
+pkg_shasum=00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5
 pkg_deps=(core/glibc)
 pkg_build_deps=(core/gcc core/make core/which core/diffutils core/perl)
 pkg_include_dirs=(include)


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4131

curator from 5.8.3 to 5.8.4
curl-static-musl from 7.75.0 to 7.80.0
valgrind from 3.17.0 to 3.18.1

Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>