### PR TITLE
[fd] changed to rust-nightly for once_cell feature

### DIFF
--- a/fd/plan.sh
+++ b/fd/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/gcc-libs
 )
 pkg_build_deps=(
-  core/rust
+  core/rust-nightly
 )
 
 do_build() {


### PR DESCRIPTION
once_cell is unstable feature and only available in nightly builds of rust

For more information about this error, try `rustc --explain E0658`

Signed-off-by: Nimit [nimit.jyotiana@hotmail.com](mailto:nimit.jyotiana@hotmail.com)