### PR TITLE
Issue-HABP-42 [ghc and go bumped for windows]

### DIFF
--- a/ghc/plan.ps1
+++ b/ghc/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="ghc"
 $pkg_origin="core"
-$pkg_version="8.10.4"
+$pkg_version="8.10.7"
 $pkg_license=@("BSD-3-Clause")
 $pkg_upstream_url="https://www.haskell.org/ghc/"
 $pkg_description="The Glasgow Haskell Compiler"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-x86_64-unknown-mingw32.tar.xz"
-$pkg_shasum="e9175a276504c3390a5e0084954e6997d56078737dbe7158049518892cf6bfb2"
+$pkg_shasum="b6515b0ea3f7a6e34d92e7fcd0c1fef50d6030fe8f46883000185289a4b8ea9a"
 
 $pkg_bin_dirs=@("bin")
 $pkg_lib_dirs=@("lib")

--- a/go/plan.ps1
+++ b/go/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="go"
 $pkg_origin="core"
-$pkg_version="1.16.4"
+$pkg_version="1.16.15"
 $pkg_description="Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
 $pkg_upstream_url="https://golang.org/"
 $pkg_license=@("BSD-3-Clause")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://dl.google.com/go/go$pkg_version.windows-amd64.msi"
-$pkg_shasum="9ae1cafad5f206f004cfe4e9e9b64e4710cb69c83f6221da89c113b6f2e8dec8"
+$pkg_shasum="3ebe9a9d7d0c7149b9acca623db2e533d0a0392a21320bf0f9353172b97019b1"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_dirname="go"
 $pkg_bin_dirs=@("bin")


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-42
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

ghc bumped from 8.10.4 to 8.10.7
go bumped from 1.16.4 to 1.16.15