### PR TITLE
Issue4172 [wordpress to 4.9.18, tlog to 12 and shellcheck to 0.8.0 bumped]

### DIFF
--- a/shellcheck/plan.sh
+++ b/shellcheck/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=shellcheck
 hkg_name=ShellCheck
 pkg_origin=core
-pkg_version=0.7.1
+pkg_version=0.8.0
 pkg_license=('GPL-3')
 pkg_upstream_url="http://www.shellcheck.net/"
 pkg_description="ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://hackage.haskell.org/package/${hkg_name}-${pkg_version}/${hkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="415f23ed77c17cb6837b328a35b9fa262c7d9b1a9093bc801f50d99010e4a41a"
+pkg_shasum="62080e8a59174b12ecd2d753af3e6b9fed977e6f5f7301cde027a54aee555416"
 pkg_dirname="${hkg_name}-${pkg_version}"
 
 pkg_bin_dirs=(bin)

--- a/tlog/plan.sh
+++ b/tlog/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=tlog
 pkg_origin=core
-pkg_version=11
+pkg_version=12
 pkg_description="Tlog is a terminal I/O recording and playback package suitable for implementing centralized user session recording."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-2.0-or-later")
 pkg_source="https://github.com/Scribery/tlog/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
 pkg_upstream_url="https://github.com/Scribery/tlog"
-pkg_shasum=e22971bb2ee201b527a7e101ba02654262f09333ac802be3cebe93c6a5d397a6
+pkg_shasum=d1e9b40f5933267b5e9e949e496e45ebf667f7641be62824f9d5130d3f743969
 
 pkg_deps=(
   core/curl

--- a/wordpress/plan.sh
+++ b/wordpress/plan.sh
@@ -3,11 +3,11 @@
 
 pkg_name=wordpress
 pkg_origin=core
-pkg_version="4.7.19"
+pkg_version="4.9.18"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://wordpress.org/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum="87808ef84082e491d21a46fefcd85d4e0cce5b3e54e465d5fd3e0fc89b2c5603"
+pkg_shasum="4c0349c899c036aa750818d6be4f0571af917d63f6221b9728becadb2e7798b7"
 pkg_description="installs wordpress"
 pkg_upstream_url="https://wordpress.org/"
 


### PR DESCRIPTION
Issue: #4172
Wordpress from 4.7.19 to 4.9.18
tlog from 11 to 12
shellcheck from 0.7.1 to 0.8.0
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>