### PR TITLE
Issue4133 [consul to 1.10.4 and coreutils-static to 9.0 bumped]

### DIFF
--- a/consul/plan.sh
+++ b/consul/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=consul
-pkg_version=1.9.4
+pkg_version=1.10.4
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")
 pkg_description="Consul is a tool for service discovery, monitoring and configuration."
 pkg_upstream_url=https://www.consul.io/
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=da3919197ef33c4205bb7df3cc5992ccaae01d46753a72fe029778d7f52fb610
+pkg_shasum=2be6414cdce1540c022acda76da55ef6bbd51c537dc2e3d4020652e72daec62d
 pkg_filename="${pkg_name}-${pkg_version}_linux_amd64.zip"
 pkg_deps=()
 pkg_build_deps=(core/unzip)

--- a/coreutils-static/plan.sh
+++ b/coreutils-static/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=coreutils-static
 _distname=coreutils
 pkg_origin=core
-pkg_version=8.32
+pkg_version=9.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 The GNU Core Utilities are the basic file, shell and text manipulation \
@@ -11,7 +11,7 @@ expected to exist on every operating system.\
 pkg_upstream_url="https://www.gnu.org/software/coreutils/"
 pkg_license=('GPL-3.0')
 pkg_source="http://ftp.gnu.org/gnu/$_distname/${_distname}-${pkg_version}.tar.xz"
-pkg_shasum="4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa"
+pkg_shasum="ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce"
 pkg_dirname=${_distname}-${pkg_version}
 
 pkg_build_deps=(


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4133
consul from 1.9.4 to 1.10.4 
coreutils-static from 8.32 to 9.0
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>