### PR TITLE
issue-HABP-36 [asciinema, aws-cli and buildkite-agent bumped for windows]

### DIFF
--- a/asciinema/plan.ps1
+++ b/asciinema/plan.ps1
@@ -4,7 +4,7 @@ $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('GPL-3.0-or-later')
 $pkg_description="Terminal session recorder"
 $pkg_upstream_url="https://github.com/asciinema/asciinema"
-$pkg_version = '2.0.1'
+$pkg_version = '2.1.0'
 $pkg_deps=@(
     "core/python"
 )

--- a/buildkite-agent/plan.ps1
+++ b/buildkite-agent/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="buildkite-agent"
 $pkg_origin="core"
-$pkg_version="3.29.0"
+$pkg_version="3.34.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("MIT")
 $pkg_description="The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
 $pkg_source="https://github.com/buildkite/agent/releases/download/v${pkg_version}/buildkite-agent-windows-amd64-${pkg_version}.zip"
 $pkg_filename="buildkite-agent-windows-amd64-${pkg_version}.zip"
-$pkg_shasum="24c4aae7079aaf84e82679d963d301f56ea5e775646d29cae5995381c352e8e6"
+$pkg_shasum="1fdf1aaf85c09f121ef029088602f521cd182dcda427755dea9ba7328ff5309f"
 $pkg_upstream_url="https://buildkite.com"
 $pkg_bin_dirs=@("bin")
 


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-36
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

asciinema bumped from 2.0.1 to 2.1.0
aws-cli bumped from 1.20.33 to 1.22.71 (No change in plan.ps1 as pkg-version calculated at runtime)
buildkite-agent bumped from 3.29.0 to 3.34.0 