### PR TITLE
Issue4168 [dotnet-core-sdk to 3.1.416 and dotnet-core to 3.1.22 bumped]

### DIFF
--- a/dotnet-core-sdk/plan.sh
+++ b/dotnet-core-sdk/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core-sdk
 pkg_origin=core
-pkg_version=3.1.113
+pkg_version=3.1.416
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/9efb8d13-3d56-4379-8eb6-a0c8cc35b754/77a81e14a24790e16816d65f420019a3/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=1cdaf4a761dff3f28a41995bc062eb74abf29c8fa106e27e77be0c816f9fa436
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/3c98126b-50f5-4497-8ffd-18d17a3f6b95/044d0f20256fd9bf2971f8da9a0364e4/dotnet-sdk-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=5152c88b9fb540b2e6af0fb025ba33ac2c9bc2c91d7758ea2adb26fd54e1480e
 pkg_filename="dotnet-dev-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/coreutils

--- a/dotnet-core/plan.sh
+++ b/dotnet-core/plan.sh
@@ -1,14 +1,14 @@
 pkg_name=dotnet-core
 pkg_origin=core
-pkg_version=3.1.13
+pkg_version=3.1.22
 pkg_license=('MIT')
 pkg_upstream_url=https://www.microsoft.com/net/core
 pkg_description=".NET Core is a blazing fast, lightweight and modular platform
   for creating web applications and services that run on Windows,
   Linux and Mac."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source="https://download.visualstudio.microsoft.com/download/pr/6880db3b-a4fe-4801-8e80-bbbec045f7c0/283b70d5e263c0341f011adf5a2ea5b1/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
-pkg_shasum=4e8e308934a56f8e9b55f895642ac39297465facbd2154651bd69fdbd50db996
+pkg_source="https://download.visualstudio.microsoft.com/download/pr/8a11a2ba-d599-486f-ba61-9e420bc4a2bb/db9d61f28e0a688adc83687b611702ff/dotnet-runtime-${pkg_version}-linux-x64.tar.gz"
+pkg_shasum=8a5b1a9a8ca0b927450c14671e879f5e1d99906e4b67e2933047c888fda879e1
 pkg_filename="dotnet-debian-x64.${pkg_version}.tar.gz"
 pkg_deps=(
   core/curl


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4168
dotnet-core-sdk from 3.1.113 to 3.1.416
botnet-core from 3.1.13 to 3.1.22
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>