### PR TITLE
ruby31 bumped from 3.1.2 to 3.1.6 in stable channel [CHEF-15295]

### DIFF
--- a/ruby31/plan.sh
+++ b/ruby31/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=ruby31
 pkg_origin=core
 pkg_major=3.1
-pkg_version=3.1.2
+pkg_version=3.1.6
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -9,7 +9,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/ruby/${pkg_major}/ruby-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e
+pkg_shasum=0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
https://chefio.atlassian.net/browse/CHEF-15295

ruby31 with version 3.1.6 required in stable channel.