### PR TITLE
Issue-HABP-40 [dotnet-5-runtime bumped and dotnet-47,471 and 472 url changed for windows]

### DIFF
--- a/dotnet-47-dev-pack/plan.ps1
+++ b/dotnet-47-dev-pack/plan.ps1
@@ -5,8 +5,8 @@ $pkg_description=".NET 4.7 Targeting Pack and the .NET 4.7 SDK."
 $pkg_upstream_url="https://www.microsoft.com/net/download/all"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe"
-$pkg_shasum="16346bd9c464ae6439bd702702d5377beb1b623683a4415db5dbd3160318f625"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/fe069d49-7999-4ac8-bf8d-625282915070/d52a6891b5014014e1f12df252fab620/ndp47-devpack-kb3186612-enu.exe"
+$pkg_shasum="efe311d8ea6a597860af8549b184d837da79b41f2c2c73d3ebe7386f2635544f"
 $pkg_build_deps=@("core/lessmsi", "core/wix")
 
 $pkg_bin_dirs=@("Program Files\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools\x64")

--- a/dotnet-471-dev-pack/plan.ps1
+++ b/dotnet-471-dev-pack/plan.ps1
@@ -7,5 +7,5 @@ $pkg_description=".NET 4.7.1 Targeting Pack and the .NET 4.7.1 SDK."
 $pkg_upstream_url="https://www.microsoft.com/net/download/all"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/9/0/1/901B684B-659E-4CBD-BEC8-B3F06967C2E7/NDP471-DevPack-ENU.exe"
-$pkg_shasum="a615488d2c5229aff3b97c56f7e5519cc7ac4f58b638a8e159b19c5c3d455c7b"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/e5eb8d37-5bbd-4fb7-a71d-b749e010ef9f/601437d729667ecd29020a829fbc4881/ndp471-devpack-enu.exe"
+$pkg_shasum="a70b790dcf7ee4a0cae65fb82a16fb67fe970eb21b9424c9da35e1acafbc4348"

--- a/dotnet-472-dev-pack/plan.ps1
+++ b/dotnet-472-dev-pack/plan.ps1
@@ -7,5 +7,5 @@ $pkg_description=".NET 4.7.2 Targeting Pack and the .NET 4.7.2 SDK."
 $pkg_upstream_url="https://www.microsoft.com/net/download/all"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.microsoft.com/download/3/B/F/3BFB9C35-405D-45DF-BDAF-0EB57D047888/NDP472-DevPack-ENU.exe"
-$pkg_shasum="2f4ee2852b95c37a806e2deec567751dd59b0dd27049641bbd4e1c0e22adfe46"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/158dce74-251c-4af3-b8cc-4608621341c8/9c1e178a11f55478e2112714a3897c1a/ndp472-devpack-enu.exe"
+$pkg_shasum="878fdf9f137b1466855de995c793b466cd50fccc523d1f41250567973623180c"

--- a/dotnet-472-runtime/plan.ps1
+++ b/dotnet-472-runtime/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="dotnet-472-runtime"
 $pkg_origin="core"
-$pkg_version="0.1.0"
+$pkg_version="4.7.2"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Microsoft Software License")
-$pkg_source="https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/124d2afe5c8f67dfa910da5f9e3db9c1/ndp472-kb4054531-web.exe"
 $pkg_description=".Net 4.7.2 Framework Runtime"
 $pkg_upstream_url="https://dotnet.microsoft.com/download"
-$pkg_shasum="c908f0a5bea4be282e35acba307d0061b71b8b66ca9894943d3cbb53cad019bc"
+$pkg_shasum="151b1c11f625e7122d517b6a1778841df8ff168d931c41730f59b9e4b8bcbe36"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Unpack {}

--- a/dotnet-5-runtime/plan.ps1
+++ b/dotnet-5-runtime/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="dotnet-5-runtime"
 $pkg_origin="core"
-$pkg_version="5.0.6"
+$pkg_version="5.0.15"
 $pkg_license=('MIT')
 $pkg_upstream_url="https://dotnet.microsoft.com/"
 $pkg_description=".NET is a free, cross-platform, open-source developer platform for building many different types of applications."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://dotnetcli.azureedge.net/dotnet/Runtime/$pkg_version/dotnet-runtime-$pkg_version-win-x64.zip"
-$pkg_shasum="62464751fb0744e85acca14f14304ed21f0ab11b38ba16e43072cb3fc6ca16f7"
+$pkg_shasum="e39c55364dc59af91828c80a08b511112a02d8341c6b4b2cda9d0630afa707bd"
 $pkg_bin_dirs=@("bin")
 
 function Invoke-Install {


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-40
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

dotnet-5-runtime bumped from 5.0.6 to 5.0.15
pkg_source value changed for dotnet-472-runtime,dotnet-472-dev-pack,dotnet-471-dev-pack and dotnet-47-dev-pack