### PR TITLE
[Habitat Packages Version Tracker] - vault version bump

### DIFF
--- a/vault/plan.sh
+++ b/vault/plan.sh
@@ -1,6 +1,6 @@
 pkg_origin=core
 pkg_name=vault
-pkg_version=1.7.0
+pkg_version=1.9.3
 pkg_description="A tool for managing secrets."
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=("MPL-2.0")


### PR DESCRIPTION
Bumping package version from 1.7.0 to 1.9.3