### PR TITLE
fix(msodbcsql17): match either file output for patchelf

### DIFF
--- a/msodbcsql17/plan.sh
+++ b/msodbcsql17/plan.sh
@@ -36,7 +36,7 @@ do_build() {
   build_line "Fixing rpath for lib:"
 
   find . -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-pie-executable; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "x-\(pie-executable\|sharedlib\); charset=binary"' _ {} \; \
     -print \
     -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
 }


### PR DESCRIPTION
core/file/5.37 and core/file/5.39 give different answers for the same input

See https://github.com/habitat-sh/core-plans/pull/2289#issuecomment-1073307241

Signed-off-by: Chris Alfano <chris@jarv.us>