### PR TITLE
[postfix] fix for unidentified kernel release

### DIFF
--- a/postfix/fix-aws-kernel-version.patch
+++ b/postfix/fix-aws-kernel-version.patch
@@ -1,0 +1,24 @@
+diff -Naur a/makedefs b/makedefs
+--- a/makedefs	2023-08-22 11:01:14.461101408 +0000
++++ b/makedefs	2023-08-22 11:04:13.001023406 +0000
+@@ -568,7 +568,7 @@
+ 		: ${SHLIB_ENV="LD_LIBRARY_PATH=`pwd`/lib"}
+ 		: ${PLUGIN_LD="${CC-gcc} -shared"}
+ 		;;
+- Linux.[345].*)	SYSTYPE=LINUX$RELEASE_MAJOR
++ Linux.[3456].*)	SYSTYPE=LINUX$RELEASE_MAJOR
+ 		case "$CCARGS" in
+ 		 *-DNO_DB*) ;;
+ 		 *-DHAS_DB*) ;;
+diff -Naur a/src/util/sys_defs.h b/src/util/sys_defs.h
+--- a/src/util/sys_defs.h	2023-08-22 11:01:14.537101381 +0000
++++ b/src/util/sys_defs.h	2023-08-22 11:07:20.316948827 +0000
+@@ -749,7 +749,7 @@
+  /*
+   * LINUX.
+   */
+-#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5)
++#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5) || defined(LINUX6)
+ #define SUPPORTED
+ #define UINT32_TYPE	unsigned int
+ #define UINT16_TYPE	unsigned short

--- a/postfix/plan.sh
+++ b/postfix/plan.sh
@@ -34,6 +34,7 @@ pkg_svc_user=root
 
 do_prepare() {
   patch -p1 < "${PLAN_CONTEXT}/postfix-glibc-2.34.patch"
+  patch -p1 < "${PLAN_CONTEXT}/fix-aws-kernel-version.patch"
 }
 
 do_build() {


### PR DESCRIPTION
updated source code to include kernel release 6.x to build postfix on Ubuntu 22.04 Amazon AMI

Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)