### PR TITLE
[scaffolding-ruby] fix to remove warnings at build time

### DIFF
--- a/scaffolding-ruby/lib/scaffolding.sh
+++ b/scaffolding-ruby/lib/scaffolding.sh
@@ -878,13 +878,14 @@ _bundle_install() {
   path="$1"
   shift
 
+  _bundle config set --local --shebang "$(pkg_path_for "$_ruby_pkg")/bin/ruby"
+  _bundle config set --local path "$path"
+  _bundle config set --local deployment 'true'
+  _bundle config set --local without "development:test"
+
   _bundle install ${*:-} \
     --jobs "$(nproc)" \
-    --without development:test \
-    --path "$path" \
-    --shebang="$(pkg_path_for "$_ruby_pkg")/bin/ruby" \
-    --no-clean \
-    --deployment
+    --no-clean
 }
 
 _compare_gem() {


### PR DESCRIPTION
Below warnings messages are displayed at build time when core/scaffolding-ruby is added as dependency

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local deployment 'true'`, and stop using this flag
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path '/hab/pkgs/winhab/habitatize/0.1.0/20220524143318/app/vendor/bundle'`, and stop using this flag
[DEPRECATED] The `--shebang` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local shebang '/hab/pkgs/core/ruby/3.0.3/20220313012229/bin/ruby'`, and stop using this flag
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local without 'development:test'`, and stop using this flag
```
Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)