### PR TITLE
docker-cred-helper and git bumped for windows

### DIFF
--- a/docker-credential-helper/plan.ps1
+++ b/docker-credential-helper/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name = "docker-credential-helper"
 $pkg_description = "Docker Credential Helper"
 $pkg_origin = "core"
-$pkg_version = "0.6.3"
+$pkg_version = "0.6.4"
 $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license = @("MIT")
 $pkg_source = "https://github.com/docker/docker-credential-helpers/releases/download/v$pkg_version/docker-credential-wincred-v$pkg_version-amd64.zip"
 $pkg_upstream_url = "https://github.com/docker/docker-credential-helpers"
-$pkg_shasum = "837fa8f21c0bc94a72938970913bfe3804090cade0e96d570f47002a6c2e21f1"
+$pkg_shasum = "25031fec7fa0501666d47e63dc7593e2b0e6ad72c6bf13abef5917691ea47e37"
 $pkg_bin_dirs = @("bin")
 
 function Invoke-Unpack {

--- a/git/plan.ps1
+++ b/git/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name = "git"
 $pkg_origin = "core"
-$pkg_version = "2.31.1"
+$pkg_version = "2.35.1"
 $pkg_description = "Git is a free and open source distributed version control
   system designed to handle everything from small to very large projects with
   speed and efficiency."
@@ -8,7 +8,7 @@ $pkg_upstream_url = "https://git-scm.com/"
 $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license = @("GPL-2.0")
 $pkg_source = "https://github.com/git-for-windows/git/releases/download/v$pkg_version.windows.1/Git-$pkg_version-64-bit.tar.bz2"
-$pkg_shasum = "c70934e84fd610cf8f492bdfe858d4738b8af09f5b5dc734795d2b40d99bcb53"
+$pkg_shasum = "a8dafe3ed839494e8b71212c1027830aa8d6f2f04365f4e523888f793f8e3fd5"
 $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @("core/7zip")
 


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/HABP-54
Signed-off-by: Sangameshwar Mandakanalli <sangameshwar.mandakanalli@progress.com>

docker-credential-helper bumped from 0.6.3 to 0.6.4
git bumped from 2.33.1 to 2.35.1