### PR TITLE
[Habitat Packages Version Tracker] - netcat-openbsd version bump

### DIFF
--- a/netcat-openbsd/plan.sh
+++ b/netcat-openbsd/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=netcat-openbsd
 pkg_origin=core
-pkg_version=1.217
+pkg_version=1.218
 pkg_description="TCP/IP swiss army knife, OpenBSD variant"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url=https://tracker.debian.org/pkg/netcat


### PR DESCRIPTION
Bumping package version from 1.217 to 1.218