### PR TITLE
[Habitat Packages Version Tracker] - valgrind version bump

### DIFF
--- a/valgrind/plan.sh
+++ b/valgrind/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=valgrind
 pkg_origin=core
-pkg_version=3.17.0
+pkg_version=3.18.1
 pkg_description="An instrumentation framework for building dynamic analysis tools"
 pkg_upstream_url="http://www.valgrind.org/"
 pkg_license=('GPL-2.0')


### PR DESCRIPTION
Bumping package version from 3.17.0 to 3.18.1