### PR TITLE
Issue4176 [xeyes to 1.2.0 and mssql to 14.0.3421.10-2 bumped]

### DIFF
--- a/mssql/plan.sh
+++ b/mssql/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=mssql
 pkg_origin=core
-pkg_version=14.0.3381.3-2
+pkg_version=14.0.3421.10-2
 pkg_license=('MICROSOFT PRE-RELEASE SOFTWARE LICENSE')
 pkg_upstream_url=https://www.microsoft.com/en-us/sql-server/sql-server-vnext-including-Linux
 pkg_description="Microsoft SQL Server for Linux"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://packages.microsoft.com/ubuntu/16.04/mssql-server-2017/pool/main/m/mssql-server/mssql-server_${pkg_version}_amd64.deb"
-pkg_shasum=382bd7af2fc58248e317cfb0d2853850ecfc34af191340bdd82d1c35fb3f0509
+pkg_shasum=f9717419f7e7093da4f9ebcaac8a58e30cc8ba5dd0607115c134d1f58600cb5f
 pkg_filename="mssql-server_${pkg_version}_amd64.deb"
 pkg_svc_user="root"
 pkg_svc_group="root"

--- a/xeyes/plan.sh
+++ b/xeyes/plan.sh
@@ -1,24 +1,38 @@
 pkg_name=xeyes
 pkg_origin=core
-pkg_version=1.1.2
+pkg_version=1.2.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="xeyes"
 pkg_upstream_url="https://www.x.org/"
 pkg_license=('MIT')
 pkg_source="https://www.x.org/releases/individual/app/${pkg_name}-${pkg_version}.tar.bz2"
-pkg_shasum=57bcec0d2d167af9e5d44d0dbd74c6d7c0f0591cd0608952b23c749fdd910553
-pkg_deps=(core/glibc
-          core/xlib
-          core/libxcb
-          core/libxau
-          core/libxdmcp
-          core/libxt
-          core/libice
-          core/libsm
-          core/libxext
-	  core/libxrender
-          core/libxmu)
-pkg_build_deps=(core/gcc core/make core/pkg-config core/xproto core/kbproto core/libpthread-stubs core/xextproto core/renderproto)
+pkg_shasum=f8a17e23146bef1ab345a1e303c6749e42aaa7bcf4f25428afad41770721b6db
+pkg_deps=(
+  core/glibc
+  core/xlib
+  core/libxcb
+  core/libxau
+  core/libxdmcp
+  core/libxt
+  core/libice
+  core/libsm
+  core/libxext
+	core/libxrender
+  core/libxmu
+  core/xextproto
+  core/renderproto
+  core/libxi
+  core/inputproto
+  core/fixesproto
+  core/libxfixes
+  core/xproto
+  core/kbproto
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/pkg-config
+)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4176
xeyes from 1.1.2 to 1.2.0
mssql from 14.0.3381.3-2 to 14.0.3421.10-2