### PR TITLE
Issue4145 [rebar3 to 3.17.0, postfix to 3.6.3 and pngquant to 2.17.0 bumped]

### DIFF
--- a/pngquant/plan.sh
+++ b/pngquant/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=pngquant
 pkg_origin=core
-pkg_version=2.13.1
+pkg_version=2.17.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-only")
 pkg_description="Lossy PNG compressor"
 pkg_upstream_url="https://pngquant.org"
 pkg_source="http://pngquant.org/pngquant-${pkg_version}-src.tar.gz"
-pkg_shasum=4b911a11aa0c35d364b608c917d13002126185c8c314ba4aa706b62fd6a95a7a
+pkg_shasum=a27cf0e64db499ccb3ddae9b36036e881f78293e46ec27a9e7a86a3802fcda66
 pkg_deps=(
   core/coreutils
   core/libpng

--- a/postfix/plan.sh
+++ b/postfix/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=postfix
 pkg_origin=core
-pkg_version="3.5.9"
+pkg_version="3.6.3"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Postfix is a free and open-source mail transfer agent that routes and delivers electronic mail."
 pkg_upstream_url="http://www.postfix.org/"
 pkg_license=('IPL-1.0')
 pkg_source="http://cdn.postfix.johnriley.me/mirrors/${pkg_name}-release/official/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="51ced5a3165a415beba812b6c9ead0496b7172ac6c3beb654d2ccd9a1b00762b"
+pkg_shasum="0f1241d456a0158e0c418abf62c52c2ff83f8f1dcf2fbdd4c40765b67789b1bc"
 pkg_build_deps=(
   core/make
   core/gcc
@@ -21,7 +21,7 @@ pkg_deps=(
   core/db
   core/glibc
   core/libnsl
-  core/openssl
+  core/openssl11
   core/pcre
   core/zlib
   # plan/hook deps
@@ -38,7 +38,7 @@ do_build() {
     -DHAS_NIS
       -"I$(pkg_path_for core/libnsl)/include"
     -DUSE_TLS
-      -"I$(pkg_path_for core/openssl)/include"
+      -"I$(pkg_path_for core/openssl11)/include"
     -DUSE_SASL_AUTH -DUSE_CYRUS_SASL
       -"I$(pkg_path_for core/cyrus-sasl)/include/sasl"
   )
@@ -52,7 +52,7 @@ do_build() {
     -lresolv
       -"L$(pkg_path_for core/glibc)/lib"
     -lssl -lcrypto
-      -"L$(pkg_path_for core/openssl)/lib"
+      -"L$(pkg_path_for core/openssl11)/lib"
     -lsasl2
       -"L$(pkg_path_for core/cyrus-sasl)/lib"
   )

--- a/rebar3/plan.sh
+++ b/rebar3/plan.sh
@@ -1,12 +1,12 @@
 pkg_origin=core
 pkg_name=rebar3
-pkg_version=3.14.4
+pkg_version=3.17.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/erlang/${pkg_name}/archive/${pkg_version}.tar.gz"
 pkg_description="rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases."
 pkg_upstream_url="https://github.com/rebar/rebar3"
-pkg_shasum=8d78ed53209682899d777ee9443b26b39c9bf96c8b081fe94b3dd6693077cb9a
+pkg_shasum=4c7f33a342bcab498f9bf53cc0ee5b698d9598b8fa9ef6a14bcdf44d21945c27
 pkg_deps=(
   core/erlang
   core/busybox-static


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4145
rebar3 from 3.14.14to 3.17.0, 
postfix from 3.5.9 o 3.6.3 
pngquant from 2.13.1 to 2.17.0
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>