### PR TITLE
change gem update version to match compatibility with older ruby version

### DIFF
--- a/ruby27/plan.sh
+++ b/ruby27/plan.sh
@@ -39,6 +39,6 @@ do_check() {
 
 do_install() {
   do_default_install
-  gem update --system --no-document
+  gem update --system 3.4.22 --no-document
   gem install rb-readline --no-document
 }


### PR DESCRIPTION
older ruby version is incompatible with new releases of rubygems-update.
change gem update version to match compatibility with older ruby version