### PR TITLE
Issue 4188 [All Kubernetes components bumped from 1.20.5 to 1.23.0]

### DIFF
--- a/kubernetes-apiserver/plan.sh
+++ b/kubernetes-apiserver/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.20.5
-pkg_deps=("core/kubernetes/1.20.5")
+pkg_version=1.23.0
+pkg_deps=("core/kubernetes/1.23.0")
 
 do_build() {
   return 0

--- a/kubernetes-controller-manager/plan.sh
+++ b/kubernetes-controller-manager/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.20.5
-pkg_deps=("core/kubernetes/1.20.5")
+pkg_version=1.23.0
+pkg_deps=("core/kubernetes/1.23.0")
 
 do_build() {
   return 0

--- a/kubernetes-kubelet/plan.sh
+++ b/kubernetes-kubelet/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.20.5
-pkg_deps=("core/kubernetes/1.20.5")
+pkg_version=1.23.0
+pkg_deps=("core/kubernetes/1.23.0")
 pkg_svc_user="root"
 pkg_svc_group="${pkg_svc_user}"
 

--- a/kubernetes-proxy/plan.sh
+++ b/kubernetes-proxy/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.20.5
-pkg_deps=("core/kubernetes/1.20.5")
+pkg_version=1.23.0
+pkg_deps=("core/kubernetes/1.23.0")
 pkg_svc_user="root"
 pkg_svc_group="${pkg_svc_user}"
 

--- a/kubernetes-scheduler/plan.sh
+++ b/kubernetes-scheduler/plan.sh
@@ -4,8 +4,8 @@ pkg_description="Production-Grade Container Scheduling and Management"
 pkg_upstream_url=https://github.com/kubernetes/kubernetes
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_version=1.20.5
-pkg_deps=("core/kubernetes/1.20.5")
+pkg_version=1.23.0
+pkg_deps=("core/kubernetes/1.23.0")
 
 do_build() {
   return 0

--- a/kubernetes/plan.sh
+++ b/kubernetes/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=kubernetes
 pkg_origin=core
-pkg_version=1.20.5
+pkg_version=1.23.0
 pkg_description="Production-Grade Container Scheduling and Management"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
https://github.com/habitat-sh/core-plans/issues/4188
Kubernetes from 1.20.5 to 1.23.0
Kubernetes-apiserver from 1.20.5 to 1.23.0
Kubernetes-kubelet from 1.20.5 to 1.23.0
Kubernetes-proxy from 1.20.5 to 1.23.0
Kubernetes-scheduler from 1.20.5 to 1.23.0
Kubernetes-controller-manager from 1.20.5 to 1.23.0
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>