### PR TITLE
go22 bumped from 1.22.4 to 1.22.5 for windows

### DIFF
--- a/go22/plan.ps1
+++ b/go22/plan.ps1
@@ -1,12 +1,12 @@
 $pkg_name="go22"
 $pkg_origin="core"
-$pkg_version="1.22.4"
+$pkg_version="1.22.5"
 $pkg_description="Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
 $pkg_upstream_url="https://golang.org/"
 $pkg_license=@("BSD-3-Clause")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://dl.google.com/go/go$pkg_version.windows-amd64.msi"
-$pkg_shasum="3c21105d7b584759b6e266383b777caf6e87142d304a10b539dbc66ab482bb5f"
+$pkg_shasum="86b0299ab8cb9c44882a9080dac03f7f4d9546f51ed1ba1015599114bcbc66d0"
 $pkg_build_deps=@("core/lessmsi")
 $pkg_dirname="go22"
 $pkg_bin_dirs=@("bin")


### PR DESCRIPTION
go22 from 1.22.4 to 1.225 for courier team.