### PR TITLE
[Habitat Packages Version Tracker] - p11-kit version bump

### DIFF
--- a/p11-kit/plan.sh
+++ b/p11-kit/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=p11-kit
 pkg_origin=core
-pkg_version="0.23.22"
+pkg_version="0.24.1"
 pkg_description="Provides a way to load and enumerate PKCS#11 modules."
 pkg_upstream_url="https://p11-glue.github.io/p11-glue/p11-kit.html"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-3-Clause')
 pkg_source="https://github.com/p11-glue/${pkg_name}/releases/download/${pkg_version}/${pkg_name}-${pkg_version}.tar.xz"
 #pkg_source="https://github.com/p11-glue/p11-kit/releases/download/0.23.10/p11-kit-0.23.10.tar.gz"
-pkg_shasum=8a8f40153dd5a3f8e7c03e641f8db400133fb2a6a9ab2aee1b6d0cb0495ec6b6
+pkg_shasum=d8be783efd5cd4ae534cee4132338e3f40f182c3205d23b200094ec85faaaef8
 pkg_deps=(
   core/libtasn1
   core/libffi


### PR DESCRIPTION
Bumping package version from 0.23.22 to 0.24.1