### PR TITLE
Issue4119 [govc and googlemock bumped]

### DIFF
--- a/googlemock/plan.sh
+++ b/googlemock/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=googlemock
 pkg_origin=core
-pkg_version="1.10.0"
+pkg_version="1.11.0"
 pkg_description="$(cat << EOF
 The Google C++ mocking framework.
 EOF
@@ -8,7 +8,7 @@ EOF
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('bsd-3-clause')
 pkg_source="https://github.com/google/googletest/archive/release-${pkg_version}.tar.gz"
-pkg_shasum=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
+pkg_shasum=b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
 pkg_upstream_url="https://github.com/google/googletest/tree/master/googlemock"
 pkg_dirname="googletest-release-${pkg_version}"
 
@@ -43,7 +43,7 @@ do_build() {
       -Dgtest_build_tests="${DO_CHECK}" \
       -Dgmock_build_tests="${DO_CHECK}" \
       -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-      "../../${GTEST_TARGET}"
+      "../../"
   make
 }
 
@@ -57,7 +57,7 @@ do_install() {
   #make install
   #cd ../.. || exit
 
-  install -Dm644 googlemock/LICENSE "${pkg_prefix}/share/licenses/license.txt"
+  install -Dm644 LICENSE "${pkg_prefix}/share/licenses/license.txt"
 
   mkdir -p "${pkg_prefix}/lib/pkgconfig"
   cat <<EOF > "${pkg_prefix}/lib/pkgconfig/libgmock.pc"

--- a/govc/plan.sh
+++ b/govc/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=govc
 pkg_origin=core
-pkg_version="0.24.1"
+pkg_version="0.27.1"
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("Apache-2.0")
 pkg_description="govc is a vSphere CLI built on top of govmomi."


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4119
govc bumped from 0.24.1 to 0.27.1
googlemock from 1.10.0 to 1.11.0