### PR TITLE
Issue-HABP-46 [node14,openssl and packer bumped for windows]

### DIFF
--- a/node14/plan.ps1
+++ b/node14/plan.ps1
@@ -2,7 +2,7 @@
 
 $pkg_name="node14"
 $pkg_origin="core"
-$pkg_version="14.16.0"
+$pkg_version="14.19.0"
 $pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
 $pkg_source="https://nodejs.org/dist/v$pkg_version/node-v$pkg_version-x64.msi"
-$pkg_shasum="d9243c9d02f5e4801b8b3ab848f45ce0da2882b5fff448191548ca49af434066"
+$pkg_shasum="f1b1d4e00b36bc3be0025a409a1e44d4375220407239202d8627becd7fd359f0"

--- a/openssl/plan.ps1
+++ b/openssl/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="openssl"
 $pkg_origin="core"
-$pkg_version="1.1.1k"
+$pkg_version="1.1.1l"
 $_pkg_version_text=($pkg_version).Replace(".", "_")
 $pkg_description="OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library."
 $pkg_upstream_url="https://www.openssl.org"
 $pkg_license=@("OpenSSL")
 $pkg_source="https://github.com/openssl/openssl/archive/OpenSSL_$_pkg_version_text.zip"
-$pkg_shasum="255c038f5861616f67b527434475d226f5fe00522fbd21fafd3df32019edd202"
+$pkg_shasum="23d8908e82b63af754018256a4eb02f13965f10067969f6a63f497960c11dbeb"
 $pkg_deps=@("core/visual-cpp-redist-2015")
 $pkg_build_deps=@("core/visual-cpp-build-tools-2015", "core/perl", "core/nasm")
 $pkg_bin_dirs=@("bin")

--- a/packer/plan.ps1
+++ b/packer/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="packer"
 $pkg_origin="core"
-$pkg_version="1.7.2"
+$pkg_version="1.8.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('MPL2')
 $pkg_bin_dirs=@("bin")
 $pkg_source="https://releases.hashicorp.com/packer/${pkg_version}/packer_${pkg_version}_windows_amd64.zip"
-$pkg_shasum="3622c7d475417eda644d27481748c076a63e946501965eb5499893825d9e0fde"
+$pkg_shasum="6c1b00069e4924e97b362b6c72a7315960487aaeb287bfdec717468ca2b50e9a"
 
 function Invoke-Install {
     Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_name-$pkg_version/$pkg_name.exe" $pkg_prefix\bin


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-46
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

node14 bumped from 14.16.0 to 14.19.0
openssl bumped from 1.1.1k to 1.1.1L
packer bumped from 1.7.2 to 1.8.0
