### PR TITLE
revert lsyncd upgrade to v2.2.1

### DIFF
--- a/lsyncd/plan.sh
+++ b/lsyncd/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=lsyncd
 pkg_origin=core
-pkg_version=2.2.3
+pkg_version=2.2.1
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('GPL-2.0')
 pkg_source="https://github.com/axkibe/$pkg_name/archive/release-$pkg_version.tar.gz"


### PR DESCRIPTION
due to incompatibility with Lua v5.4.2, it is been decided to revert upgrade of package and add to skip list for refresh

fixes #4147 

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>