### PR TITLE
[python] downgraded python to v3.11 from v3.12

### DIFF
--- a/python/plan.sh
+++ b/python/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=python
 pkg_distname=Python
-pkg_version=3.12.0
+pkg_version=3.11.0
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Python-2.0')
@@ -9,7 +9,7 @@ pkg_description="Python is a programming language that lets you work quickly \
 pkg_upstream_url="https://www.python.org"
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
-pkg_shasum="51412956d24a1ef7c97f1cb5f70e185c13e3de1f50d131c0aac6338080687afb"
+pkg_shasum="64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb"
 
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
 downgraded python to v3.11 from v3.12 due to compatibility issues in dependents
 
 Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)