### PR TITLE
Issue-HABP-37 [cmake, cacerts and cabal-install bumped for windows]

### DIFF
--- a/cabal-install/plan.ps1
+++ b/cabal-install/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="cabal-install"
 $pkg_origin="core"
-$pkg_version="3.4.0.0"
+$pkg_version="3.6.2.0"
 $pkg_license=@("BSD-3-Clause")
 $pkg_upstream_url="https://www.haskell.org/cabal/"
 $pkg_description="Command-line interface for Cabal and Hackage"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-${pkg_version}-x86_64-windows.zip"
-$pkg_shasum="860fff2d39a82d1dc0ca924a77164d0988af49c2c5f45e15d615144122beb647"
+$pkg_shasum="89aa3aa3f76d15182c0d03227639890cd537627ba0bf0ef9ab451fee504b24c6"
 
 $pkg_bin_dirs=@("bin")
 

--- a/cmake/plan.ps1
+++ b/cmake/plan.ps1
@@ -1,13 +1,13 @@
 $pkg_name="cmake"
 $pkg_origin="core"
-$base_version="3.20"
-$pkg_version="$base_version.2"
+$base_version="3.22"
+$pkg_version="$base_version.3"
 $pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 $pkg_upstream_url="https://cmake.org/"
 $pkg_license=@("BSD-3-Clause")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="http://cmake.org/files/v$base_version/cmake-$pkg_version-windows-x86_64.msi"
-$pkg_shasum="552b5d165e568b571bb804fed9b9b9794bf7c515c03c266641c4ed29500d84c2"
+$pkg_shasum="5bebbd44abc339c02fd525dce7c2931f9668d7d1a4a11e42e32be49301ba3658"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-37
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

cmake bumped from 3.20.2 to 3.23.3
cabal-install bumped from 3.4.0.0 to 3.6.2.0
carets from 21.07.05 to 22.02.01 (No change in plan.ps1 as pkg-version calculated at runtime) 