### PR TITLE
[mongodb] fix for python package pyyaml incompatibility

### DIFF
--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -48,7 +48,7 @@ do_prepare() {
 do_build() {
   # This is currently necessary because MongoDB still uses Python 2.x
   # When it supports Python 3.x, this line will be unnecessary
-  pip install typing pyyaml==5.3.1 cheetah3
+  pip install typing==3.10.0.0 pyyaml==5.3.1 cheetah3==3.2.6
 
   scons CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" CPPPATH="${CFLAGS}" LINKFLAGS="${LDFLAGS}" LIBPATH="${LDFLAGS}" core --propagate-shell-environment --disable-warnings-as-errors --prefix="${pkg_prefix}" --ssl -j"$(nproc)"
 }

--- a/mongodb/plan.sh
+++ b/mongodb/plan.sh
@@ -48,7 +48,7 @@ do_prepare() {
 do_build() {
   # This is currently necessary because MongoDB still uses Python 2.x
   # When it supports Python 3.x, this line will be unnecessary
-  pip install typing pyyaml cheetah3
+  pip install typing pyyaml==5.3.1 cheetah3
 
   scons CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" CPPPATH="${CFLAGS}" LINKFLAGS="${LDFLAGS}" LIBPATH="${LDFLAGS}" core --propagate-shell-environment --disable-warnings-as-errors --prefix="${pkg_prefix}" --ssl -j"$(nproc)"
 }

--- a/shield-agent/plan.sh
+++ b/shield-agent/plan.sh
@@ -34,12 +34,12 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
+pkg_svc_user="root"
+pkg_svc_group="$pkg_svc_user"
+
 pkg_binds_optional=(
   [daemon]="port provisioning_key"
 )
-
-pkg_svc_user="root"
-pkg_svc_group="$pkg_svc_user"
 
 do_before() {
   SHIELD_SRC_PATH="${HAB_CACHE_SRC_PATH}/${pkg_dirname}/src/github.com/starkandwayne/shield"
@@ -65,9 +65,10 @@ do_prepare() {
   GO111MODULE=off
   export GO111MODULE
 
-  git config --global url."git://github.com/".insteadOf "https://github.com/"
+  pushd "${SHIELD_SRC_PATH}" || exit
   go get github.com/kardianos/govendor
   go install github.com/kardianos/govendor
+  popd
 }
 
 do_build() {

--- a/shield/plan.sh
+++ b/shield/plan.sh
@@ -8,8 +8,19 @@ pkg_upstream_url="https://github.com/starkandwayne/shield"
 pkg_source="https://github.com/starkandwayne/shield/archive/v${pkg_version}.tar.gz"
 pkg_shasum=dbea689596bc496e2f16f8a4bf2aaade8fb693b3934f11b5b7e956573ebbc599
 
-pkg_deps=(core/bash core/glibc core/postgresql core/shield-proxy/"${pkg_version}")
-pkg_build_deps=(core/go core/git core/gcc core/make core/gox)
+pkg_deps=(
+	core/bash
+	core/glibc
+	core/postgresql
+	core/shield-proxy/"${pkg_version}"
+)
+pkg_build_deps=(
+	core/go
+	core/git
+	core/gcc
+	core/make
+	core/gox
+)
 
 pkg_bin_dirs=(bin)
 
@@ -38,20 +49,19 @@ do_clean() {
 
 do_unpack() {
   mkdir -p "${SHIELD_SRC_PATH}"
-  tar xf "${HAB_CACHE_SRC_PATH}"/"${pkg_filename}" -C "${SHIELD_SRC_PATH}" --strip-components 1
+  tar xf "${HAB_CACHE_SRC_PATH}/${pkg_filename}" --strip-components=1 -C "${SHIELD_SRC_PATH}"
 }
 
 do_prepare() {
+  VERSION="${pkg_version}"
+  export VERSION
   GOPATH="${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
   export GOPATH
   PATH="$PATH:$GOPATH/bin"
   export PATH
-  VERSION="${pkg_version}"
-  export VERSION
   GO111MODULE="off"
   export GO111MODULE
 
-  git config --global url."git://github.com/".insteadOf "https://github.com/"
   pushd "${SHIELD_SRC_PATH}" &>/dev/null || exit 1
     go get github.com/kardianos/govendor
     go install github.com/kardianos/govendor


### PR DESCRIPTION
pre-build pyyaml package is downloaded by pip while building MongoDB as an incompatible dependency hence v5.3.1 is configured to be used.

Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)