### PR TITLE
Fixing the build error as we moved linux and Winodws plan files in same folder [CHEF-9071]

### DIFF
--- a/nginx/plan.ps1
+++ b/nginx/plan.ps1
@@ -19,7 +19,14 @@ function Invoke-Install {
     } | ForEach-Object {
         Copy-Item $_.FullName $pkg_prefix
     }
-mkdir "$pkg_prefix\hooks"
+}
+
+function Invoke-BuildConfig {
+   
+	mkdir "$pkg_prefix\hooks"
+	mkdir "$pkg_prefix\config"
+	Copy-Item "$PLAN_CONTEXT/default.toml" "$pkg_prefix"
+	Copy-Item "$PLAN_CONTEXT/config\*" "$pkg_prefix\config" -Force
 
 @"
 Set-Location {{pkg.svc_path}}


### PR DESCRIPTION
https://chefio.atlassian.net/browse/CHEF-9071
As we moved the Windows and Linux plan files in the root folder, hooks from Linux are copied to Windows folder.  Added new function to fix the error.