### PR TITLE
Issue4174 [grpc-cpp bumped from 1.38.0 to 1.42.0]

### DIFF
--- a/grpc-cpp/plan.sh
+++ b/grpc-cpp/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=grpc-cpp
 pkg_distname=grpc
 pkg_origin=core
-pkg_version="1.38.0"
+pkg_version="1.42.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source="https://github.com/grpc/grpc.git"


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4174
grace-cpp from 1.38.0 to 1.42.0
journalbeat : https://github.com/habitat-sh/core-plans/pull/4318
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>