### PR TITLE
Issue HABP-47 [perl, postgresql-client and postgresql11-client bumped for windows]

### DIFF
--- a/perl/plan.ps1
+++ b/perl/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="perl"
 $pkg_origin="core"
-$pkg_version="5.33.9"
+$pkg_version="5.34.0"
 $pkg_description="Perl 5 is a highly capable, feature-rich programming language with over 29 years of development."
 $pkg_upstream_url="http://www.perl.org/"
 $pkg_license=@("GPL-1.0-or-later", "Artistic-1.0-Perl")
 $pkg_source="https://github.com/Perl/perl5/archive/v$pkg_version.zip"
-$pkg_shasum="d897bf5a4db8dd038394bb65507710d83287c320130f65050e718a57e4d0d924"
+$pkg_shasum="e46b8bd5be3c6dd13fdc2238928ecdff28db7f5cb8a409e239bb725e967159b5"
 $pkg_deps=@("core/visual-cpp-redist-2015")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015")
 $pkg_bin_dirs=@("bin")

--- a/postgresql-client/plan.ps1
+++ b/postgresql-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql-client"
 $pkg_origin="core"
-$pkg_version="9.6.21"
+$pkg_version="9.6.24"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-2-windows-x64-binaries.zip"
-$pkg_shasum="f12d8c7e7760096b0a263109c9e87bc76ef3f580ed1a2292ae9b115ef7545181"
+$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
+$pkg_shasum="ea9373564fe7f97ac2bb1c8788154e0f6400d4c842c6c02092f4a0318ae17361"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"

--- a/postgresql11-client/plan.ps1
+++ b/postgresql11-client/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="postgresql11-client"
 $pkg_origin="core"
-$pkg_version="11.11"
+$pkg_version="11.15"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-3-windows-x64-binaries.zip"
-$pkg_shasum="1a89a89cc9b091a3d391a25b8e2ce3184d23562eda75e6fcb8350f00af224710"
+$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
+$pkg_shasum="475896f21a40457e8f236f6d113740689ec9778cb794a8067de6ab306a797d4e"
 
 $pkg_deps=@(
     "core/visual-cpp-redist-2013"


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-47
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

perl bumped from 5.33.9 to 5.34.0
postgresql-client from 9.6.21 to 9.6.24
postgresql11-client from 11.11 to 11.15