### PR TITLE
Add Postgres 13 Client

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1144,6 +1144,8 @@ paths = [
 ]
 [postgresql12-client]
 plan_path = "postgresql12-client"
+[postgresql13-client]
+plan_path = "postgresql13-client"
 [powershell]
 plan_path = "powershell"
 [procps-ng]

--- a/postgresql13-client/plan.sh
+++ b/postgresql13-client/plan.sh
@@ -1,0 +1,92 @@
+pkg_name=postgresql13-client
+pkg_version=13.4
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="PostgreSQL is a powerful, open source object-relational database system."
+pkg_upstream_url="https://www.postgresql.org/"
+pkg_license=('PostgreSQL')
+pkg_dirname="postgresql-${pkg_version}"
+pkg_source="https://ftp.postgresql.org/pub/source/v${pkg_version}/${pkg_dirname}.tar.bz2"
+pkg_shasum="ea93e10390245f1ce461a54eb5f99a48d8cabd3a08ce4d652ec2169a357bc0cd"
+
+pkg_deps=(
+  core/bash
+  core/gawk
+  core/glibc
+  core/grep
+  core/libossp-uuid
+  core/openssl
+  core/perl
+  core/readline
+  core/zlib
+)
+
+pkg_build_deps=(
+  core/coreutils
+  core/gcc
+  core/make
+)
+
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+# These commands only make sense for if there's a postgres server
+# running locally, and in that case can use the versions that came
+# with that install
+
+server_execs=(
+    ecpg
+    initdb
+    pg_archivecleanup
+    pg_controldata
+    pg_resetxlog
+    pg_rewind
+    pg_test_fsync
+    pg_test_timing
+    pg_upgrade
+    pg_xlogdump
+)
+
+server_includes=(
+    postgresql/informix
+    postgresql/server
+)
+
+do_build() {
+    # ld manpage: "If -rpath is not used when linking an ELF
+    # executable, the contents of the environment variable LD_RUN_PATH
+    # will be used if it is defined"
+    ./configure --disable-rpath \
+              --with-openssl \
+              --prefix="$pkg_prefix" \
+              --with-uuid=ossp \
+              --with-includes="$LD_INCLUDE_PATH" \
+              --with-libraries="$LD_LIBRARY_PATH" \
+              --sysconfdir="$pkg_svc_config_path" \
+              --localstatedir="$pkg_svc_var_path"
+    make --jobs="$(nproc)" world
+}
+
+do_install() {
+	make -C src/bin install
+	make -C src/include install
+	make -C src/interfaces install
+
+	# Clean up files needed only for server installs
+    # this shrinks the package by about 60%
+    echo "Purging unneeded execs"
+    for unneeded in "${server_execs[@]}"
+    do
+       target="$pkg_prefix/bin/${unneeded}"
+       echo "rm -f ${target}"
+       rm -f "${target}"
+    done
+    echo "Purging unneeded includes"
+    for unneeded in "${server_includes[@]}"
+    do
+       target="$pkg_prefix/include/${unneeded}"
+       echo "rm -rf ${target}"
+       rm -rf "${target}"
+    done
+}


### PR DESCRIPTION
We have corresponding client packages for each of the server versions. Added the missing client version for Postgres 13. 

Once the PR is approved and merged to main, we need to trigger a new build and publish to 'stable', and 'stable2021-q2' (required by automate) channels.

Signed-off-by: Phani Sajja <psajja@progress.com>