### PR TITLE
bump core/rust from 1.67.1 to 1.68.0

### DIFF
--- a/rust/plan.ps1
+++ b/rust/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="rust"
 $pkg_origin="core"
-$pkg_version="1.67.1"
+$pkg_version="1.68.0"
 $pkg_description="Safe, concurrent, practical language"
 $pkg_upstream_url="https://www.rust-lang.org/"
 $pkg_license=@("Apache-2.0", "MIT")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://static.rust-lang.org/dist/rust-$pkg_version-x86_64-pc-windows-msvc.msi"
-$pkg_shasum = "00ddcdff08226ac36049951b4aaac0d036a337e415acbbe8ef76d1b57bb567b2"
+$pkg_shasum = "68c24484c79cde83d3197ffdf03657d16590385536e45cefa63e60e274de0bb1"
 $pkg_deps=@("core/visual-cpp-redist-2015", "core/visual-cpp-build-tools-2015")
 $pkg_build_deps=@("core/lessmsi")
 $pkg_bin_dirs=@("bin")

--- a/rust/plan.sh
+++ b/rust/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.67.1
+pkg_version=1.68.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Rust is a systems programming language that runs blazingly fast, prevents \
@@ -10,7 +10,7 @@ pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
 _url_base="https://static.rust-lang.org/dist"
 pkg_source="$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz"
-pkg_shasum="652a8966436c4e97b127721d9130810e1cdc8dfdf526fad68c9c1f6281bd02a3"
+pkg_shasum="7be1acdac656d0b0b7e909e5c0d4ddf61c755c203ec26ebafbd306322335b361"
 pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu"
 pkg_deps=(
   core/glibc
@@ -33,7 +33,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-    "0d722ae8568b72bce0d4db5d3b717c12aa7d541da3bfe93606c59030b769af2b"
+    "cc7bf16e542445c637c03fc9e01e0bf51703b0ceaeb26328d10f5786dfdc3144"
 )
 
 do_download() {


### PR DESCRIPTION
modified plan files as part of bumping core/rust from 1.67.1 to 1.68.0