### PR TITLE
[haproxy] update to 2.2.29, containing CVE-2023-25725 fix

### DIFF
--- a/haproxy/plan.sh
+++ b/haproxy/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=haproxy
 pkg_origin=core
 pkg_description="The Reliable, High Performance TCP/HTTP Load Balancer"
-pkg_version=2.2.18
+pkg_version=2.2.29
 pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
 pkg_license=('GPL-2.0' 'LGPL-2.1')
 pkg_source="https://www.haproxy.org/download/2.2/src/haproxy-${pkg_version}.tar.gz"
 pkg_upstream_url="https://www.haproxy.org/"
-pkg_shasum=a04a179d82711cac2199c4615621aaa9598c4788de2b34dccb9dd44da2862c50
+pkg_shasum=1e41f49674fbf5663b55c5f7919a7d05e480730653f2bcdec384b8836efc1fb0
 pkg_svc_run='haproxy -f config/haproxy.conf -db'
 pkg_svc_user=root
 pkg_svc_group=root


### PR DESCRIPTION
This PR updates HAProxy to 2.2.29, which has a fix for CVE-2023-25725. 