### PR TITLE
Issue4175 [ffmpeg, ffmpeg3, ffmpeg4 and drush bumped]

### DIFF
--- a/drush/plan.sh
+++ b/drush/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=drush
 pkg_origin=core
-pkg_version="8"
+pkg_version="8.4.8"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('gplv2+')
 pkg_deps=(core/bash core/coreutils core/php core/which)

--- a/ffmpeg/plan.sh
+++ b/ffmpeg/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=ffmpeg
 pkg_origin=core
-pkg_version=4.3.2
+pkg_version=4.4.1
 pkg_description="A complete, cross-platform solution to record, convert and stream audio and video."
 pkg_upstream_url=https://ffmpeg.org/
 pkg_license=('LGPL-2.1-or-later' 'GPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ffmpeg.org/releases/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=b4701d5d1220cfa2f140090a0ae349cd76dafe335e60227d1e3f8301998634c9
+pkg_shasum=82c98f74777f623710b72f9a3389fd38c1ed93bc661107e65df19234e395f6b9
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)

--- a/ffmpeg3/plan.sh
+++ b/ffmpeg3/plan.sh
@@ -3,13 +3,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../ffmpeg/plan.sh"
 pkg_name=ffmpeg3
 pkg_origin=core
 pkg_distname=ffmpeg
-pkg_version=3.4.8
+pkg_version=3.4.9
 pkg_description="A complete, cross-platform solution to record, convert and stream audio and video."
 pkg_upstream_url=https://ffmpeg.org/
 pkg_license=('LGPL-2.1-or-later' 'GPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ffmpeg.org/releases/${pkg_distname}-${pkg_version}.tar.gz"
-pkg_shasum=839af372d8e52b1998aa67a433615e7607519107367af89a2714fa56f53d3d70
+pkg_shasum=afb2c2f8b97f202d6a9f7633bcb38bdebc3c54c5bad91278c50c4292aaac730f
 pkg_dirname="ffmpeg-$pkg_version"
 
 pkg_deps=(

--- a/ffmpeg4/plan.sh
+++ b/ffmpeg4/plan.sh
@@ -3,13 +3,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../ffmpeg/plan.sh"
 pkg_name=ffmpeg4
 pkg_origin=core
 pkg_distname=ffmpeg
-pkg_version=4.4
+pkg_version=4.4.1
 pkg_description="A complete, cross-platform solution to record, convert and stream audio and video."
 pkg_upstream_url=https://ffmpeg.org/
 pkg_license=('LGPL-2.1-or-later' 'GPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://ffmpeg.org/releases/${pkg_distname}-${pkg_version}.tar.gz"
-pkg_shasum=a4abede145de22eaf233baa1726e38e137f5698d9edd61b5763cd02b883f3c7c
+pkg_shasum=82c98f74777f623710b72f9a3389fd38c1ed93bc661107e65df19234e395f6b9
 pkg_dirname="ffmpeg-${pkg_version}"
 
 pkg_deps=(


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4175
ffmpeg bumped from 4.3.2 to 4.4.1
ffmpeg3 bumped from 3.4.8 to 3.4.9
ffmpeg4 bumped from 4.4 to 4.4.1
Drush from 8 to 8.4.8
