### PR TITLE
Issue-HABP-48 [postgresql96-client,powershell and protobuf bumped for Windows]

### DIFF
--- a/postgresql96-client/plan.ps1
+++ b/postgresql96-client/plan.ps1
@@ -2,10 +2,10 @@
 
 $pkg_name="postgresql96-client"
 $pkg_origin="core"
-$pkg_version="9.6.21"
+$pkg_version="9.6.24"
 $pkg_license=('PostgreSQL')
 $pkg_upstream_url="https://www.postgresql.org/"
 $pkg_description="PostgreSQL is a powerful, open source object-relational database system."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-2-windows-x64-binaries.zip"
-$pkg_shasum="f12d8c7e7760096b0a263109c9e87bc76ef3f580ed1a2292ae9b115ef7545181"
+$pkg_source="https://get.enterprisedb.com/postgresql/postgresql-${pkg_version}-1-windows-x64-binaries.zip"
+$pkg_shasum="ea9373564fe7f97ac2bb1c8788154e0f6400d4c842c6c02092f4a0318ae17361"

--- a/powershell/plan.ps1
+++ b/powershell/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="powershell"
 $pkg_origin="core"
-$pkg_version="7.1.3"
+$pkg_version="7.2.2"
 $pkg_license=@("MIT")
 $pkg_upstream_url="https://msdn.microsoft.com/powershell"
 $pkg_description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with your existing tools and is optimized for dealing with structured data (e.g. JSON, CSV, XML, etc.), REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets."
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://github.com/PowerShell/PowerShell/releases/download/v$pkg_version/PowerShell-$pkg_version-win-x64.zip"
-$pkg_shasum="47475f1d4015704f3fb5f6d2cf61196d121aba60c19592b04be818317ce01039"
+$pkg_shasum="e639b5f47d6d39b5942df70ada4a69a1c85616747622582eedfb197b8ccad298"
 $pkg_filename="powershell-$pkg_version-win-x64.zip"
 $pkg_bin_dirs=@("bin")
 

--- a/protobuf/plan.ps1
+++ b/protobuf/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="protobuf"
 $pkg_origin="core"
-$pkg_version="3.16.0"
+$pkg_version="3.19.4"
 $pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
 $pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 $pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 $pkg_license=("BSD")
 $pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.zip"
-$pkg_shasum="69f6bca818bf76e5cb00443223d15361998a8999bac71485a7524910f9711028"
+$pkg_shasum="aabe421c26836c520256cafaee0fca2ba7b02759c60ef1174a96a531c2d75f75"
 $pkg_deps=@(
     "core/zlib"
 )


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-48
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

Postgresql96-client from 9.6.21 to 9.6.24
Powershell from 7.1.3 to 7.2.2
protobuf from 3.16.0 to 3.19.4