### PR TITLE
New package go22 with version 1.22.4 added for Linux/Wondows[CHEF-12605]

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -502,6 +502,8 @@ plan_path = "go19"
 plan_path = "go20"
 [go21]
 plan_path = "go21"
+[go22]
+plan_path = "go22"
 [goaccess]
 plan_path = "goaccess"
 [gobject-introspection]

--- a/go22/README.md
+++ b/go22/README.md
@@ -1,0 +1,80 @@
+# go
+
+Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.  See [documentation](https://golang.org)
+
+## Maintainers
+
+* The Core Planners: <chef-core-planners@chef.io>
+
+## Type of Package
+
+Binary package
+
+### Use as Dependency
+
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%21Your%21Dependencies) for more information.
+
+To add core/go as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/go22)
+
+#### Runtime dependency
+
+> pkg_deps=(core/go22)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/go22 --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/go
+* /bin/gofmt
+
+For example:
+
+```bash
+$ hab pkg install core/go22 --binlink
+» Installing core/g19
+☁ Determining latest version of core/go22 in the 'stable' channel
+→ Found newer installed version (core/go22/1.22.x/2122xxx...) than remote version (core/go22/1.22.x/2122xxx...)
+→ Using core/go22/1.22.x/2122xxx...
+★ Install of core/go22/1.22.x/2122xxx... complete with 0 new packages installed.
+» Binlinking gofmt from corego22/1.22.x/2122xxx... into /bin
+★ Binlinked gofmt from core/go22/1.22.x/2122xxx... to /bin/gofmt
+» Binlinking go from cor/go22/1.22.x/2122xxx... into /bin
+★ Binlinked go from core/go22/1.22.x/2122xxx... to /bin/go
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/go --help`` or ``go --help``
+
+```bash
+$ go --help
+Go is a tool for managing Go source code.
+
+Usage:
+
+        go <command> [arguments]
+
+The commands are:
+
+        bug         start a bug report
+        build       compile packages and dependencies
+        clean       remove object files and cached files
+        doc         show documentation for package or symbol
+        env         print Go environment information
+        fix         update packages to use new APIs
+        fmt         gofmt (reformat) package sources
+...
+...
+```

--- a/go22/cacerts.patch
+++ b/go22/cacerts.patch
@@ -1,0 +1,11 @@
+diff --git a/src/crypto/x509/root_linux.go b/src/crypto/x509/root_linux.go
+index aa1785e..33e06c9 100644
+--- a/src/crypto/x509/root_linux.go
++++ b/src/crypto/x509/root_linux.go
+@@ -10,5 +10,6 @@ var certFiles = []string{
+ 	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+ 	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+ 	"/etc/pki/tls/cacert.pem",                           // OpenELEC
++	"@cacerts@", // Bldr Package
+ 	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+ }

--- a/go22/plan.ps1
+++ b/go22/plan.ps1
@@ -1,0 +1,29 @@
+$pkg_name="go22"
+$pkg_origin="core"
+$pkg_version="1.22.4"
+$pkg_description="Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
+$pkg_upstream_url="https://golang.org/"
+$pkg_license=@("BSD-3-Clause")
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_source="https://dl.google.com/go/go$pkg_version.windows-amd64.msi"
+$pkg_shasum="3c21105d7b584759b6e266383b777caf6e87142d304a10b539dbc66ab482bb5f"
+$pkg_build_deps=@("core/lessmsi")
+$pkg_dirname="go22"
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Unpack {
+    mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    try {
+        lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+    } finally { Pop-Location }
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/go$pkg_version.windows-amd64/SourceDir/Go/*" "$pkg_prefix" -Recurse -Force
+}
+
+function Invoke-Check() {
+    (& "$HAB_CACHE_SRC_PATH/$pkg_dirname/go$pkg_version.windows-amd64/SourceDir/Go/bin/go.exe" version).StartsWith("go version go$pkg_version")
+}

--- a/go22/plan.sh
+++ b/go22/plan.sh
@@ -1,0 +1,140 @@
+# shellcheck disable=SC2034
+pkg_name=go22
+pkg_origin=core
+pkg_version=1.22.4
+# Rolled back recent change to core/go17 to facillitate a from-scratch
+# base-plan refresh.
+pkg_bootstrap_pkg="core/go21"
+pkg_description="Go is an open source programming language that makes it easy to
+  build simple, reliable, and efficient software."
+pkg_upstream_url=https://golang.org/
+pkg_license=("BSD-3-Clause")
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://dl.google.com/go/go${pkg_version}.src.tar.gz"
+pkg_shasum=fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784
+pkg_dirname=go
+pkg_deps=(
+  core/glibc
+  core/iana-etc
+  core/cacerts
+)
+pkg_build_deps=(
+  core/coreutils
+  core/inetutils
+  core/bash
+  core/patch
+  core/gcc
+  "${pkg_bootstrap_pkg}"
+  core/perl
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  export GOOS=linux
+  build_line "Setting GOOS=$GOOS"
+  export GOARCH=amd64
+  build_line "Setting GOARCH=$GOARCH"
+  export CGO_ENABLED=1
+  build_line "Setting CGO_ENABLED=$CGO_ENABLED"
+
+  export GOROOT
+  GOROOT="$PWD"
+  build_line "Setting GOROOT=$GOROOT"
+  export GOBIN="$GOROOT/bin"
+  build_line "Setting GOBIN=$GOBIN"
+  # shellcheck disable=SC2154
+  export GOROOT_FINAL="$pkg_prefix"
+  build_line "Setting GOROOT_FINAL=$GOROOT_FINAL"
+
+  PATH="$GOBIN:$PATH"
+  build_line "Updating PATH=$PATH"
+
+  # Building Go after 1.5 requires a previous version of Go to bootstrap with.
+  export GOROOT_BOOTSTRAP
+  GOROOT_BOOTSTRAP="$(pkg_path_for $pkg_bootstrap_pkg)"
+  build_line "Setting GOROOT_BOOTSTRAP=$GOROOT_BOOTSTRAP"
+
+  # Add `cacerts` to the SSL certificate lookup chain
+  # shellcheck disable=SC2002
+  cat "${PLAN_CONTEXT}/cacerts.patch" \
+    | sed -e "s,@cacerts@,$(pkg_path_for cacerts)/ssl/cert.pem,g" \
+    | patch -p1
+
+  # Set the dynamic linker from `glibc`
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
+  sed -e "s,/lib64/ld-linux-x86-64.so.2,${dynamic_linker}," \
+    -i src/cmd/link/internal/amd64/obj.go
+
+  # Use the services database from `iana-etc`
+  for f in src/net/port_unix.go src/net/parse_test.go; do
+    sed -e "s,/etc/services,$(pkg_path_for iana-etc)/etc/services," -i $f
+  done
+}
+
+do_build() {
+  pushd src > /dev/null || return 1
+    bash make.bash --no-clean
+  popd > /dev/null || return 1
+}
+
+do_check() {
+  # The go test suite requires several hardcoded files to be present that might
+  # not be present in the build studio. Here we create symlinks to any missing
+  # files and then clean them up after the test has completed.
+  local _clean_links=()
+  declare -A _links
+
+  _links=(
+    ["/bin/pwd"]="$(pkg_path_for coreutils)/bin/pwd"
+    ["/bin/env"]="$(pkg_path_for coreutils)/bin/env"
+    ["/bin/hostname"]="$(pkg_path_for coreutils)/bin/hostname"
+    # cgo tests that make getaddrinfo() syscalls use the hardcoded paths
+    ["/etc/services"]="$(pkg_path_for iana-etc)/etc/services"
+    ["/etc/protocols"]="$(pkg_path_for iana-etc)/etc/protocols"
+  )
+
+  for target in "${!_links[@]}"; do
+    if [[ ! -r ${target} ]]; then
+      ln -sv "${_links[$target]}" "${target}"
+      _clean_links+=("${target}")
+    fi
+  done
+
+  # NOTE: misc/cgo/testsanitizers/cshared_test.go has a known failing test
+  # because it strips LD_LIBRARY_PATH and expects libgcc_s.so.1 to be present in
+  # the tests temporary directory.
+  pushd src > /dev/null || return 1
+    env LD_LIBRARY_PATH="$(pkg_path_for gcc)/lib" bash run.bash --no-rebuild -k
+  popd > /dev/null || return 1
+
+  # Clean up any symlinks that were added to support the build's test suite.
+  for sym in "${_clean_links[@]}"; do
+    rm -fv "${sym}"
+  done
+}
+
+do_install() {
+  cp -av bin src lib doc misc "${pkg_prefix}/"
+
+  mkdir -pv "${pkg_prefix}/bin" "${pkg_prefix}/pkg"
+  cp -av pkg/tool "${pkg_prefix}/pkg/"
+  if [[ -d "pkg/linux_${GOARCH}_race" ]]; then
+    cp -av pkg/linux_${GOARCH}_race "${pkg_prefix}/pkg/"
+  fi
+
+  # Install the license
+  install -v -Dm644 LICENSE "${pkg_prefix}/share/licenses/LICENSE"
+
+  # Remove unneeded Windows files
+  rm -fv "${pkg_prefix}/src/*.bat"
+
+  # Move header files to the correct place
+  cp -arv "${pkg_prefix}/src/runtime" "${pkg_prefix}/pkg/include"
+}
+
+do_strip() {
+  # Strip manually since `strip` will not process Go's static libraries.
+  for f in "${pkg_prefix}/bin/"* "${pkg_prefix}/pkg/tool/linux_${GOARCH}/"*; do
+    strip -s "${f}"
+  done
+}

--- a/go22/tests/hello.go
+++ b/go22/tests/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}

--- a/go22/tests/test.bats
+++ b/go22/tests/test.bats
@@ -1,0 +1,18 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} go version | awk '{print $3}')"
+  [ "$result" = "go${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} go help
+  [ $status -eq 0 ]
+}
+
+@test "Simple compile" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} go run ${BATS_TEST_DIRNAME}/hello.go)"
+  status=$?
+  [ $status -eq 0 ]
+  [ "$result" = "Hello, 世界" ]
+}

--- a/go22/tests/test.sh
+++ b/go22/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
https://chefio.atlassian.net/browse/CHEF-12605

core/go22 needed on **stable** channel for Linux and Windows platforms for Courier and node agents.