### PR TITLE
issue-HABP-45 [nginx, node and node12 bumped for windows]

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="nginx"
 $pkg_origin="core"
-$pkg_version="1.20.0"
+$pkg_version="1.21.6"
 $pkg_description="NGINX web server."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=('BSD-2-Clause')
 $pkg_source="https://nginx.org/download/nginx-$pkg_version.zip"
 $pkg_upstream_url="https://nginx.org/"
-$pkg_shasum="bb2844c0572c05b077f7ebc0f5e3571c819fe5151661bc5fe624798c93d1712c"
+$pkg_shasum="b00326617c7461f3df955a7fc11b2bd4d032fc5fa5ea7c49e748a2287efa51a5"
 $pkg_bin_dirs=@('bin')
 $pkg_exports=@{port ="http.listen.port"}
 $pkg_exposes=@('port')

--- a/node/plan.ps1
+++ b/node/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="node"
 $pkg_origin="core"
-$pkg_version="14.16.0"
+$pkg_version="14.19.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_upstream_url="https://nodejs.org/"
 $pkg_license=@("MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="d9243c9d02f5e4801b8b3ab848f45ce0da2882b5fff448191548ca49af434066"
+$pkg_shasum="f1b1d4e00b36bc3be0025a409a1e44d4375220407239202d8627becd7fd359f0"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")
 

--- a/node12/plan.ps1
+++ b/node12/plan.ps1
@@ -2,10 +2,10 @@
 
 $pkg_name="node12"
 $pkg_origin="core"
-$pkg_version="12.22.1"
+$pkg_version="12.22.10"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="02f53b3530a0310b1076db801770803527c63f724b56c22d6a0625c12a03c982"
+$pkg_shasum="3fe6f727581c2f46a1ce7f9e2fd79ab16010a49878f1e566cf7fddc2e09a87c8"
 
 function Invoke-Check() {
     (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/node-v$pkg_version-x64/SourceDir/nodejs/node" --version) -eq "v$pkg_version"


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-45
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

nginx bumped from 1.20.0 to 1.21.6
node from 14.16.0 to 14.19.0
node12 from 12.22.1 to 12.22.10