### PR TITLE
[Habitat Packages Version Tracker] - libgcrypt version bump

### DIFF
--- a/libgcrypt/plan.sh
+++ b/libgcrypt/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=libgcrypt
 pkg_origin=core
-pkg_version=1.9.2
+pkg_version=1.10.0
 pkg_license=('LGPL-2.0-or-later')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="ftp://ftp.gnupg.org/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2"


### PR DESCRIPTION
Bumping package version from 1.9.2 to 1.10.0