### PR TITLE
Issue4182: [Jenkins to 2.319.1, gtk2 to 2.24.33 and libepoxy to 1.5.9 bumped]

### DIFF
--- a/gtk2/plan.sh
+++ b/gtk2/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=gtk2
 pkg_origin=core
-pkg_version=2.24.31
+pkg_version=2.24.33
 pkg_description="GTK+, or the GIMP Toolkit, is a multi-platform toolkit for creating graphical user interfaces."
 pkg_upstream_url="https://www.gtk.org"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('LGPL-2.0')
 upstream_name="gtk+"
 pkg_source="https://download.gnome.org/sources/${upstream_name}/${pkg_version%.*}/${upstream_name}-${pkg_version}.tar.xz"
-pkg_shasum=68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658
+pkg_shasum=ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da
 pkg_dirname="${upstream_name}-${pkg_version}"
 pkg_deps=(
   core/atk

--- a/jenkins/plan.sh
+++ b/jenkins/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=jenkins
 pkg_origin=core
-pkg_version=2.277.1
+pkg_version=2.319.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project."
 pkg_license=('MIT')
 pkg_upstream_url="https://jenkins.io/"
 pkg_source="http://mirrors.jenkins.io/war-stable/${pkg_version}/jenkins.war"
-pkg_shasum=399741db1152ee7bbe8dc08e0972efa0b128a1b55a0f8b10c087fefeec66d151
+pkg_shasum=7e4b848a752eda740c2c7a60956bf05d9df42602c805bbaeac897179b630a562
 pkg_deps=(
   core/openjdk11
   core/curl

--- a/libepoxy/plan.sh
+++ b/libepoxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=libepoxy
 pkg_origin=core
-pkg_version=1.5.5
+pkg_version=1.5.9
 pkg_description="Epoxy is a library for handling OpenGL function pointer management for you"
 pkg_upstream_url="https://github.com/anholt/libepoxy"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('MIT')
 pkg_source="https://github.com/anholt/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
-pkg_shasum=261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556
+pkg_shasum=d168a19a6edfdd9977fef1308ccf516079856a4275cf876de688fb7927e365e4
 pkg_deps=(
   core/glibc
   core/libdrm # not linked to bins/libs


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4182

Jenkins from 2.277.1 to 2.319.1, 
gtk2 from 2.24.31  to 2.24.33
libepoxy from 1.5.5 to 1.5.9 