### PR TITLE
Issue-HABP-52 [visual-build-tools for 2017 and 2019 bumped for Windows]

### DIFF
--- a/visual-build-tools-2017/plan.ps1
+++ b/visual-build-tools-2017/plan.ps1
@@ -1,12 +1,13 @@
 $pkg_name="visual-build-tools-2017"
 $pkg_origin="core"
-$pkg_version="15.9.21"
+$pkg_version="15.9.45"
 $pkg_description="Standalone compiler, libraries and scripts"
 $pkg_upstream_url="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/67f7bfaa-2635-43d9-ba82-26564f458881/bb057808eeff7d02561cab636b32397e298c3e770ed278602c46d119fa2e4ee8/vs_BuildTools.exe"
-$pkg_shasum="bb057808eeff7d02561cab636b32397e298c3e770ed278602c46d119fa2e4ee8"
+$pkg_source="
+https://download.visualstudio.microsoft.com/download/pr/4dfffe3f-2a7e-4dea-922b-62d4beca5e36/e10c2bfb0e7b0358c24bd0df951f3d81897f309a0642a199b93f248db303263c/vs_BuildTools.exe"
+$pkg_shasum="e10c2bfb0e7b0358c24bd0df951f3d81897f309a0642a199b93f248db303263c"
 $pkg_build_deps=@("core/7zip")
 
 $pkg_bin_dirs=@(

--- a/visual-build-tools-2019/plan.ps1
+++ b/visual-build-tools-2019/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="visual-build-tools-2019"
 $pkg_origin="core"
-$pkg_version="16.10.4"
+$pkg_version="16.11.11"
 $pkg_description="Standalone compiler, libraries and scripts"
 $pkg_upstream_url="https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://download.visualstudio.microsoft.com/download/pr/acfc792d-506b-4868-9924-aeedc61ae654/1778d923fd40c62c29f85cf4ef63a0c855a61c13b1dd68419bcda2cff38c984f/vs_BuildTools.exe"
-$pkg_shasum="1778d923fd40c62c29f85cf4ef63a0c855a61c13b1dd68419bcda2cff38c984f"
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/73f91fcb-aa18-4bec-8c2f-8270acb22398/775c32ca5efcdc1e2227e52e943bb05bc8a7a9c1acacebb9d4ccc8496cc9906c/vs_BuildTools.exe"
+$pkg_shasum="775c32ca5efcdc1e2227e52e943bb05bc8a7a9c1acacebb9d4ccc8496cc9906c"
 $pkg_build_deps=@("core/7zip")
 
 $pkg_bin_dirs=@(


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-52
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

visual-build-tools-2017 from 15.9.21 to 15.9.45
visual-build-tools-2019 from 16.10.4 to 16.11.11