### PR TITLE
Issue4181 [jetty to 9.4.44, kafka to 2.7.2 and leiningen to 2.9.8 bumped]

### DIFF
--- a/jetty/plan.sh
+++ b/jetty/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=jetty
 pkg_origin=core
-pkg_version=9.4.38
-jetty_release=v20210224
+pkg_version=9.4.44
+jetty_release=v20210927
 pkg_source=https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${pkg_version}.${jetty_release}/jetty-distribution-${pkg_version}.${jetty_release}.tar.gz
 pkg_upstream_url=https://eclipse.org/jetty
-pkg_shasum=579f6496ecf1d2a77cac8a12a0606b37e5098eca95f0c4de74235ddb898eff09
+pkg_shasum=fdfd0d1e2732576c09246df8484ff7ed4aa4c84143927936934cb6b8e5194fa3
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Jetty webserver and Java container"
 pkg_license=('Apache-2.0')

--- a/kafka/plan.sh
+++ b/kafka/plan.sh
@@ -1,8 +1,8 @@
 pkg_name=kafka
 pkg_origin=core
-pkg_version=2.7.0
+pkg_version=2.7.2
 pkg_source="https://downloads.apache.org/${pkg_name}/${pkg_version}/${pkg_name}_2.13-${pkg_version}.tgz"
-pkg_shasum="1dd84b763676a02fecb48fa5d7e7e94a2bf2be9ff87bce14cf14109ce1cb7f90"
+pkg_shasum="81a95f5aba56f43af424176a15cbfb695c48a0a7e3c5282b52bb670080ad09ae"
 pkg_dirname="${pkg_name}_2.13-${pkg_version}"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="A distributed streaming platform"

--- a/leiningen/plan.sh
+++ b/leiningen/plan.sh
@@ -1,13 +1,13 @@
 pkg_origin=core
 pkg_name=leiningen
-pkg_version="2.9.5"
+pkg_version="2.9.8"
 pkg_description="Automate Clojure projects without setting your hair on fire."
 pkg_upstream_url="https://leiningen.org/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("EPL-1.0")
-pkg_filename="${pkg_name}-${pkg_version}-standalone.zip"
-pkg_source="https://github.com/technomancy/${pkg_name}/releases/download/${pkg_version}/${pkg_filename}"
-pkg_shasum=df490c98bfe8d667bc5d83b80238528877234c285d0d48f61a4c8743c2db1eea
+pkg_filename="${pkg_version}.zip"
+pkg_source="https://github.com/technomancy/${pkg_name}/archive/refs/tags/${pkg_filename}"
+pkg_shasum=76f63afd58443d1c43e0d440b11bec07cf1c1ff540aea4db6a23bffd390d6d1e
 pkg_deps=(
   core/bash
   core/coreutils
@@ -22,7 +22,7 @@ do_download() {
 
 do_verify() {
   do_default_verify
-  verify_file "lein" "3601d55c4b5ac5c654e4ebd0d75abf7ad683f48cba8a7af1a8730b6590187b8a"
+  verify_file "lein" "9952cba539cc6454c3b7385ebce57577087bf2b9001c3ab5c55d668d0aeff6e9"
 }
 
 do_unpack() {


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4181
jetty 9.4.38 to 9.4.44
kafka 2.7.0 o 2.7.2
leiningen from 2.9.5 to 2.9.8
Signed-off-by: Sangameshwar Mandakanalli <smandaka@progress.com>