### PR TITLE
[Habitat Packages Version Tracker] - pngquant version bump

### DIFF
--- a/pngquant/plan.sh
+++ b/pngquant/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("GPL-3.0-only")
 pkg_description="Lossy PNG compressor"
 pkg_upstream_url="https://pngquant.org"
 pkg_source="http://pngquant.org/pngquant-${pkg_version}-src.tar.gz"
-pkg_shasum=a27cf0e64db499ccb3ddae9b36036e881f78293e46ec27a9e7a86a3802fcda66
+pkg_shasum=4b911a11aa0c35d364b608c917d13002126185c8c314ba4aa706b62fd6a95a7a
 pkg_deps=(
   core/coreutils
   core/libpng

--- a/pngquant/plan.sh
+++ b/pngquant/plan.sh
@@ -6,7 +6,7 @@ pkg_license=("GPL-3.0-only")
 pkg_description="Lossy PNG compressor"
 pkg_upstream_url="https://pngquant.org"
 pkg_source="http://pngquant.org/pngquant-${pkg_version}-src.tar.gz"
-pkg_shasum=4b911a11aa0c35d364b608c917d13002126185c8c314ba4aa706b62fd6a95a7a
+pkg_shasum=a27cf0e64db499ccb3ddae9b36036e881f78293e46ec27a9e7a86a3802fcda66
 pkg_deps=(
   core/coreutils
   core/libpng

--- a/pngquant/plan.sh
+++ b/pngquant/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=pngquant
 pkg_origin=core
-pkg_version=2.13.1
+pkg_version=2.17.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("GPL-3.0-only")
 pkg_description="Lossy PNG compressor"
 pkg_upstream_url="https://pngquant.org"
 pkg_source="http://pngquant.org/pngquant-${pkg_version}-src.tar.gz"
-pkg_shasum=4b911a11aa0c35d364b608c917d13002126185c8c314ba4aa706b62fd6a95a7a
+pkg_shasum=a27cf0e64db499ccb3ddae9b36036e881f78293e46ec27a9e7a86a3802fcda66
 pkg_deps=(
   core/coreutils
   core/libpng


### PR DESCRIPTION
Bumping package version from 2.13.1 to 2.17.0