### PR TITLE
Issue4162 [glib to 2.70.2, libdrm to 2.4.109, meson to 0.60.2, msodbcsql to 17.8.1.1-1 and atk to 2.36.0 bumped]

### DIFF
--- a/atk/plan.sh
+++ b/atk/plan.sh
@@ -1,27 +1,41 @@
 pkg_name=atk
 pkg_origin=core
-pkg_version=2.28.1
+pkg_version=2.36.0
 pkg_description="Library for a set of interfaces providing accessibility."
 pkg_upstream_url=https://developer.gnome.org/atk/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("LGPL-2.0-or-later")
 pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=cd3a1ea6ecc268a2497f0cd018e970860de24a6d42086919d6bf6c8e8d53f4fc
+pkg_shasum=fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788
 pkg_deps=(
   core/glib
   core/glibc
   core/libffi
   core/libiconv
   core/pcre
+  core/gobject-introspection
 )
 pkg_build_deps=(
   core/diffutils
   core/gcc
   core/gettext
-  core/make
+  core/cmake
   core/perl
   core/pkg-config
+  core/meson
+  core/ninja
+  core/git
 )
+pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+  meson --prefix="$pkg_prefix" _build .
+  ninja -C _build
+}
+
+do_install() {
+  ninja -C _build install
+}

--- a/glib/plan.sh
+++ b/glib/plan.sh
@@ -1,6 +1,6 @@
 pkg_origin=core
 pkg_name=glib
-pkg_version="2.68.0"
+pkg_version="2.70.2"
 pkg_description="$(cat << EOF
   GLib is a general-purpose utility library, which provides many useful data
   types, macros, type conversions, string utilities, file utilities, a
@@ -12,7 +12,7 @@ pkg_source="https://download.gnome.org/sources/${pkg_name}/${pkg_version%.*}/${p
 pkg_license=('LGPL-2.0')
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_upstream_url="https://developer.gnome.org/glib/"
-pkg_shasum="67734f584f3a05a2872f57e9a8db38f3b06c7087fb531c5a839d9171968103ea"
+pkg_shasum="0551459c85cd3da3d58ddc9016fd28be5af503f5e1615a71ba5b512ac945806f"
 pkg_deps=(
   core/coreutils
   core/elfutils

--- a/libdrm/plan.sh
+++ b/libdrm/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libdrm
 pkg_origin=core
-pkg_version=2.4.104
+pkg_version=2.4.109
 pkg_description="Direct Rendering Manager"
 pkg_upstream_url="https://dri.freedesktop.org/wiki/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://dri.freedesktop.org/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=d66ad8b5c2441015ac1333e40137bb803c3bde3612ff040286fcc12158ea1bcb
+pkg_shasum=629352e08c1fe84862ca046598d8a08ce14d26ab25ee1f4704f993d074cb7f26
 pkg_deps=(
   core/libpciaccess
   core/glibc

--- a/meson/plan.sh
+++ b/meson/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=meson
 pkg_origin=core
-pkg_version=0.57.1
+pkg_version=0.60.2
 pkg_description="The Meson Build System"
 pkg_upstream_url="http://mesonbuild.com/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/mesonbuild/${pkg_name}/archive/${pkg_version}.tar.gz"
-pkg_shasum=0c043c9b5350e9087cd4f6becf6c0d10b1d618ca3f919e0dcca2cdf342360d5d
+pkg_shasum=fc7c2f315b5b63fee0414b0b94b5a7d0e9c71c8c9bb8487314eb5a9a33984b8d
 pkg_deps=(
   # https://github.com/mesonbuild/meson/issues/7999
   # Doesn't seem to work against 3.9

--- a/msodbcsql17/plan.sh
+++ b/msodbcsql17/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=msodbcsql17
 pkg_origin=core
-pkg_version=17.7.2.1-1
+pkg_version=17.8.1.1-1
 pkg_license=("Microsoft Software License")
 pkg_upstream_url="https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-2017"
 pkg_description="ODBC driver for SQL server"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/m/${pkg_name}/${pkg_name}_${pkg_version}_amd64.deb"
-pkg_shasum="dfcb958f3625dca439bee14c2f5f91aba53bf137ab1f53c3945fd0952bf8dfd0"
+pkg_shasum="73bfd1fb1b70dac76e68e59f5635d9383e3bce223ccbd73b43246cdef4a5b626"
 
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4162

glib 2.68.0 to 2.70.2, 
libdrm from 2.4.104 to 2.4.109, 
meson from 0.57.1 to 0.60.2 
msodbcsql from 17.7.2.1-1 to 17.8.1.1-1
ask from 2.28.1 to 2.36.0