### PR TITLE
upgraded elasticsearch to v6.8.21 due to CVE44228

### DIFF
--- a/elasticsearch/plan.sh
+++ b/elasticsearch/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=elasticsearch
 pkg_origin=core
-pkg_version=6.8.15
+pkg_version=6.8.21
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Open Source, Distributed, RESTful Search Engine"
 pkg_upstream_url="https://elastic.co"
 pkg_license=('Revised BSD')
 pkg_source="https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=14fa8a88049ef8314619fa028c9a19301acc8660b0caadb6a90372f4d142e156
+pkg_shasum=ad4ecba186172eda803df6dcbc3ee8b92bd72b118464f5aefca35b9b357e6cc2
 pkg_build_deps=(
   core/patchelf
 )


### PR DESCRIPTION
fixes #4282

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>