### PR TITLE
Issue 4146[powershell to 7.2.0, netdata to 1.32.0, openresty to 1.19.9.1 and nmap to 7.92 bumped]

### DIFF
--- a/netdata/plan.sh
+++ b/netdata/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=netdata
 pkg_origin=core
-pkg_version=1.29.3
+pkg_version=1.32.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-or-later")
 pkg_description="netdata is a system for distributed real-time performance and health monitoring."
 pkg_upstream_url="https://github.com/netdata/netdata"
 pkg_source="https://github.com/netdata/${pkg_name}/archive/v${pkg_version}.tar.gz"
-pkg_shasum=8e045ea153db99317a95232d1d7a76711bee46f4bc2666d22e268ff03011aa43
+pkg_shasum=9b77f468752778d14ec57cb3b76ad1f2c9bd606b7f9bf47d32ce6df38cd45626
 pkg_build_deps=(
   core/autoconf
   core/autogen
@@ -14,6 +14,7 @@ pkg_build_deps=(
   core/pkg-config
   core/gcc
   core/make
+  core/openssl
 )
 pkg_deps=(
   core/bash

--- a/nmap/plan.sh
+++ b/nmap/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nmap
 pkg_origin=core
-pkg_version=7.91
+pkg_version=7.92
 pkg_description="nmap is a free security scanner for network exploration and security audits"
 pkg_upstream_url="https://nmap.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source="https://nmap.org/dist/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum=18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300
+pkg_shasum=a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/openresty/plan.sh
+++ b/openresty/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=openresty
 pkg_origin=core
-pkg_version=1.19.3.1
+pkg_version=1.19.9.1
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://openresty.org/download/${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=f36fcd9c51f4f9eb8aaab8c7f9e21018d5ce97694315b19cacd6ccf53ab03d5d
+pkg_shasum=576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6
 pkg_deps=(
   core/glibc
   core/gcc-libs

--- a/powershell/plan.sh
+++ b/powershell/plan.sh
@@ -1,12 +1,12 @@
 pkg_name="powershell"
 pkg_origin="core"
-pkg_version="7.1.3"
+pkg_version="7.2.0"
 pkg_license=("MIT")
 pkg_upstream_url="https://msdn.microsoft.com/powershell"
 pkg_description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/PowerShell/PowerShell/releases/download/v$pkg_version/PowerShell-$pkg_version-linux-x64.tar.gz"
-pkg_shasum="9f853fb8f7c7719005bd1054fa13ca4d925c519b893f439dd2574e84503e6a85"
+pkg_shasum="15b67d0571d9891a10e541a1462c906084ab148614dd83c6bbddf90046a815a8"
 pkg_filename="powershell-$pkg_version-linux-x64.tar.gz"
 pkg_bin_dirs=("bin")
 pkg_deps=("core/icu" "core/openssl" "core/glibc" "core/gcc-libs")
@@ -36,8 +36,6 @@ do_install() {
 
   # The linux powersheel distribution symlinks libssl and libcrypto to /lib64
   # We will replace those with symlinks to the openssl hab package
-  rm "$pkg_prefix"/bin/libssl.so.1.0.0
-  rm "$pkg_prefix"/bin/libcrypto.so.1.0.0
   ln -s "$(pkg_path_for openssl)/lib/libssl.so.1.0.0" "$pkg_prefix"/bin/libssl.so.1.0.0
   ln -s "$(pkg_path_for openssl)/lib/libcrypto.so.1.0.0" "$pkg_prefix"/bin/libcrypto.so.1.0.0
 }


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4146
poershell from 7.1.3 to 7.2.0, 
netdata from 1.29.3 to 1.32.0, 
openresty 1.19.3.1 to 1.19.9.1
nmap from 7.91 to 7.92 
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>